### PR TITLE
Prevent serialization from modifying user circuit.

### DIFF
--- a/tensorflow_quantum/core/serialize/serializer.py
+++ b/tensorflow_quantum/core/serialize/serializer.py
@@ -14,8 +14,8 @@
 # ==============================================================================
 """A basic serializer used to serialize/deserialize Cirq circuits for tfq."""
 # TODO(pmassey / anyone): determine if this should be kept as globals.
+import copy
 import numbers
-
 import sympy
 
 import cirq
@@ -320,7 +320,7 @@ SERIALIZER = cirq.google.SerializableGateSet(gate_set_name="tfq_gate_set",
                                              deserializers=DESERIALIZERS)
 
 
-def serialize_circuit(circuit):
+def serialize_circuit(circuit_inp):
     """Returns a `cirq.Program` proto representing the `cirq.Circuit`.
 
     Note that the circuit must use gates valid in the tfq_gate_set.
@@ -330,12 +330,15 @@ def serialize_circuit(circuit):
     we use the `cirq.Program` proto, we only support `cirq.GridQubit` instances
     during serialization of circuits.
 
+    Note: once serialized terminal measurements are removed.
+
     Args:
-        circuit: A `cirq.Circuit`.
+        circuit_inp: A `cirq.Circuit`.
 
     Returns:
         A `cirq.google.api.v2.Program` proto.
     """
+    circuit = copy.deepcopy(circuit_inp)
     if not isinstance(circuit, cirq.Circuit):
         raise TypeError("serialize requires cirq.Circuit objects."
                         " Given: " + str(type(circuit)))

--- a/tensorflow_quantum/core/serialize/serializer_test.py
+++ b/tensorflow_quantum/core/serialize/serializer_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 """Module to test serialization core."""
+import copy
 import numpy as np
 import sympy
 import tensorflow as tf
@@ -611,6 +612,8 @@ class SerializerTest(tf.test.TestCase, parameterized.TestCase):
         simple_circuit = cirq.Circuit(cirq.H(q0), cirq.measure(q0), cirq.H(q1),
                                       cirq.Z(q1), cirq.measure(q1))
 
+        simple_circuit_before_call = copy.deepcopy(simple_circuit)
+
         expected_circuit = cirq.Circuit(cirq.Moment([cirq.H(q0),
                                                      cirq.H(q1)]),
                                         cirq.Moment([cirq.Z(q1)]),
@@ -619,8 +622,12 @@ class SerializerTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(serializer.serialize_circuit(simple_circuit),
                          serializer.serialize_circuit(expected_circuit))
 
+        # Check that serialization didn't modify existing circuit.
+        self.assertEqual(simple_circuit, simple_circuit_before_call)
+
         invalid_circuit = cirq.Circuit(cirq.H(q0), cirq.measure(q0),
                                        cirq.measure(q0))
+
         with self.assertRaisesRegex(ValueError, expected_regex="non-terminal"):
             serializer.serialize_circuit(invalid_circuit)
 


### PR DESCRIPTION
Accidentally modified user circuit if we ran terminal measurement removal for serialization. Removed that.