### PR TITLE
install --no-deps, fix download links

### DIFF
--- a/docs/tutorials/barren_plateaus.ipynb
+++ b/docs/tutorials/barren_plateaus.ipynb
@@ -62,7 +62,7 @@
     "    <a target=\"_blank\" href=\"https://github.com/tensorflow/quantum/blob/master/docs/tutorials/barren_plateaus.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://storage.googleapis.com/tensorflow_quantum/docs/tutorials/barren_plateaus.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/quantum/tutorials/barren_plateaus.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
     "  </td>\n",
     "</table>"
    ]
@@ -139,7 +139,7 @@
     "!cd ~/\n",
     "!rm -r -f TFQuantum/\n",
     "!git clone https://{h}:{h}@github.com/quantumlib/TFQuantum.git;cd TFQuantum/\n",
-    "!pip install --upgrade ./TFQuantum/wheels/tfquantum-0.2.0-cp36-cp36m-linux_x86_64.whl"
+    "!pip install --upgrade  --no-deps ./TFQuantum/wheels/tfquantum-0.2.0-cp36-cp36m-linux_x86_64.whl"
    ]
   },
   {
@@ -524,7 +524,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5rc1"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/gradients.ipynb
+++ b/docs/tutorials/gradients.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "colab": {},
@@ -62,7 +62,7 @@
     "    <a target=\"_blank\" href=\"https://github.com/tensorflow/quantum/blob/master/docs/tutorials/gradients.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://storage.googleapis.com/tensorflow_quantum/docs/tutorials/gradients.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/quantum/docs/tutorials/gradients.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
     "  </td>\n",
     "</table>"
    ]
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -141,7 +141,7 @@
     "!cd ~/\n",
     "!rm -r -f TFQuantum/\n",
     "!git clone https://{h}:{h}@github.com/quantumlib/TFQuantum.git;cd TFQuantum/\n",
-    "!pip install --upgrade ./TFQuantum/wheels/tfquantum-0.2.0-cp36-cp36m-linux_x86_64.whl"
+    "!pip install --upgrade  --no-deps ./TFQuantum/wheels/tfquantum-0.2.0-cp36-cp36m-linux_x86_64.whl"
    ]
   },
   {
@@ -156,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -306,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -335,7 +335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -365,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -394,7 +394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -443,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -498,7 +498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -522,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -552,7 +552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -581,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -630,7 +630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -746,7 +746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -802,7 +802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -874,9 +874,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5rc1"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/docs/tutorials/hello_many_worlds.ipynb
+++ b/docs/tutorials/hello_many_worlds.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "colab": {},
@@ -62,7 +62,7 @@
     "    <a target=\"_blank\" href=\"https://github.com/tensorflow/quantum/blob/master/docs/tutorials/hello_many_worlds.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://storage.googleapis.com/tensorflow_quantum/docs/tutorials/hello_many_worlds.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/quantum/docs/tutorials/hello_many_worlds.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
     "  </td>\n",
     "</table>"
    ]
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -138,8 +138,8 @@
     "h = \"2dfcfceb9726fa73c40381c037dc01facd3d061e\"\n",
     "!cd ~/\n",
     "!rm -r -f TFQuantum/\n",
-    "!git clone https://{h}:{h}@github.com/quantumlib/TFQuantum.git;\n",
-    "!pip install --upgrade ./TFQuantum/wheels/tfquantum-0.2.0-cp36-cp36m-manylinux1_x86_64.whl"
+    "!git clone git@github.com:quantumlib/TFQuantum\n",
+    "!pip install --upgrade --no-deps ./TFQuantum/wheels/tfquantum-0.2.0-cp36-cp36m-manylinux1_x86_64.whl"
    ]
   },
   {
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -230,7 +230,7 @@
    },
    "outputs": [],
    "source": [
-    "# Create two qubits.\n",
+    "# Create two qubits\n",
     "q0, q1 = cirq.GridQubit.rect(1, 2)\n",
     "\n",
     "# Create a circuit on these qubits using the parameters you created above.\n",
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -318,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -333,7 +333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -364,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -387,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -422,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -466,7 +466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -499,7 +499,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -545,7 +545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -583,7 +583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -602,7 +602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -657,7 +657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -708,7 +708,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -733,7 +733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -755,7 +755,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -806,9 +806,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5rc1"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/docs/tutorials/mnist.ipynb
+++ b/docs/tutorials/mnist.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "colab": {},
@@ -62,7 +62,7 @@
     "    <a target=\"_blank\" href=\"https://github.com/tensorflow/quantum/blob/master/docs/tutorials/mnist.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://storage.googleapis.com/tensorflow_quantum/docs/tutorials/mnist.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/quantum/docs/tutorials/mnist.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
     "  </td>\n",
     "</table>"
    ]
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -139,7 +139,7 @@
     "!cd ~/\n",
     "!rm -r -f TFQuantum/\n",
     "!git clone https://{h}:{h}@github.com/quantumlib/TFQuantum.git;cd TFQuantum/\n",
-    "!pip install --upgrade ./TFQuantum/wheels/tfquantum-0.2.0-cp36-cp36m-linux_x86_64.whl"
+    "!pip install --upgrade  --no-deps ./TFQuantum/wheels/tfquantum-0.2.0-cp36-cp36m-linux_x86_64.whl"
    ]
   },
   {
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -275,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -301,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -347,7 +347,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -375,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -424,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -468,7 +468,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -494,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -534,7 +534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -595,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -620,6 +620,7 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -632,9 +633,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5rc1"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/docs/tutorials/qcnn.ipynb
+++ b/docs/tutorials/qcnn.ipynb
@@ -62,7 +62,7 @@
     "    <a target=\"_blank\" href=\"https://github.com/tensorflow/quantum/blob/master/docs/tutorials/qcnn.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://storage.googleapis.com/tensorflow_quantum/docs/tutorials/qcnn.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/quantum/tutorials/qcnn.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
     "  </td>\n",
     "</table>"
    ]
@@ -141,7 +141,7 @@
     "!cd ~/\n",
     "!rm -r -f TFQuantum/\n",
     "!git clone https://{h}:{h}@github.com/quantumlib/TFQuantum.git;cd TFQuantum/\n",
-    "!pip install --upgrade ./TFQuantum/wheels/tfquantum-0.2.0-cp36-cp36m-linux_x86_64.whl"
+    "!pip install --upgrade --no-deps ./TFQuantum/wheels/tfquantum-0.2.0-cp36-cp36m-linux_x86_64.whl"
    ]
   },
   {
@@ -1122,7 +1122,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5rc1"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The notebooks are failing on import because the pip install is installing the wheel files that still list cirq 0.6 as  the requirement. So it installs 0.7, installs a TFQ which requires 0.6 and overwrites the version. 

`pip install --no-deps` fixes this.

Also: fixed the download links.

 