### PR TITLE
Pinned version of google-api-client.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pylint==2.4.4
 yapf==0.28.0
 tensorflow==2.1.0
 pathos==0.2.5
+google-api-python-client==1.8.0


### PR DESCRIPTION
Looks like cirq didn't pin a version on their google-api-python-client and an update might have broken our CI. Investigating fix.