### PR TITLE
Fixed Cirq version problems.

### DIFF
--- a/release/setup.py
+++ b/release/setup.py
@@ -50,7 +50,7 @@ class InstallPlatlib(install):
             self.install_lib = self.install_platlib
 
 
-REQUIRED_PACKAGES = ['cirq >= 0.7.0', 'pathos == 0.2.5']
+REQUIRED_PACKAGES = ['cirq == 0.7.0', 'pathos == 0.2.5']
 CUR_VERSION = '0.3.0'
 
 


### PR DESCRIPTION
Cirq 0.8 currently breaks us. Fixing `setup.py` to hard pin to 0.7. Let me know if I've missed anything