### PR TITLE
Review mnist.ipynb

### DIFF
--- a/docs/tutorials/mnist.ipynb
+++ b/docs/tutorials/mnist.ipynb
@@ -785,7 +785,7 @@
       },
       "outputs": [],
       "source": [
-        "EPOCHS = 10\n",
+        "EPOCHS = 3\n",
         "BATCH_SIZE = 32\n",
         "NUM_EXAMPLES = len(x_train_tfcirc)"
       ]


### PR DESCRIPTION
Functional changes (LMK f you disagree on any of these and I'll revert that part):

- Removed  `remove_contradicting`. This is not standard practice.
- Shift [-1,1] expectation output to [0,1] and treat it as a probability. This is a classification problem, so `BinaryCrossentropy` is the more standard approach. 
  * It makes sense (this is the probability the model assigns to a "3" = the probability the circuit measures `1`).
  * It simplifies the code (We can drop `custom_accuracy`).
  * The gradient pressure exerted by incorrect examples is more than that exerted by correct examples, so the model can focus on optimizing examples that are failing, this could give a slight accuracy boost (with hinge the gradient magnitude is always 1.0).  

Less significant:

- Simplify data loading (use vectorized functions instead of `zip(map(*zip(...`)
- Broke up large code cells
- Added more plots and print-outs (show the circuit layers).
- Added a "Fair" classical model (~32 parameters, 4x4-binary input)
- Train to convergence (use full dataset) so the published doc shows the converged performance (85%+), included instructions on how to make it end faster.
- I change the dataset variable name each time I edit it, this way the content only depends on the name, and not which cells were run in which order.

Open questions: 

- Why not use `antialias=True` for the image down-sampling? (you do need to adjust the threshold if you do this)
- Can this whole circuit be written as a single matrix-multiply? 
- What does an XX gate *do*?