### PR TITLE
Ported Z basis parsing to OSS qsim.

### DIFF
--- a/tensorflow_quantum/core/src/circuit_parser_qsim.cc
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim.cc
@@ -458,7 +458,7 @@ Status QsimZBasisCircuitFromPauliTerm(
     transform_exponent = -0.5;
     gate_type = "Y";
     if (pair.pauli_type() == "Y") {
-      // Y regquires X**0.5 transform.
+      // Y requires X**0.5 transform.
       transform_exponent = 0.5;
       gate_type = "X";
     }

--- a/tensorflow_quantum/core/src/circuit_parser_qsim.cc
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim.cc
@@ -438,4 +438,48 @@ Status QsimCircuitFromPauliTerm(
                                 circuit, fused_circuit);
 }
 
+Status QsimZBasisCircuitFromPauliTerm(
+    const PauliTerm& term, const int num_qubits, QsimCircuit* circuit,
+    std::vector<qsim::GateFused<QsimGate>>* fused_circuit) {
+  Program measurement_program;
+  SymbolMap empty_map;
+  measurement_program.mutable_circuit()->set_scheduling_strategy(
+      cirq::google::api::v2::Circuit::MOMENT_BY_MOMENT);
+  Moment* term_moment = measurement_program.mutable_circuit()->add_moments();
+  float transform_exponent = 0.0;
+  std::string gate_type;
+  for (const tfq::proto::PauliQubitPair& pair : term.paulis()) {
+    if (pair.pauli_type() == "Z") {
+      // Z requires no transform.
+      continue;
+    }
+
+    // Assume it is X and the transform is Y^-0.5
+    transform_exponent = -0.5;
+    gate_type = "Y";
+    if (pair.pauli_type() == "Y") {
+      // Y regquires X**0.5 transform.
+      transform_exponent = 0.5;
+      gate_type = "X";
+    }
+
+    Operation* new_op = term_moment->add_operations();
+
+    // create corresponding eigen gate op.
+    new_op->add_qubits()->set_id(pair.qubit_id());
+    new_op->mutable_gate()->set_id(gate_type + "P");
+    (*new_op->mutable_args())["exponent"].mutable_arg_value()->set_float_value(
+        transform_exponent);
+    (*new_op->mutable_args())["global_shift"]
+        .mutable_arg_value()
+        ->set_float_value(0.0);
+    (*new_op->mutable_args())["exponent_scalar"]
+        .mutable_arg_value()
+        ->set_float_value(1.0);
+  }
+
+  return QsimCircuitFromProgram(measurement_program, empty_map, num_qubits,
+                                circuit, fused_circuit);
+}
+
 }  // namespace tfq

--- a/tensorflow_quantum/core/src/circuit_parser_qsim.h
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim.h
@@ -45,6 +45,14 @@ tensorflow::Status QsimCircuitFromPauliTerm(
     qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit,
     std::vector<qsim::GateFused<qsim::Cirq::GateCirq<float>>>* fused_circuit);
 
+// parse a serialized pauliTerm from a larger cirq.Paulisum proto
+// into a qsim Circuit and fused circuit that represents the transformation
+// to the z basis.
+tensorflow::Status QsimZBasisCircuitFromPauliTerm(
+    const tfq::proto::PauliTerm& term, const int num_qubits,
+    qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit,
+    std::vector<qsim::GateFused<qsim::Cirq::GateCirq<float>>>* fused_circuit);
+
 }  // namespace tfq
 
 #endif  // TFQ_CORE_SRC_CIRCUIT_PARSER_QSIM_H_

--- a/tensorflow_quantum/core/src/circuit_parser_qsim_test.cc
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim_test.cc
@@ -590,5 +590,113 @@ TEST(QsimCircuitParserTest, CircuitFromPauliTermEmpty) {
   ASSERT_EQ(test_circuit.gates.size(), 0);
 }
 
+TEST(QsimCircuitParserTest, ZBasisCircuitFromPauliTermPauliX) {
+  tfq::proto::PauliTerm pauli_proto;
+  // The created circuit should not depend on the coefficient
+  pauli_proto.set_coefficient_real(3.14);
+  tfq::proto::PauliQubitPair* pair_proto = pauli_proto.add_paulis();
+  pair_proto->set_qubit_id("0");
+  pair_proto->set_pauli_type("X");
+
+  // Build the corresponding correct circuit
+  auto reference = qsim::Cirq::YPowGate<float>::Create(0, 0, -0.5, 0.0);
+  QsimCircuit test_circuit;
+  std::vector<qsim::GateFused<QsimGate>> fused_circuit;
+  tensorflow::Status status;
+
+  // Check conversion
+  status = QsimZBasisCircuitFromPauliTerm(pauli_proto, 1, &test_circuit,
+                                          &fused_circuit);
+  ASSERT_EQ(status, tensorflow::Status::OK());
+  ASSERT_EQ(test_circuit.num_qubits, 1);
+  ASSERT_EQ(test_circuit.gates.size(), 1);
+  AssertOneQubitEqual(test_circuit.gates[0], reference);
+}
+
+TEST(QsimCircuitParserTest, ZBasisCircuitFromPauliTermPauliY) {
+  tfq::proto::PauliTerm pauli_proto;
+  // The created circuit should not depend on the coefficient
+  pauli_proto.set_coefficient_real(3.14);
+  tfq::proto::PauliQubitPair* pair_proto = pauli_proto.add_paulis();
+  pair_proto->set_qubit_id("0");
+  pair_proto->set_pauli_type("Y");
+
+  // Build the corresponding correct circuit
+  auto reference = qsim::Cirq::XPowGate<float>::Create(0, 0, 0.5, 0.0);
+  QsimCircuit test_circuit;
+  std::vector<qsim::GateFused<QsimGate>> fused_circuit;
+  tensorflow::Status status;
+
+  // Check conversion
+  status = QsimZBasisCircuitFromPauliTerm(pauli_proto, 1, &test_circuit,
+                                          &fused_circuit);
+  ASSERT_EQ(status, tensorflow::Status::OK());
+  ASSERT_EQ(test_circuit.num_qubits, 1);
+  ASSERT_EQ(test_circuit.gates.size(), 1);
+  AssertOneQubitEqual(test_circuit.gates[0], reference);
+}
+
+TEST(QsimCircuitParserTest, ZBasisCircuitFromPauliTermPauliZ) {
+  tfq::proto::PauliTerm pauli_proto;
+  // The created circuit should not depend on the coefficient
+  pauli_proto.set_coefficient_real(3.14);
+  tfq::proto::PauliQubitPair* pair_proto = pauli_proto.add_paulis();
+  pair_proto->set_qubit_id("0");
+  pair_proto->set_pauli_type("Z");
+
+  // Build the corresponding correct circuit
+  QsimCircuit test_circuit;
+  std::vector<qsim::GateFused<QsimGate>> fused_circuit;
+  tensorflow::Status status;
+
+  // Check conversion
+  status = QsimZBasisCircuitFromPauliTerm(pauli_proto, 1, &test_circuit,
+                                          &fused_circuit);
+  ASSERT_EQ(status, tensorflow::Status::OK());
+  ASSERT_EQ(test_circuit.num_qubits, 1);
+  ASSERT_EQ(test_circuit.gates.size(), 0);
+}
+
+TEST(QsimCircuitParserTest, ZBasisCircuitFromPauliTermPauliCompound) {
+  tfq::proto::PauliTerm pauli_proto;
+  // The created circuit should not depend on the coefficient
+  pauli_proto.set_coefficient_real(3.14);
+  tfq::proto::PauliQubitPair* pair_proto = pauli_proto.add_paulis();
+  pair_proto->set_qubit_id("0");
+  pair_proto->set_pauli_type("X");
+  pair_proto = pauli_proto.add_paulis();
+  pair_proto->set_qubit_id("1");
+  pair_proto->set_pauli_type("Y");
+
+  auto reference1 = qsim::Cirq::YPowGate<float>::Create(0, 1, -0.5, 0.0);
+  auto reference2 = qsim::Cirq::XPowGate<float>::Create(0, 0, 0.5, 0.0);
+
+  // Build the corresponding correct circuit
+  QsimCircuit test_circuit;
+  std::vector<qsim::GateFused<QsimGate>> fused_circuit;
+  tensorflow::Status status;
+
+  // Check conversion
+  status = QsimZBasisCircuitFromPauliTerm(pauli_proto, 2, &test_circuit,
+                                          &fused_circuit);
+  ASSERT_EQ(status, tensorflow::Status::OK());
+  ASSERT_EQ(test_circuit.num_qubits, 2);
+  ASSERT_EQ(test_circuit.gates.size(), 2);
+  AssertOneQubitEqual(test_circuit.gates[0], reference1);
+  AssertOneQubitEqual(test_circuit.gates[1], reference2);
+}
+
+TEST(QsimCircuitParserTest, ZBasisCircuitFromPauliTermEmpty) {
+  tfq::proto::PauliTerm pauli_proto;
+  tensorflow::Status status;
+  QsimCircuit test_circuit;
+  std::vector<qsim::GateFused<QsimGate>> fused_circuit;
+  status = QsimZBasisCircuitFromPauliTerm(pauli_proto, 0, &test_circuit,
+                                          &fused_circuit);
+  ASSERT_EQ(status, tensorflow::Status::OK());
+  ASSERT_EQ(test_circuit.num_qubits, 0);
+  ASSERT_EQ(test_circuit.gates.size(), 0);
+}
+
 }  // namespace
 }  // namespace tfq


### PR DESCRIPTION
Porting over ZBasis conversion code from `circuit_parser` to `circuit_parser_qsim` in the ongoing effort here: #263 . This brings us one step closer to getting tfq_sampled_expectation onto OSS qsim too.