### PR TITLE
Change from multiprocessing to pathos for windows compatability.

### DIFF
--- a/release/setup.py
+++ b/release/setup.py
@@ -50,7 +50,7 @@ class InstallPlatlib(install):
             self.install_lib = self.install_platlib
 
 
-REQUIRED_PACKAGES = ['cirq >= 0.7.0']
+REQUIRED_PACKAGES = ['cirq >= 0.7.0', 'pathos == 0.2.5']
 CUR_VERSION = '0.3.0'
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ nbformat==4.4.0
 pylint==2.4.4
 yapf==0.28.0
 tensorflow==2.1.0
+pathos==0.2.5


### PR DESCRIPTION
Convert from using multiprocessing to using the pathos library. Windows was having trouble pickling things for multiprocessing in #160 . Pathos seems to be a more robust alternative, but it is a little slower. I'm not super worried about the performance hit here, since if you are choosing to not use the C++ simulators you must have a good reason to be willing to forgo performance already.