### PR TITLE
Added ability to sample from state vector in qsim.

### DIFF
--- a/tensorflow_quantum/core/qsim/BUILD
+++ b/tensorflow_quantum/core/qsim/BUILD
@@ -121,5 +121,16 @@ cc_library(
     name = "util",
     srcs = ["util.cc"],
     hdrs = ["util.h"],
-    deps = [],
+    deps = [":state_space"],
+)
+
+cc_test(
+    name = "util_test",
+    srcs = ["util_test.cc"],
+    deps = [
+        ":mux",
+        ":state_space",
+        ":util",
+        "@com_google_googletest//:gtest_main",
+    ],
 )

--- a/tensorflow_quantum/core/qsim/util.cc
+++ b/tensorflow_quantum/core/qsim/util.cc
@@ -55,17 +55,17 @@ void sample_state(const StateSpace& space, const int m,
   tensorflow::random::SimplePhilox gen(&philox);
 
   double cdf_so_far = 0.0;
-  std::vector<double> random_vals(m, 0.0);
+  std::vector<float> random_vals(m, 0.0);
   samples->reserve(m);
   for (int i = 0; i < m; i++) {
-    random_vals[i] = gen.RandDouble();
+    random_vals[i] = gen.RandFloat();
   }
   std::sort(random_vals.begin(), random_vals.end());
 
   int j = 0;
   for (uint64_t i = 0; i < space.GetDimension(); i++) {
-    std::complex<float> f_amp = space.GetAmpl(i);
-    std::complex<double> d_amp = std::complex<double>(
+    const std::complex<float> f_amp = space.GetAmpl(i);
+    const std::complex<double> d_amp = std::complex<double>(
         static_cast<double>(f_amp.real()), static_cast<double>(f_amp.imag()));
     cdf_so_far += std::norm(d_amp);
     while (random_vals[j] < cdf_so_far && j < m) {

--- a/tensorflow_quantum/core/qsim/util.cc
+++ b/tensorflow_quantum/core/qsim/util.cc
@@ -15,8 +15,14 @@ limitations under the License.
 
 #include "tensorflow_quantum/core/qsim/util.h"
 
+#include <algorithm>
+#include <complex>
 #include <cstddef>
 #include <cstdlib>
+#include <vector>
+
+#include "tensorflow/core/lib/random/simple_philox.h"
+#include "tensorflow_quantum/core/qsim/state_space.h"
 
 namespace tfq {
 namespace qsim {
@@ -32,6 +38,49 @@ void* _aligned_malloc(size_t size) {
 }
 
 void _aligned_free(void* ptr) { free(*(reinterpret_cast<void**>(ptr) - 1)); }
+
+void sample_state(const StateSpace& space, const int m,
+                  std::vector<uint64_t>* samples) {
+  // An alternate would be to use:
+  // tensorflow/core/lib/random/distribution_sampler.h which would have a
+  // runtime of:
+  // O(2 ** num_qubits + m) and additional mem O(2 ** num_qubits + m)
+  // This method has (which is good because memory is expensive to get):
+  // O(2 ** num_qubits + m * log(m)) and additional mem O(m)
+  // Note: random samples in samples will appear in order.
+  if (m == 0) {
+    return;
+  }
+  tensorflow::random::PhiloxRandom philox(std::rand());
+  tensorflow::random::SimplePhilox gen(&philox);
+
+  double cdf_so_far = 0.0;
+  std::vector<double> random_vals(m, 0.0);
+  samples->reserve(m);
+  for (int i = 0; i < m; i++) {
+    random_vals[i] = gen.RandDouble();
+  }
+  std::sort(random_vals.begin(), random_vals.end());
+
+  int j = 0;
+  for (uint64_t i = 0; i < space.GetDimension(); i++) {
+    std::complex<float> f_amp = space.GetAmpl(i);
+    std::complex<double> d_amp = std::complex<double>(
+        static_cast<double>(f_amp.real()), static_cast<double>(f_amp.imag()));
+    cdf_so_far += std::norm(d_amp);
+    while (random_vals[j] < cdf_so_far && j < m) {
+      samples->push_back(i);
+      j++;
+    }
+  }
+
+  // Safety measure in case of state norm underflow.
+  // Likely to not have huge impact.
+  while (j < m) {
+    samples->push_back(samples->at(samples->size() - 1));
+    j++;
+  }
+}
 
 }  // namespace qsim
 }  // namespace tfq

--- a/tensorflow_quantum/core/qsim/util.h
+++ b/tensorflow_quantum/core/qsim/util.h
@@ -17,6 +17,9 @@ limitations under the License.
 #define TFQ_CORE_QSIM_UTIL_H_
 
 #include <cstddef>
+#include <vector>
+
+#include "tensorflow_quantum/core/qsim/state_space.h"
 
 namespace tfq {
 namespace qsim {
@@ -26,6 +29,12 @@ void* _aligned_malloc(size_t size);
 
 // Workaround for std::alligned_alloc not working on C++11.
 void _aligned_free(void* ptr);
+
+// Function to draw m samples from a StateSpace Object in
+// O(2 ** num_qubits + m * log(m)) time.
+// Samples are stored as bit encoded integers.
+void sample_state(const StateSpace& space, const int m,
+                  std::vector<uint64_t>* samples);
 
 }  // namespace qsim
 }  // namespace tfq

--- a/tensorflow_quantum/core/qsim/util_test.cc
+++ b/tensorflow_quantum/core/qsim/util_test.cc
@@ -1,0 +1,122 @@
+/* Copyright 2020 The TensorFlow Quantum Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow_quantum/core/qsim/util.h"
+
+#include <cmath>
+#include <complex>
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "tensorflow_quantum/core/qsim/mux.h"
+#include "tensorflow_quantum/core/qsim/state_space.h"
+
+namespace tfq {
+namespace qsim {
+namespace {
+
+TEST(UtilTest, OneSample) {
+  auto equal = std::unique_ptr<StateSpace>(GetStateSpace(1, 1));
+  equal->CreateState();
+  equal->SetAmpl(0, std::complex<float>(1.0, 0.));
+  equal->SetAmpl(1, std::complex<float>(0.0, 0.));
+
+  std::vector<uint64_t> samples;
+  sample_state(*equal.get(), 1, &samples);
+  ASSERT_EQ(samples.size(), 1);
+}
+
+TEST(UtilTest, ZeroSamples) {
+  auto equal = std::unique_ptr<StateSpace>(GetStateSpace(1, 1));
+  equal->CreateState();
+  equal->SetAmpl(0, std::complex<float>(1.0, 0.));
+  equal->SetAmpl(1, std::complex<float>(0.0, 0.));
+
+  std::vector<uint64_t> samples;
+  sample_state(*equal.get(), 0, &samples);
+  ASSERT_EQ(samples.size(), 0);
+}
+
+TEST(UtilTest, SampleEqual) {
+  auto equal = std::unique_ptr<StateSpace>(GetStateSpace(1, 1));
+  equal->CreateState();
+  equal->SetAmpl(0, std::complex<float>(0.707, 0.));
+  equal->SetAmpl(1, std::complex<float>(0.707, 0.));
+
+  std::vector<uint64_t> samples;
+  const int m = 100000;
+  sample_state(*equal.get(), m, &samples);
+
+  float num_ones = 0.0;
+  for (int i = 0; i < m; i++) {
+    if (samples[i]) {
+      num_ones++;
+    }
+  }
+  ASSERT_EQ(samples.size(), m);
+  EXPECT_NEAR(num_ones / static_cast<float>(m), 0.5, 1E-2);
+}
+
+TEST(UtilTest, SampleSkew) {
+  auto skew = std::unique_ptr<StateSpace>(GetStateSpace(1, 1));
+  skew->CreateState();
+
+  std::vector<float> rots = {0.1, 0.3, 0.5, 0.7, 0.9};
+  for (int t = 0; t < 5; t++) {
+    float z_amp = std::sqrt(rots[t]);
+    float o_amp = std::sqrt(1.0 - rots[t]);
+    skew->SetAmpl(0, std::complex<float>(z_amp, 0.));
+    skew->SetAmpl(1, std::complex<float>(o_amp, 0.));
+
+    std::vector<uint64_t> samples;
+    const int m = 100000;
+    sample_state(*skew.get(), m, &samples);
+    float num_z = 0.0;
+    for (int i = 0; i < m; i++) {
+      if (samples[i] == 0) {
+        num_z++;
+      }
+    }
+    ASSERT_EQ(samples.size(), m);
+    EXPECT_NEAR(num_z / static_cast<float>(m), rots[t], 1E-2);
+  }
+}
+
+TEST(UtilTest, ComplexDist) {
+  auto state = std::unique_ptr<StateSpace>(GetStateSpace(3, 1));
+  state->CreateState();
+
+  std::vector<float> probs = {0.05, 0.2, 0.05, 0.2, 0.05, 0.2, 0.05, 0.2};
+  for (int i = 0; i < 8; i++) {
+    state->SetAmpl(i, std::complex<float>(std::sqrt(probs[i]), 0.0));
+  }
+
+  std::vector<uint64_t> samples;
+  const int m = 100000;
+  sample_state(*state.get(), m, &samples);
+
+  std::vector<float> measure_probs = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+  for (int i = 0; i < m; i++) {
+    measure_probs[samples[i]] += 1.0;
+  }
+  for (int i = 0; i < 8; i++) {
+    EXPECT_NEAR(measure_probs[i] / static_cast<float>(m), probs[i], 1E-2);
+  }
+  ASSERT_EQ(samples.size(), m);
+}
+
+}  // namespace
+}  // namespace qsim
+}  // namespace tfq


### PR DESCRIPTION
Added the ability to sample from state vectors in qsim. This is the first step in solving #144 .
Next step is to make an op around this. I put the functionality in `util.cc` since it is pretty hard for us to test `state_space` at the moment.

@zaqqwerty if you are going to get around to testing `state_space` soon do you think you could move this functionality over to `state_space` or would you rather we wait to put this in until we have some better testing on `state_space` ?