### PR TITLE
Remove accidental promotion of float to double.

### DIFF
--- a/tensorflow_quantum/core/ops/parse_context.cc
+++ b/tensorflow_quantum/core/ops/parse_context.cc
@@ -222,7 +222,7 @@ Status GetSymbolMaps(OpKernelContext* context, std::vector<SymbolMap>* maps) {
     SymbolMap map;
     for (int j = 0; j < symbol_values.dimension(1); j++) {
       const std::string& name = symbol_names(j);
-      const double value = (double)symbol_values(i, j);
+      const float value = symbol_values(i, j);
       map[name] = {j, value};
     }
 

--- a/tensorflow_quantum/core/ops/parse_context.h
+++ b/tensorflow_quantum/core/ops/parse_context.h
@@ -41,7 +41,7 @@ tensorflow::Status GetProgramsAndProgramsToAppend(
 // A parameter map is a mapping from the name of the parameter to the index in
 // the input parameter value tensor (for gradient computations) and the value
 // of the parameter (for forward computation).
-typedef absl::flat_hash_map<std::string, std::pair<int, double>> SymbolMap;
+typedef absl::flat_hash_map<std::string, std::pair<int, float>> SymbolMap;
 
 // Parses Cirq Program protos out of the 'circuit_specs' input Tensor. Also
 // resolves the QubitIds inside of the Program. Optionally will resolve the

--- a/tensorflow_quantum/core/src/program_resolution.cc
+++ b/tensorflow_quantum/core/src/program_resolution.cc
@@ -108,7 +108,7 @@ int GetNumQubits(const Program& program) {
 }
 
 Status ResolveSymbols(
-    const absl::flat_hash_map<std::string, std::pair<int, double>>& param_map,
+    const absl::flat_hash_map<std::string, std::pair<int, float>>& param_map,
     Program* program) {
   for (Moment& moment : *program->mutable_circuit()->mutable_moments()) {
     for (Operation& operation : *moment.mutable_operations()) {

--- a/tensorflow_quantum/core/src/program_resolution.h
+++ b/tensorflow_quantum/core/src/program_resolution.h
@@ -54,7 +54,7 @@ int GetNumQubits(const cirq::google::api::v2::Program& program);
 // TODO(pmassey): Consider returning an error if a value in the parameter map
 // isn't used.
 tensorflow::Status ResolveSymbols(
-    const absl::flat_hash_map<std::string, std::pair<int, double>>& param_map,
+    const absl::flat_hash_map<std::string, std::pair<int, float>>& param_map,
     cirq::google::api::v2::Program* program);
 
 }  // namespace tfq

--- a/tensorflow_quantum/core/src/program_resolution_test.cc
+++ b/tensorflow_quantum/core/src/program_resolution_test.cc
@@ -94,7 +94,7 @@ TEST(ProgramResolutionTest, ResolveSymbols) {
   Program program;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(text, &program));
 
-  const absl::flat_hash_map<std::string, std::pair<int, double>> param_map = {
+  const absl::flat_hash_map<std::string, std::pair<int, float>> param_map = {
       {"v1", {0, 1.0}}};
 
   EXPECT_TRUE(ResolveSymbols(param_map, &program).ok());


### PR DESCRIPTION
In the `ParseOperation` function we are using the `float_value` function from the proto. TensorFlow Gradients are floats. We randomly promoted them to doubles in between for no reason, so changing that code.