### PR TITLE
Parse safety

### DIFF
--- a/tensorflow_quantum/core/ops/parse_context.cc
+++ b/tensorflow_quantum/core/ops/parse_context.cc
@@ -238,7 +238,7 @@ Status GetSymbolMaps(OpKernelContext* context, std::vector<SymbolMap>* maps) {
   };
 
   // TODO(mbbrough): Determine if this is a good cycle estimate.
-  int cycle_estimate = 1000;
+  const int cycle_estimate = 1000;
   context->device()->tensorflow_cpu_worker_threads()->workers->ParallelFor(
       symbol_values.dimension(0), cycle_estimate, DoWork);
 


### PR DESCRIPTION
We Accidentally merged this in where we made potentially parallel access to the underlying hash_set. Easy fix :), note that the other change we made for parallel parsing of the PauliSums (which looks extremely similar) is not a concern since we don't have any potential for overlapping writes during the datasets "underlying expansion" moments.