### PR TITLE
Some small util ops cleanup.

### DIFF
--- a/tensorflow_quantum/core/ops/parse_context.cc
+++ b/tensorflow_quantum/core/ops/parse_context.cc
@@ -71,7 +71,7 @@ Status ParsePrograms(OpKernelContext* context, const std::string& input_name,
         absl::StrCat("programs must be rank 1. Got rank ", input->dims(), "."));
   }
 
-  const auto program_strings = input->vec<std::string>();
+  const auto program_strings = input->vec<tensorflow::tstring>();
   const int num_programs = program_strings.dimension(0);
   programs->assign(num_programs, Program());
 
@@ -161,7 +161,7 @@ Status GetPauliSums(OpKernelContext* context,
                                input->dims(), "."));
   }
 
-  const auto sum_specs = input->matrix<std::string>();
+  const auto sum_specs = input->matrix<tensorflow::tstring>();
   p_sums->reserve(sum_specs.dimension(0));
   for (int i = 0; i < sum_specs.dimension(0); i++) {
     std::vector<PauliSum> sub_ops;
@@ -208,7 +208,7 @@ Status GetSymbolMaps(OpKernelContext* context, std::vector<SymbolMap>* maps) {
                                input_values->dims(), "."));
   }
 
-  const auto symbol_names = input_names->vec<std::string>();
+  const auto symbol_names = input_names->vec<tensorflow::tstring>();
   const auto symbol_values = input_values->matrix<float>();
 
   if (symbol_names.dimension(0) != symbol_values.dimension(1)) {

--- a/tensorflow_quantum/core/ops/tfq_circuit_append_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_circuit_append_op.cc
@@ -49,16 +49,18 @@ class TfqCircuitAppendOp : public tensorflow::OpKernel {
     tensorflow::Tensor *output = nullptr;
     OP_REQUIRES_OK(context, context->allocate_output(
                                 0, context->input(0).shape(), &output));
-    auto output_tensor = output->flat<std::string>();
+    auto output_tensor = output->flat<tensorflow::tstring>();
 
     auto DoWork = [&](int start, int end) {
+      std::string temp;
       for (int i = start; i < end; i++) {
         for (int j = 0; j < programs_to_append.at(i).circuit().moments().size();
              j++) {
           Moment *new_moment = programs.at(i).mutable_circuit()->add_moments();
           *new_moment = programs_to_append.at(i).circuit().moments(j);
         }
-        programs.at(i).SerializeToString(&output_tensor(i));
+        programs.at(i).SerializeToString(&temp);
+        output_tensor(i) = temp;
       }
     };
 

--- a/tensorflow_quantum/core/ops/tfq_ps_decompose_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_ps_decompose_op.cc
@@ -53,7 +53,7 @@ class TfqPsDecomposeOp : public tensorflow::OpKernel {
     tensorflow::Tensor *output = nullptr;
     OP_REQUIRES_OK(context, context->allocate_output(
                                 0, context->input(0).shape(), &output));
-    auto output_tensor = output->flat<std::string>();
+    auto output_tensor = output->flat<tensorflow::tstring>();
 
     const int max_buffer_moments = 3;
 
@@ -61,6 +61,7 @@ class TfqPsDecomposeOp : public tensorflow::OpKernel {
       for (int i = start; i < end; i++) {
         Program cur_program = programs.at(i);
         Program new_program;
+        std::string temp;
         new_program.mutable_language()->set_gate_set("tfq_gate_set");
         new_program.mutable_circuit()->set_scheduling_strategy(
             Circuit::MOMENT_BY_MOMENT);
@@ -145,7 +146,8 @@ class TfqPsDecomposeOp : public tensorflow::OpKernel {
             }
           }
         }
-        new_program.SerializeToString(&output_tensor(i));
+        new_program.SerializeToString(&temp);
+        output_tensor(i) = temp;
       }
     };
 

--- a/tensorflow_quantum/core/ops/tfq_ps_weights_from_symbols_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_ps_weights_from_symbols_op.cc
@@ -52,13 +52,13 @@ class TfqPsWeightsFromSymbolOp : public tensorflow::OpKernel {
 
     // Parse the input string here.
     const Tensor *symbols_tensor;
-    context->input("symbols", &symbols_tensor);
+    OP_REQUIRES_OK(context, context->input("symbols", &symbols_tensor));
     OP_REQUIRES(
         context, symbols_tensor->dims() == 1,
         tensorflow::errors::InvalidArgument(absl::StrCat(
             "symbols must be rank 1. Got rank ", symbols_tensor->dims(), ".")));
 
-    const auto symbols = symbols_tensor->vec<std::string>();
+    const auto symbols = symbols_tensor->vec<tensorflow::tstring>();
     const int n_symbols = symbols.size();
 
     // (i,j,k) = the kth scalar value found for symbols(j) in programs(i).
@@ -175,6 +175,12 @@ REGISTER_OP("TfqPsWeightsFromSymbols")
 
       tensorflow::shape_inference::ShapeHandle symbols_shape;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &symbols_shape));
+
+      c->set_output(
+          0, c->MakeShape(
+                 {c->Dim(programs_shape, 0),
+                  tensorflow::shape_inference::InferenceContext::kUnknownDim,
+                  tensorflow::shape_inference::InferenceContext::kUnknownDim}));
 
       return tensorflow::Status::OK();
     });


### PR DESCRIPTION
Cleaned up util ops and ps_util ops:
1. when dealing with tensor data apparently it's better to use `tensorflow::tstring` since it is more portable and such.
2. Added a few missing `OP_REQUIRES_OK`
3. Added shape outputs.