### PR TITLE
update gradients.ipnyb

### DIFF
--- a/docs/tutorials/gradients.ipynb
+++ b/docs/tutorials/gradients.ipynb
@@ -126,6 +126,7 @@
       },
       "source": [
         "try:\n",
+        "    # %tensorflow_version only works in Colab.\n",
         "    %tensorflow_version 2.x\n",
         "except Exception:\n",
         "    pass"


### PR DESCRIPTION
changed this
```
try:
    %tensorflow_version 2.x
except Exception:
    pass
```
to
```
try:
     # %tensorflow_version only works in Colab.
    %tensorflow_version 2.x
except Exception:
    pass
```