### PR TITLE
Rollback pathos

### DIFF
--- a/release/setup.py
+++ b/release/setup.py
@@ -50,7 +50,7 @@ class InstallPlatlib(install):
             self.install_lib = self.install_platlib
 
 
-REQUIRED_PACKAGES = ['cirq == 0.8.0', 'pathos == 0.2.5', 'sympy == 1.5']
+REQUIRED_PACKAGES = ['cirq == 0.8.0', 'sympy == 1.5']
 CUR_VERSION = '0.4.0'
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ nbformat==4.4.0
 pylint==2.4.4
 yapf==0.28.0
 tensorflow==2.1.0
-pathos==0.2.5
 google-api-python-client==1.8.0

--- a/tensorflow_quantum/core/ops/batch_util.py
+++ b/tensorflow_quantum/core/ops/batch_util.py
@@ -18,9 +18,9 @@ import collections
 import itertools
 import os
 
+import multiprocessing as mp
 import numpy as np
 import cirq
-import multiprocessing as mp
 from multiprocessing.pool import Pool as ProcessPool
 
 from tensorflow_quantum.core.serialize import serializer

--- a/tensorflow_quantum/core/ops/batch_util.py
+++ b/tensorflow_quantum/core/ops/batch_util.py
@@ -19,9 +19,9 @@ import itertools
 import os
 
 import multiprocessing as mp
+from multiprocessing.pool import Pool as ProcessPool
 import numpy as np
 import cirq
-from multiprocessing.pool import Pool as ProcessPool
 
 from tensorflow_quantum.core.serialize import serializer
 

--- a/tensorflow_quantum/core/ops/batch_util.py
+++ b/tensorflow_quantum/core/ops/batch_util.py
@@ -387,9 +387,9 @@ def batch_calculate_state(circuits, param_resolvers, simulator):
     input_args = _prep_pool_input_args(range(len(circuits)), circuits,
                                        param_resolvers)
     with ProcessPool(processes=None,
-                                   initializer=_setup_dict,
-                                   initargs=(shared_array, return_mem_shape,
-                                             simulator, post_process)) as pool:
+                     initializer=_setup_dict,
+                     initargs=(shared_array, return_mem_shape, simulator,
+                               post_process)) as pool:
 
         pool.starmap(_state_worker_func, list(input_args))
 
@@ -471,9 +471,9 @@ def batch_calculate_expectation(circuits, param_resolvers, ops, simulator):
                               slice_args=False))
 
     with ProcessPool(processes=None,
-                                   initializer=_setup_dict,
-                                   initargs=(shared_array, return_mem_shape,
-                                             simulator, post_process)) as pool:
+                     initializer=_setup_dict,
+                     initargs=(shared_array, return_mem_shape, simulator,
+                               post_process)) as pool:
 
         pool.starmap(_analytical_expectation_worker_func, input_args)
 
@@ -562,9 +562,9 @@ def batch_calculate_sampled_expectation(circuits, param_resolvers, ops,
                               slice_args=False))
 
     with ProcessPool(processes=None,
-                                   initializer=_setup_dict,
-                                   initargs=(shared_array, return_mem_shape,
-                                             simulator, None)) as pool:
+                     initializer=_setup_dict,
+                     initargs=(shared_array, return_mem_shape, simulator,
+                               None)) as pool:
 
         pool.starmap(_sample_expectation_worker_func, input_args)
 
@@ -633,9 +633,9 @@ def batch_sample(circuits, param_resolvers, n_samples, simulator):
                               [n_samples] * len(circuits)))
 
     with ProcessPool(processes=None,
-                                   initializer=_setup_dict,
-                                   initargs=(shared_array, return_mem_shape,
-                                             simulator, post_process)) as pool:
+                     initializer=_setup_dict,
+                     initargs=(shared_array, return_mem_shape, simulator,
+                               post_process)) as pool:
 
         pool.starmap(_sample_worker_func, input_args)
 


### PR DESCRIPTION
Because `pathos` is just a wrapper of `multiprocessing`, we decided rolling back to `multiprocessing` by removing `pathos`.