### PR TITLE
Update install instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@ There are a few ways to set up your environment to use TensorFlow Quantum (TFQ):
 ### Requirements
 
 * pip 19.0 or later (requires `manylinux2010` support)
-* [TensorFlow >= 2.1](https://www.tensorflow.org/install/pip)
+* [TensorFlow == 2.1](https://www.tensorflow.org/install/pip)
 * [Cirq 0.7](https://cirq.readthedocs.io/en/stable/install.html)
 
 See the [TensorFlow install guide](https://www.tensorflow.org/install/pip) to


### PR DESCRIPTION
Now that 2.2rc2 is on it's way and has introduced some upgrades that break us (`tensorflow::tstring` and bazel 2.0.0 among other things) we should indicate that we currently don't support the latest tensorflow until we have #181 go in and upgrade our nightly build pipelines.