### PR TITLE
Smarter parallelization of state op

### DIFF
--- a/tensorflow_quantum/core/ops/circuit_execution_ops_test.py
+++ b/tensorflow_quantum/core/ops/circuit_execution_ops_test.py
@@ -230,15 +230,16 @@ class ExecutionOpsConsistentyTest(tf.test.TestCase, parameterized.TestCase):
                 **{
                     'op_and_sim': [(op, sim)
                                    for (op,
-                                        sim) in zip(STATE_OPS[:-1], SIMS[:-1])],
+                                        sim) in zip(STATE_OPS[:-2], SIMS[:-2])],
                 })))
     def test_simulate_state_large(self, op_and_sim):
-        """Test a reasonably large and complex circuit."""
+        """Test two reasonably large and complex circuits."""
         op, sim = op_and_sim
         symbol_names = []
+        # Trigger ComputeLarge in tfq_simulate_state.cc
         circuit_batch, resolver_batch = \
             util.random_circuit_resolver_batch(
-                cirq.GridQubit.rect(4, 4), 5)
+                cirq.GridQubit.rect(2, 13), 2, n_moments=5)
 
         symbol_values_array = np.array(
             [[resolver[symbol]

--- a/tensorflow_quantum/core/ops/circuit_execution_ops_test.py
+++ b/tensorflow_quantum/core/ops/circuit_execution_ops_test.py
@@ -234,7 +234,7 @@ class ExecutionOpsConsistentyTest(tf.test.TestCase, parameterized.TestCase):
                 })))
     def test_simulate_state_large(self, op_and_sim):
         """Test two reasonably large and complex circuits."""
-        op, sim = op_and_sim
+        op, _ = op_and_sim
         symbol_names = []
         # Trigger ComputeLarge in tfq_simulate_state.cc
         circuit_batch, resolver_batch = \

--- a/tensorflow_quantum/core/ops/tfq_simulate_state_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_state_op.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "../qsim/lib/circuit.h"
 #include "../qsim/lib/gate_appl.h"
 #include "../qsim/lib/gates_cirq.h"
+#include "../qsim/lib/seqfor.h"
 #include "../qsim/lib/simmux.h"
 #include "cirq/google/api/v2/program.pb.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -93,8 +94,31 @@ class TfqSimulateStateOp : public tensorflow::OpKernel {
 
     tensorflow::Tensor *output = nullptr;
     OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));
-    auto output_tensor = output->matrix<std::complex<float>>();
+    tensorflow::TTypes<std::complex<float>, 1, long int>::Matrix output_tensor = output->matrix<std::complex<float>>();
 
+    // Cross reference with standard google cloud compute instances
+    // Memory ~= 2 * num_threads * (2 * 64 * 2 ** num_qubits in circuits)
+    // e2s2 = 2 CPU, 8GB -> Can safely do 25 since Memory = 4GB
+    // e2s4 = 4 CPU, 16GB -> Can safely do 25 since Memory = 8GB
+    // ...
+    if(max_num_qubits < 26) {
+      ComputeSmall(num_qubits, max_num_qubits, fused_circuits, context, &output_tensor);
+    } else {
+      ComputeLarge(num_qubits, max_num_qubits, fused_circuits, context, &output_tensor);
+    }
+
+    programs.clear();
+    num_qubits.clear();
+    maps.clear();
+    qsim_circuits.clear();
+    fused_circuits.clear();
+  }
+ private:
+  void ComputeLarge(const std::vector<int>& num_qubits,
+                    const int max_num_qubits,
+                    const std::vector<std::vector<qsim::GateFused<QsimGate>>>& fused_circuits,
+                    tensorflow::OpKernelContext *context,
+                    tensorflow::TTypes<std::complex<float>, 1, long int>::Matrix* output_tensor) {
     // Instantiate qsim objects.
     const auto tfq_for = tfq::QsimFor(context);
     using Simulator = qsim::Simulator<const tfq::QsimFor &>;
@@ -108,7 +132,7 @@ class TfqSimulateStateOp : public tensorflow::OpKernel {
     // Simulate programs one by one. Parallelizing over wavefunctions
     // we no longer parallelize over circuits. Each time we encounter a
     // a larger circuit we will grow the Statevector as nescessary.
-    for (int i = 0; i < programs.size(); i++) {
+    for (int i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
       Simulator sim = Simulator(nq, tfq_for);
       StateSpace ss = StateSpace(nq, tfq_for);
@@ -131,11 +155,11 @@ class TfqSimulateStateOp : public tensorflow::OpKernel {
 
         if (start < crossover) {
           for (uint64_t j = 0; j < upper; j++) {
-            output_tensor(i, j) = ss.GetAmpl(sv, j);
+            (*output_tensor)(i, j) = ss.GetAmpl(sv, j);
           }
         }
         for (uint64_t j = upper; j < end; j++) {
-          output_tensor(i, j) = std::complex<float>(-2, 0);
+          (*output_tensor)(i, j) = std::complex<float>(-2, 0);
         }
       };
       const int num_cycles_copy = 50;
@@ -143,11 +167,50 @@ class TfqSimulateStateOp : public tensorflow::OpKernel {
           uint64_t(1) << max_num_qubits, num_cycles_copy, copy_f);
     }
     sv.release();
-    programs.clear();
-    num_qubits.clear();
-    maps.clear();
-    qsim_circuits.clear();
-    fused_circuits.clear();
+  }
+
+  void ComputeSmall(const std::vector<int>& num_qubits,
+                    const int max_num_qubits,
+                    const std::vector<std::vector<qsim::GateFused<QsimGate>>>& fused_circuits,
+                    tensorflow::OpKernelContext *context,
+                    tensorflow::TTypes<std::complex<float>, 1, long int>::Matrix* output_tensor) {
+
+    const auto tfq_for = qsim::SequentialFor(1);
+    using Simulator = qsim::Simulator<const qsim::SequentialFor& >;
+    using StateSpace = Simulator::StateSpace;
+    using State = StateSpace::State;
+
+    auto DoWork = [&](int start, int end) {
+      int largest_nq = 1;
+      State sv = StateSpace(largest_nq, tfq_for).CreateState();
+      for (int i = start; i < end; i++) {
+        int nq = num_qubits[i];
+        Simulator sim = Simulator(nq, tfq_for);
+        StateSpace ss = StateSpace(nq, tfq_for);
+        if (nq > largest_nq) {
+          // need to switch to larger statespace.
+          largest_nq = nq;
+          sv = ss.CreateState();
+        }
+        ss.SetStateZero(sv);
+        for (int j = 0; j < fused_circuits[i].size(); j++) {
+          qsim::ApplyFusedGate(sim, fused_circuits[i][j], sv);
+        }
+
+        for (uint64_t j = 0; j < (uint64_t(1) << nq); j++) {
+          (*output_tensor)(i, j) = ss.GetAmpl(sv, j);
+        }
+        for (uint64_t j = (uint64_t(1) << nq); j < (uint64_t(1) << max_num_qubits);
+             j++) {
+          (*output_tensor)(i, j) = std::complex<float>(-2, 0);
+        }
+      }
+      sv.release();
+    };
+
+    const int num_cycles = 200 * (1 << max_num_qubits);
+      context->device()->tensorflow_cpu_worker_threads()->workers->ParallelFor(
+          fused_circuits.size(), num_cycles, DoWork);
   }
 };
 


### PR DESCRIPTION
Noticed that there are certain cases where parallelizing over wavefunctions vs parallelizing over batches have their benefits. TL;DR Circuit smaller than 26 qubits can parallelize over the batch. Circuits larger than 26 qubits should parallelize over wavefunctions and process the batch serially. 

More specifically:
If the circuits are less than ~26 qubits , most machines (https://cloud.google.com/compute/docs/machine-types#e2_machine_types) should have enough memory to simulate circuits entirely isolated in their own threads. This is nice because we can assign large workloads to each thread without having to worry about memory or whether or not the threads have enough work to do.

If the circuits are more than 26 qubits we then run the risk of this O(num_threads * size of state vector) memory usage becoming a pretty serious problem so we can move to parallelize over a single wave function instead. Once it is that large, this should keep the CPU busy long enough to benefit from the alternate parallelization scheme.