### PR TITLE
tfq_simulate_state uses OSS qsim.

### DIFF
--- a/tensorflow_quantum/core/ops/tfq_simulate_expectation_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_expectation_op.cc
@@ -109,7 +109,7 @@ class TfqSimulateExpectationOp : public tensorflow::OpKernel {
 
     // Simulate programs one by one. Parallelizing over wavefunctions
     // we no longer parallelize over circuits. Each time we encounter a
-    // a larger circuit we will grow the Statevector as nescessary.
+    // a larger circuit we will grow the Statevector as necessary.
     for (int i = 0; i < programs.size(); i++) {
       int nq = num_qubits[i];
       Simulator sim = Simulator(nq, tfq_for);

--- a/tensorflow_quantum/core/src/circuit_parser_qsim.cc
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim.cc
@@ -389,6 +389,11 @@ tensorflow::Status QsimCircuitFromProgram(
   // Convert proto to qsim internal representation.
   circuit->num_qubits = num_qubits;
   int time = 0;
+  // Special case empty.
+  if (num_qubits <= 0) {
+    return Status::OK();
+  }
+
   for (const Moment& moment : program.circuit().moments()) {
     for (const Operation& op : moment.operations()) {
       Status status = ParseAppendGate(op, param_map, num_qubits, time, circuit);
@@ -401,7 +406,7 @@ tensorflow::Status QsimCircuitFromProgram(
 
   // Build fused circuit.
   *fused_circuit = qsim::BasicGateFuser<qsim::IO, QsimGate>().FuseGates(
-      circuit->num_qubits, circuit->gates, time);
+      circuit->num_qubits, circuit->gates, time + 1);
   return Status::OK();
 }
 


### PR DESCRIPTION
Switched `tfq_simulate_expectation` over to depending on OSS qsim. Once we get this merged this will just leave
`tfq_simualte_sampled_expectation` and `tfq_calculate_unitary` left to do. This covers step 5 in #263 .