### PR TITLE
Remove slash in MANIFEST.in

### DIFF
--- a/release/MANIFEST.in
+++ b/release/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include tensorflow_quantum/ *.so
+recursive-include tensorflow_quantum *.so


### PR DESCRIPTION
This PR resolves the issue in windows build.

https://docs.python.org/2/distutils/sourcedist.html#principle

This rule says no slash is required at the end. For satisfying windows as well as macos and linux, we need to remove the slash because windows uses backslash, and others use forward slash.