### PR TITLE
no-restart

### DIFF
--- a/docs/tutorials/barren_plateaus.ipynb
+++ b/docs/tutorials/barren_plateaus.ipynb
@@ -138,9 +138,7 @@
         "id": "FxkQA6oblNqI"
       },
       "source": [
-        "Install TensorFlow Quantum:\n",
-        "\n",
-        "Note: This may require restarting the Colab runtime (*Runtime > Restart Runtime*)."
+        "Install TensorFlow Quantum:"
       ]
     },
     {

--- a/docs/tutorials/gradients.ipynb
+++ b/docs/tutorials/gradients.ipynb
@@ -140,9 +140,7 @@
         "id": "OIbP5hklC338"
       },
       "source": [
-        "Install TensorFlow Quantum:\n",
-        "\n",
-        "Note: This may require restarting the Colab runtime (*Runtime > Restart Runtime*)."
+        "Install TensorFlow Quantum:"
       ]
     },
     {

--- a/docs/tutorials/hello_many_worlds.ipynb
+++ b/docs/tutorials/hello_many_worlds.ipynb
@@ -138,9 +138,7 @@
         "id": "FxkQA6oblNqI"
       },
       "source": [
-        "Install TensorFlow Quantum:\n",
-        "\n",
-        "Note: This may require restarting the Colab runtime (*Runtime > Restart Runtime*)."
+        "Install TensorFlow Quantum:"
       ]
     },
     {

--- a/docs/tutorials/mnist.ipynb
+++ b/docs/tutorials/mnist.ipynb
@@ -138,9 +138,7 @@
         "id": "FxkQA6oblNqI"
       },
       "source": [
-        "Install TensorFlow Quantum:\n",
-        "\n",
-        "Note: This may require restarting the Colab runtime (*Runtime > Restart Runtime*)."
+        "Install TensorFlow Quantum:"
       ]
     },
     {

--- a/docs/tutorials/qcnn.ipynb
+++ b/docs/tutorials/qcnn.ipynb
@@ -140,9 +140,7 @@
         "id": "e_ZuLN_N8yhT"
       },
       "source": [
-        "Install TensorFlow Quantum:\n",
-        "\n",
-        "Note: This may require restarting the Colab runtime (*Runtime > Restart Runtime*)."
+        "Install TensorFlow Quantum:"
       ]
     },
     {


### PR DESCRIPTION
Remove the recommendation to restart the notebook. This doesn't seem necessary, and cause confusion:

If I  restart the notebook after running `%tensorflow_version`, and then continue where I left off, then I'm back to tensorflow 1.15, which gives some unclear errror: `NotFoundError: /usr/lib/python3/dist-packages/tensorflow_quantum/core/ops/_tfq_simulate_ops.so: cannot open shared object file: No such file or directory`