### PR TITLE
[WIP] Upgrade to tf 2.2rc2 and bazel 2.0.0.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -76,16 +76,12 @@ http_archive(
 
 http_archive(
     name = "org_tensorflow",
-    sha256 = "e82f3b94d863e223881678406faa5071b895e1ff928ba18578d2adbbc6b42a4c",
-    strip_prefix = "tensorflow-2.1.0",
+    # sha256 = "e82f3b94d863e223881678406faa5071b895e1ff928ba18578d2adbbc6b42a4c",
+    strip_prefix = "tensorflow-2.2.0-rc2",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/v2.1.0.zip",
+        "https://github.com/tensorflow/tensorflow/archive/v2.2.0-rc2.zip",
     ],
 )
-
-load("@org_tensorflow//tensorflow:workspace.bzl", "tf_workspace")
-
-tf_workspace(tf_repo_name = "@org_tensorflow")
 
 load("//third_party/tf:tf_configure.bzl", "tf_configure")
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@ There are a few ways to set up your environment to use TensorFlow Quantum (TFQ):
 ### Requirements
 
 * pip 19.0 or later (requires `manylinux2010` support)
-* [TensorFlow >= 2.1](https://www.tensorflow.org/install/pip)
+* [TensorFlow >= 2.2.0rc2](https://www.tensorflow.org/install/pip)
 * [Cirq 0.7](https://cirq.readthedocs.io/en/stable/install.html)
 
 See the [TensorFlow install guide](https://www.tensorflow.org/install/pip) to
@@ -27,7 +27,7 @@ dependencies):
 <!-- common_typos_disable -->
 <pre class="devsite-click-to-copy">
   <code class="devsite-terminal">pip3 install --upgrade pip</code>
-  <code class="devsite-terminal">pip3 install tensorflow==2.1.0</code>
+  <code class="devsite-terminal">pip3 install tensorflow==2.2.0rc2</code>
   <code class="devsite-terminal">pip3 install cirq==0.7.0</code>
 </pre>
 <!-- common_typos_enable -->
@@ -83,7 +83,7 @@ See the TensorFlow
 guide to install the <a href="https://bazel.build/" class="external">Bazel</a>
 build system.
 
-To ensure compatibility with TensorFlow, `bazel` version 0.26.1 or lower is
+To ensure compatibility with TensorFlow, `bazel` version 2.0.0 is
 required. To remove any existing version of Bazel:
 
 <!-- common_typos_disable -->
@@ -92,12 +92,12 @@ required. To remove any existing version of Bazel:
 </pre>
 <!-- common_typos_enable -->
 
-Then install Bazel version 0.26.0:
+Then install Bazel version 2.0.0:
 
 <!-- common_typos_disable -->
 <pre class="devsite-click-to-copy">
-  <code class="devsite-terminal">wget https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel_0.26.0-linux-x86_64.deb</code>
-  <code class="devsite-terminal">sudo dpkg -i bazel_0.26.0-linux-x86_64.deb</code>
+  <code class="devsite-terminal">wget https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel_2.0.0-linux-x86_64.deb</code>
+  <code class="devsite-terminal">sudo dpkg -i bazel_2.0.0-linux-x86_64.deb</code>
 </pre>
 <!-- common_typos_enable -->
 
@@ -105,7 +105,7 @@ Then install Bazel version 0.26.0:
 ### 4. Build TensorFlow from source
 
 Read the TensorFlow [build from source](https://www.tensorflow.org/install/source)
-guide for details. TensorFlow Quantum is compatible with TensorFlow version&nbsp;2.1.
+guide for details. TensorFlow Quantum is compatible with TensorFlow version&nbsp;2.2.0rc2.
 
 Download the
 <a href="https://github.com/tensorflow/tensorflow" class="external">TensorFlow source code</a>:
@@ -114,7 +114,7 @@ Download the
 <pre class="devsite-click-to-copy">
   <code class="devsite-terminal">git clone https://github.com/tensorflow/tensorflow.git</code>
   <code class="devsite-terminal">cd tensorflow</code>
-  <code class="devsite-terminal">git checkout v2.1.0</code>
+  <code class="devsite-terminal">git checkout r2.2.0</code>
 </pre>
 
 Install the TensorFlow dependencies:

--- a/docs/tutorials/barren_plateaus.ipynb
+++ b/docs/tutorials/barren_plateaus.ipynb
@@ -116,19 +116,6 @@
       ]
     },
     {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "TorxE5tnkvb2",
-        "colab": {}
-      },
-      "source": [
-        "!pip install tensorflow==2.1.0"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",

--- a/docs/tutorials/gradients.ipynb
+++ b/docs/tutorials/gradients.ipynb
@@ -118,19 +118,6 @@
       ]
     },
     {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "TorxE5tnkvb2",
-        "colab": {}
-      },
-      "source": [
-        "!pip install tensorflow==2.1.0"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",

--- a/docs/tutorials/hello_many_worlds.ipynb
+++ b/docs/tutorials/hello_many_worlds.ipynb
@@ -116,19 +116,6 @@
       ]
     },
     {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "TorxE5tnkvb2",
-        "colab": {}
-      },
-      "source": [
-        "!pip install tensorflow==2.1.0"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",

--- a/docs/tutorials/mnist.ipynb
+++ b/docs/tutorials/mnist.ipynb
@@ -116,19 +116,6 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "TorxE5tnkvb2"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install tensorflow==2.1.0"
-      ]
-    },
-    {
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",

--- a/docs/tutorials/qcnn.ipynb
+++ b/docs/tutorials/qcnn.ipynb
@@ -118,19 +118,6 @@
       ]
     },
     {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "Aquwcz-0aHqz",
-        "colab": {}
-      },
-      "source": [
-        "!pip install tensorflow==2.1.0"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",

--- a/release/build_all_wheels.sh
+++ b/release/build_all_wheels.sh
@@ -24,7 +24,7 @@ cd ..
 
 # Upgrade existing 3.6 pip.
 python3 -m pip install --upgrade pip
-python3 -m pip install tensorflow==2.1.0
+python3 -m pip install tensorflow==2.2.0rc2
 
 cp -r custom-op/third_party/toolchains quantum/third_party/
 cd /quantum
@@ -51,7 +51,7 @@ sudo make altinstall
 cd /quantum
 
 python3.7 -m pip install --upgrade pip setuptools
-python3.7 -m pip install tensorflow==2.1.0
+python3.7 -m pip install tensorflow==2.2.0rc2
 sed -i 's/python3/python3.7/g' configure.sh
 sed -i 's/python3/python3.7/g' release/build_pip_package.sh
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ nbconvert==5.6.1
 nbformat==4.4.0
 pylint==2.4.4
 yapf==0.28.0
-tensorflow==2.1.0
+tensorflow==2.2.0rc2
 pathos==0.2.5

--- a/scripts/build_pip_package_test.sh
+++ b/scripts/build_pip_package_test.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-pip install tensorflow==2.1.0 cirq==0.7.0
+pip install tensorflow==2.2.0rc2 cirq==0.7.0
 
 # cd tensorflow_quantum
 echo "Y\n" | ./configure.sh

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-wget https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel_0.26.0-linux-x86_64.deb
-sudo dpkg -i bazel_0.26.0-linux-x86_64.deb
+wget https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel_2.0.0-linux-x86_64.deb
+sudo dpkg -i bazel_2.0.0-linux-x86_64.deb
 pip install --upgrade pip setuptools wheel
 pip install -r requirements.txt


### PR DESCRIPTION
Still some questions up in the air:

1. I'm fairly confident we have bazel 2.0.0 working, but I am still a little worried about flags, does the C++ versioning or flags change for linux, windows or macos in going from 2.1.0 to 2.2rc2 ?

2. Can we confirm that colab will be rolling with tf2.2rc2 and it's safe to remove these install statements ? Should we just update them to `pip install tensorflow==2.2rc2` ?

3. Merging this will temporarily bork our nightly builds, so let's make sure we coordinate with fixing our nightly build pipelines before merging.

@yifeif Can you speak to 1. at all ?
@MarkDaoust Can you speak 2. at all ?
@jaeyoo Once we are ready to merge this I should be able to update the nightly pipelines but might need your help :)
@zaqqwerty Do you have anything you want to get in before this upgrade ?