### PR TITLE
Parameter shift grad for samples

### DIFF
--- a/scripts/import_test.py
+++ b/scripts/import_test.py
@@ -55,6 +55,7 @@ def test_imports():
     _ = tfq.differentiators.ParameterShift
     _ = tfq.differentiators.SGDifferentiator
     _ = tfq.differentiators.Differentiator
+    _ = tfq.differentiators.get_sample_op_post_process
 
     # Datasets.
     _ = tfq.datasets.excited_cluster_states

--- a/tensorflow_quantum/python/differentiators/BUILD
+++ b/tensorflow_quantum/python/differentiators/BUILD
@@ -94,7 +94,6 @@ py_test(
     python_version = "PY3",
     deps = [
         ":sampling_op_parameter_shift",
-        "//tensorflow_quantum/core/ops:circuit_execution_ops",
         "//tensorflow_quantum/python:util",
     ],
 )

--- a/tensorflow_quantum/python/differentiators/BUILD
+++ b/tensorflow_quantum/python/differentiators/BUILD
@@ -93,11 +93,7 @@ py_test(
     srcs = ["sampling_op_parameter_shift_test.py"],
     python_version = "PY3",
     deps = [
-        ":linear_combination",
-        ":parameter_shift",
-	":sampling_op_parameter_shift",
-        ":stochastic_differentiator",
-        "//tensorflow_quantum/core/ops:batch_util",
+        ":sampling_op_parameter_shift",
         "//tensorflow_quantum/core/ops:circuit_execution_ops",
         "//tensorflow_quantum/python:util",
     ],

--- a/tensorflow_quantum/python/differentiators/BUILD
+++ b/tensorflow_quantum/python/differentiators/BUILD
@@ -35,6 +35,11 @@ py_library(
     ],
 )
 
+py_library(
+    name = "sampling_op_parameter_shift",
+    srcs = ["sampling_op_parameter_shift.py"],
+)
+
 py_test(
     name = "differentiator_test",
     srcs = ["differentiator_test.py"],
@@ -74,6 +79,21 @@ py_test(
     python_version = "PY3",
     deps = [
         ":parameter_shift_util",
+        "//tensorflow_quantum/python:util",
+    ],
+)
+
+py_test(
+    name = "sampling_op_parameter_shift_test",
+    timeout = "eternal",
+    srcs = ["sampling_op_parameter_shift_test.py"],
+    python_version = "PY3",
+    deps = [
+        ":linear_combination",
+        ":parameter_shift",
+        ":stochastic_differentiator",
+        "//tensorflow_quantum/core/ops:batch_util",
+        "//tensorflow_quantum/core/ops:circuit_execution_ops",
         "//tensorflow_quantum/python:util",
     ],
 )

--- a/tensorflow_quantum/python/differentiators/BUILD
+++ b/tensorflow_quantum/python/differentiators/BUILD
@@ -38,6 +38,10 @@ py_library(
 py_library(
     name = "sampling_op_parameter_shift",
     srcs = ["sampling_op_parameter_shift.py"],
+    deps = [
+        ":parameter_shift_util",
+        "//tensorflow_quantum/core/ops:circuit_execution_ops",
+    ],
 )
 
 py_test(
@@ -91,6 +95,7 @@ py_test(
     deps = [
         ":linear_combination",
         ":parameter_shift",
+	":sampling_op_parameter_shift",
         ":stochastic_differentiator",
         "//tensorflow_quantum/core/ops:batch_util",
         "//tensorflow_quantum/core/ops:circuit_execution_ops",

--- a/tensorflow_quantum/python/differentiators/__init__.py
+++ b/tensorflow_quantum/python/differentiators/__init__.py
@@ -23,8 +23,8 @@ from tensorflow_quantum.python.differentiators.linear_combination import (
 from tensorflow_quantum.python.differentiators.parameter_shift import (
     ParameterShift,)
 
-from tensorflow_quantum.python.differentiators.sampling_op_parameter_shift import (
-    get_sample_op_post_processor,)
+from tensorflow_quantum.python.differentiators.sampling_op_parameter_shift \
+    import (get_sample_op_post_processor,)
 
 from tensorflow_quantum.python.differentiators.stochastic_differentiator \
     import (SGDifferentiator,)

--- a/tensorflow_quantum/python/differentiators/__init__.py
+++ b/tensorflow_quantum/python/differentiators/__init__.py
@@ -23,6 +23,9 @@ from tensorflow_quantum.python.differentiators.linear_combination import (
 from tensorflow_quantum.python.differentiators.parameter_shift import (
     ParameterShift,)
 
+from tensorflow_quantum.python.differentiators.sampling_op_parameter_shift import (
+    get_sample_op_post_processor,)
+
 from tensorflow_quantum.python.differentiators.stochastic_differentiator \
     import (SGDifferentiator,)
 

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
@@ -169,7 +169,8 @@ def get_sample_op_postprocessor(backend=None, post_process_func=None):
                 'spco,spc->sco', rearranged_expectations,
                 tf.cast(
                     tf.reshape(weights,
-                               [n_symbols, n_param_gates * n_shifts, n_programs]),
+                               [n_symbols,
+                                n_param_gates * n_shifts, n_programs]),
                     rearranged_expectations.dtype))
 
             # now apply the chain rule

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
@@ -103,8 +103,8 @@ def get_sample_op_postprocessor(backend=None, post_process_func=None):
                                          axis=0)
             
             # STEP 2: calculate the required expectation values
-            expectations = self.expectation_op(flat_programs, new_symbol_names,
-                                               flat_perturbations, flat_ops)
+            expectations = sample_post_process(flat_programs, new_symbol_names,
+                                               flat_perturbations, num_samples)
             
             # STEP 3: generate gradients according to the results
             

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
@@ -80,8 +80,8 @@ def get_sample_op_postprocessor(backend=None, post_process_func=None):
                 that each entry is the result of post-processing bitstrings
                 from the corresponding program in `programs`.
         """
-        forward_pass_vals = sample_post_process(
-            programs, symbol_names, symbol_values, num_samples)
+        forward_pass_vals = sample_post_process(programs, symbol_names,
+                                                symbol_values, num_samples)
 
         def gradient(grad):
             """Returns the gradient computed via parameter-shifting."""
@@ -168,9 +168,9 @@ def get_sample_op_postprocessor(backend=None, post_process_func=None):
             partials = tf.einsum(
                 'spco,spc->sco', rearranged_expectations,
                 tf.cast(
-                    tf.reshape(weights,
-                               [n_symbols,
-                                n_param_gates * n_shifts, n_programs]),
+                    tf.reshape(
+                        weights,
+                        [n_symbols, n_param_gates * n_shifts, n_programs]),
                     rearranged_expectations.dtype))
 
             # now apply the chain rule

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
@@ -45,7 +45,7 @@ def get_sample_op_postprocessor(backend=None, post_process_func=None):
             scalar_list = scalar_list.write(
                 i, post_process_func(ragged_samples[i].to_tensor()))
         scalar_list = scalar_list.stack()
-        return scalar_list
+        return tf.expand_dims(scalar_list, axis=-1)
 
     @tf.custom_gradient
     def sample_post_process_wrapper(programs, symbol_names, symbol_values,
@@ -119,8 +119,8 @@ def get_sample_op_postprocessor(backend=None, post_process_func=None):
             def rearrange_expectations(grouped):
                 
                 def split_vertically(i):
-                    return tf.slice(grouped, [i * n_programs],
-                                    [n_programs])
+                    return tf.slice(grouped, [i * n_programs, 0],
+                                    [n_programs, 1])
                 
                 return tf.map_fn(split_vertically,
                                  tf.range(n_param_gates * n_shifts),

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
@@ -1,0 +1,60 @@
+# Copyright 2020 The TensorFlow Quantum Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Differentiation of Sample post-processing with the parameter shift rule."""
+import tensorflow as tf
+
+from tensorflow_quantum.core.ops import circuit_execution_ops
+
+
+def get_differentiable_sample_op_parameter_shift(backend=None,
+                                                 post_process_func=None):
+    """Make bitstring post-processing differentiable.
+
+    Create a layer that will output bitstring samples taken from either a
+    simulated quantum state or a real quantum computer
+
+    Args:
+        backend: Optional Backend to use. Defaults to the native TensorFlow
+            Quantum simulator (None), however users may also specify a
+            preconfigured cirq execution object to use instead, which must
+            `cirq.Sampler`.
+        post_process_func: Differentiable function from tensor of
+            type `tf.int8` of shape [repetitions, num_qubits] to a scalar.
+            Assumes same function is to be applied to all sampled outputs.
+    """
+    sample_op = circuit_execution_ops.get_sampling_op(backend)
+    
+    @tf.custom_gradient
+    def sample_post_process_wrapper(programs, symbol_names, symbol_values,
+                                    num_samples):        
+        ragged_samples = sample_op(programs, symbol_names, symbol_values,
+                                   num_samples)
+        if post
+        if ragged_samples.shape[0] 
+        for i in tf.range(cpp_ragged.shape[0]):
+            
+            print(cpp_ragged[i].to_tensor())
+        
+        forward_pass_vals = 
+        def gradient(grad):
+            self._differentiate_sam(programs, symbol_names,
+                                           symbol_values, pauli_sums,
+                                           num_samples, forward_pass_vals,
+                                           grad)
+            return None, None, this_grad_vec, None
+
+        return forward_pass_vals, gradient
+
+    return sample_post_process_wrapper

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
@@ -29,30 +29,120 @@ def get_differentiable_sample_op_parameter_shift(backend=None,
         backend: Optional Backend to use. Defaults to the native TensorFlow
             Quantum simulator (None), however users may also specify a
             preconfigured cirq execution object to use instead, which must
-            `cirq.Sampler`.
+            inherit `cirq.Sampler`.
         post_process_func: Differentiable function from tensor of
-            type `tf.int8` of shape [repetitions, num_qubits] to a scalar.
-            Assumes same function is to be applied to all sampled outputs.
+            type `tf.int8` of shape [repetitions, num_qubits] to scalar of
+            type `tf.float32`. Given function is applied to all circuits.
     """
     sample_op = circuit_execution_ops.get_sampling_op(backend)
+
+    def sample_post_process(programs, symbol_names, symbol_values, num_samples):
+        ragged_samples = sample_op(programs, symbol_names, symbol_values,
+                                   num_samples)
+        scalar_list = tf.TensorArray(tf.dtypes.float32, tf.shape(programs)[0])
+        for i in tf.range(tf.shape(programs)[0]):
+            scalar_list = scalar_list.write(i, post_process_func(ragged_samples[i]))
+        return scalar_list.stack()
     
     @tf.custom_gradient
     def sample_post_process_wrapper(programs, symbol_names, symbol_values,
-                                    num_samples):        
-        ragged_samples = sample_op(programs, symbol_names, symbol_values,
-                                   num_samples)
-        if post
-        if ragged_samples.shape[0] 
-        for i in tf.range(cpp_ragged.shape[0]):
-            
-            print(cpp_ragged[i].to_tensor())
+                                    num_samples):
+        forward_pass_vals = sample_post_process(programs, symbol_names, symbol_values, num_samples)
         
-        forward_pass_vals = 
         def gradient(grad):
-            self._differentiate_sam(programs, symbol_names,
-                                           symbol_values, pauli_sums,
-                                           num_samples, forward_pass_vals,
-                                           grad)
+            # adapted from `parameter_shift.py`
+            # these get used a lot
+            n_symbols = tf.gather(tf.shape(symbol_names), 0)
+            n_programs = tf.gather(tf.shape(programs), 0)
+            # Assume cirq.decompose() generates gates with at most two distinct
+            # eigenvalues, which results in two parameter shifts.
+            n_shifts = 2
+            
+            # STEP 1: Generate required inputs for executor
+            # Deserialize programs and parse the whole parameterized gates
+            # new_programs has [n_symbols, n_param_gates, n_shifts, n_programs].
+            # These new_programs has programs that parameter-shift rule is applied,
+            # so those programs has
+            (new_programs, weights, shifts,
+             n_param_gates) = parameter_shift_util.parse_programs(
+                 programs, symbol_names, symbol_values, n_symbols)
+            
+            # Reshape & transpose new_programs, weights and shifts to fit into
+            # the input format of tensorflow_quantum simulator.
+            # [n_symbols, n_param_gates, n_shifts, n_programs]
+            new_programs = tf.transpose(new_programs, [0, 2, 3, 1])
+            weights = tf.transpose(weights, [0, 2, 3, 1])
+            shifts = tf.transpose(shifts, [0, 2, 3, 1])
+            
+            # reshape everything to fit into expectation op correctly
+            total_programs = n_programs * n_shifts * n_param_gates * n_symbols
+            # tile up and then reshape to order programs correctly
+            flat_programs = tf.reshape(new_programs, [total_programs])
+            flat_shifts = tf.reshape(shifts, [total_programs])
+            
+            # tile up and then reshape to order ops correctly
+            n_tile = n_shifts * n_param_gates * n_symbols
+            flat_perturbations = tf.concat([
+                tf.reshape(
+                    tf.tile(tf.expand_dims(symbol_values, 0),
+                            tf.stack([n_tile, 1, 1])),
+                    [total_programs, n_symbols]),
+                tf.expand_dims(flat_shifts, axis=1)
+            ],
+                                           axis=1)
+            flat_num_samples = tf.reshape(
+                tf.tile(tf.expand_dims(num_samples, 0), tf.stack([n_tile, 1, 1])),
+                [total_programs, 1])
+            # Append impurity symbol into symbol name
+            new_symbol_names = tf.concat([
+                symbol_names,
+                tf.expand_dims(tf.constant(
+                    parameter_shift_util._PARAMETER_IMPURITY_NAME),
+                               axis=0)
+            ],
+                                         axis=0)
+            
+            # STEP 2: calculate the required expectation values
+            expectations = sample_post_process(flat_programs, new_symbol_names,
+                                               flat_perturbations,
+                                               flat_num_samples)
+            
+            # STEP 3: generate gradients according to the results
+            
+            # we know the rows are grouped according to which parameter
+            # was perturbed, so reshape to reflect that
+            grouped_expectations = tf.reshape(
+                expectations,
+                [n_symbols, n_shifts * n_programs * n_param_gates, -1])
+            
+            # now we can calculate the partial of the circuit output with
+            # respect to each perturbed parameter
+            def rearrange_expectations(grouped):
+                
+                def split_vertically(i):
+                    return tf.slice(grouped, [i * n_programs, 0],
+                                    [n_programs, 1])
+                
+                return tf.map_fn(split_vertically,
+                                 tf.range(n_param_gates * n_shifts),
+                                 dtype=tf.float32)
+            
+            # reshape so that expectations calculated on different programs are
+            # separated by a dimension
+            rearranged_expectations = tf.map_fn(rearrange_expectations,
+                                                grouped_expectations)
+            
+            # now we will calculate all of the partial derivatives
+            partials = tf.einsum(
+                'spco,spc->sco', rearranged_expectations,
+                tf.cast(
+                    tf.reshape(weights,
+                               [n_symbols, n_param_gates * n_shifts, n_programs]),
+                    rearranged_expectations.dtype))
+            
+            # now apply the chain rule
+            this_grad_vec = tf.einsum('sco,co -> cs', partials, grad)
+
             return None, None, this_grad_vec, None
 
         return forward_pass_vals, gradient

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift.py
@@ -54,7 +54,7 @@ def get_sample_op_postprocessor(backend=None, post_process_func=None):
             # these get used a lot
             n_symbols = tf.gather(tf.shape(symbol_names), 0)
             n_programs = tf.gather(tf.shape(programs), 0)
-            n_ops = tf.gather(tf.shape(pauli_sums), 1)
+
             # Assume cirq.decompose() generates gates with at most two distinct
             # eigenvalues, which results in two parameter shifts.
             n_shifts = 2
@@ -92,7 +92,7 @@ def get_sample_op_postprocessor(backend=None, post_process_func=None):
                                            axis=1)
             flat_ops = tf.reshape(
                 tf.tile(tf.expand_dims(pauli_sums, 0), tf.stack([n_tile, 1, 1])),
-                [total_programs, n_ops])
+                [total_programs, 1])  # 1 was n_ops
             # Append impurity symbol into symbol name
             new_symbol_names = tf.concat([
                 symbol_names,
@@ -120,7 +120,7 @@ def get_sample_op_postprocessor(backend=None, post_process_func=None):
                 
                 def split_vertically(i):
                     return tf.slice(grouped, [i * n_programs, 0],
-                                    [n_programs, n_ops])
+                                    [n_programs, 1])  # 1 was n_ops
                 
                 return tf.map_fn(split_vertically,
                                  tf.range(n_param_gates * n_shifts),

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
@@ -21,11 +21,9 @@ import tensorflow as tf
 from absl.testing import parameterized
 
 import cirq
+from tensorflow_quantum.core.ops import circuit_execution_ops
 from tensorflow_quantum.python import util
-from tensorflow_quantum.python.differentiators import linear_combination
-from tensorflow_quantum.python.differentiators import parameter_shift
-from tensorflow_quantum.python.differentiators import stochastic_differentiator
-from tensorflow_quantum.core.ops import circuit_execution_ops, batch_util
+from tensorflow_quantum.python.differentiators import sampling_op_parameter_shift
 
 
 def _cirq_evaluate_post_process(circuit_batch, resolvers, n_samples,
@@ -77,7 +75,7 @@ class GradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
     } for sim in [None, cirq.sim.sparse_simulator.Simulator(),
                   cirq.sim.density_matrix_simulator.DensityMatrixSimulator()]])
     def test_backprop(self, sim):
-        """Compare utility sample-op gradients to analytic gradien."""
+        """Compare utility sample-op gradients to analytic gradients."""
 
         def exact_grad(theta):
             new_theta = 2 * np.pi * theta
@@ -113,188 +111,96 @@ class GradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
         # will this be too tight? time will tell.
         self.assertAllClose(exact, grad.numpy(), rtol=0.01, atol=0.01)
 
-    @parameterized.parameters(
-        list(
-            util.kwargs_cartesian_product(
-                **{
-                    'differentiator': DIFFS,
-                    'op': OPS,
-                    'n_qubits': [5],
-                    'n_programs': [3],
-                    'n_ops': [3],
-                    'symbol_names': [['a', 'b']]
-                })))
-    def test_gradients_vs_cirq_finite_difference(self, differentiator, op,
-                                                 n_qubits, n_programs, n_ops,
-                                                 symbol_names):
-        """Compare TFQ differentiators to fine-grained noiseless cirq finite
-        differencing.
-        DISCLAIMER : the consistency of STOCHASTIC_DIFFS is hard to be checked.
-        Its expectation value should be checked, but it takes long time because
-        SGDifferentiator is not optimized. Until optimized, the consistency
-        will be performed in benchmarks/scripts/differentiators:convergence_test
-        TODO(jaeyoo) : move convergence_test here once SGDifferentiator is
-         optimized.
-        """
-        differentiator.refresh()
-        op = differentiator.generate_differentiable_op(analytic_op=op)
+    # @parameterized.parameters(
+    #     list(
+    #         util.kwargs_cartesian_product(
+    #             **{
+    #                 'differentiator': DIFFS,
+    #                 'op': OPS,
+    #                 'n_qubits': [5],
+    #                 'n_programs': [3],
+    #                 'n_ops': [3],
+    #                 'symbol_names': [['a', 'b']]
+    #             })))
+    # def test_gradients_vs_cirq_finite_difference(self, differentiator, op,
+    #                                              n_qubits, n_programs, n_ops,
+    #                                              symbol_names):
+    #     """Compare TFQ differentiators to fine-grained noiseless cirq finite
+    #     differencing.
+    #     DISCLAIMER : the consistency of STOCHASTIC_DIFFS is hard to be checked.
+    #     Its expectation value should be checked, but it takes long time because
+    #     SGDifferentiator is not optimized. Until optimized, the consistency
+    #     will be performed in benchmarks/scripts/differentiators:convergence_test
+    #     TODO(jaeyoo) : move convergence_test here once SGDifferentiator is
+    #      optimized.
+    #     """
+    #     differentiator.refresh()
+    #     op = differentiator.generate_differentiable_op(analytic_op=op)
 
-        qubits = cirq.GridQubit.rect(1, n_qubits)
-        circuit_batch, resolver_batch = \
-            util.random_symbol_circuit_resolver_batch(
-                cirq.GridQubit.rect(1, n_qubits), symbol_names, n_programs)
+    #     qubits = cirq.GridQubit.rect(1, n_qubits)
+    #     circuit_batch, resolver_batch = \
+    #         util.random_symbol_circuit_resolver_batch(
+    #             cirq.GridQubit.rect(1, n_qubits), symbol_names, n_programs)
 
-        psums = [
-            util.random_pauli_sums(qubits, 1, n_ops) for _ in circuit_batch
-        ]
+    #     psums = [
+    #         util.random_pauli_sums(qubits, 1, n_ops) for _ in circuit_batch
+    #     ]
 
-        symbol_values_array = np.array(
-            [[resolver[symbol]
-              for symbol in symbol_names]
-             for resolver in resolver_batch],
-            dtype=np.float32)
+    #     symbol_values_array = np.array(
+    #         [[resolver[symbol]
+    #           for symbol in symbol_names]
+    #          for resolver in resolver_batch],
+    #         dtype=np.float32)
 
-        # calculate tfq gradient
-        symbol_values_tensor = tf.convert_to_tensor(symbol_values_array)
-        programs = util.convert_to_tensor(circuit_batch)
-        ops = util.convert_to_tensor(psums)
-        with tf.GradientTape() as g:
-            g.watch(symbol_values_tensor)
-            expectations = op(programs, symbol_names, symbol_values_tensor, ops)
-        tfq_grads = g.gradient(expectations, symbol_values_tensor)
+    #     # calculate tfq gradient
+    #     symbol_values_tensor = tf.convert_to_tensor(symbol_values_array)
+    #     programs = util.convert_to_tensor(circuit_batch)
+    #     ops = util.convert_to_tensor(psums)
+    #     with tf.GradientTape() as g:
+    #         g.watch(symbol_values_tensor)
+    #         expectations = op(programs, symbol_names, symbol_values_tensor, ops)
+    #     tfq_grads = g.gradient(expectations, symbol_values_tensor)
 
-        # calculate gradients in cirq using a very simple forward differencing
-        # scheme
-        cirq_grads = _cirq_simple_finite_difference(circuit_batch,
-                                                    resolver_batch,
-                                                    symbol_names, psums)
+    #     # calculate gradients in cirq using a very simple forward differencing
+    #     # scheme
+    #     cirq_grads = _cirq_simple_finite_difference(circuit_batch,
+    #                                                 resolver_batch,
+    #                                                 symbol_names, psums)
 
-        # will this be too tight? time will tell.
-        self.assertAllClose(cirq_grads, tfq_grads, rtol=1e-2, atol=1e-2)
+    #     # will this be too tight? time will tell.
+    #     self.assertAllClose(cirq_grads, tfq_grads, rtol=1e-2, atol=1e-2)
 
-    @parameterized.parameters(
-        list(
-            util.kwargs_cartesian_product(
-                **{
-                    'differentiator': DIFFS + STOCHASTIC_DIFFS,
-                    'op': OPS,
-                    'stochastic_cost': [False, True]
-                })))
-    def test_analytic_value_with_simple_circuit(self, differentiator, op,
-                                                stochastic_cost):
-        """Test the value of differentiator with simple circuit.
-        Since there are only one symbol, one gate and one op, there is only one
-        samling result, STOCHATIC_DIFFS shows the same result with that of
-        deterministic differentiators."""
-        # Get an expectation op, with this differentiator attached.
-        differentiator.refresh()
-        differentiator.stochastic_cost = stochastic_cost
-        op = differentiator.generate_differentiable_op(analytic_op=op)
-        qubit = cirq.GridQubit(0, 0)
-        circuit = util.convert_to_tensor(
-            [cirq.Circuit(cirq.X(qubit)**sympy.Symbol('alpha'))])
-        psums = util.convert_to_tensor([[cirq.Z(qubit)]])
-        symbol_values_array = np.array([[0.123]], dtype=np.float32)
-        # Calculate tfq gradient.
-        symbol_values_tensor = tf.convert_to_tensor(symbol_values_array)
-        with tf.GradientTape() as g:
-            g.watch(symbol_values_tensor)
-            expectations = op(circuit, ['alpha'], symbol_values_tensor, psums)
-        grads = g.gradient(expectations, symbol_values_tensor)
-        ground_truth_grads = np.array([[-1.1839752]])
-        self.assertAllClose(ground_truth_grads, grads, rtol=1e-2, atol=1e-2)
-
-
-class StochasticDifferentiatorCorrectnessTest(tf.test.TestCase,
-                                              parameterized.TestCase):
-    """Test correctness of the stochastic differentiators to reference cirq
-    algorithm.
-    DISCLAIMER: this test allows for a larger margin of error and as long
-    as convergence is happening then it passes"""
-
-    # TODO(zaqqwerty): only this test was failing after adding cirq.I
-    #    support, so it is disabled pending diagnosis
-    @parameterized.parameters(
-        list(
-            util.kwargs_cartesian_product(
-                **{
-                    'differentiator': STOCHASTIC_DIFFS,
-                    'op': OPS,
-                    'n_qubits': [5],
-                    'n_programs': [3],
-                    'n_ops': [3],
-                    'symbol_names': [['a', 'b']],
-                    'stochastic_cost_eps': [(False, 5e-1), (True, 7e-1)],
-                })))
-    def gradients_vs_cirq_finite_difference(self, differentiator, op, n_qubits,
-                                            n_programs, n_ops, symbol_names,
-                                            stochastic_cost_eps):
-        """Compare TFQ differentiators to fine-grained noiseless cirq finite
-        differencing with a larger margin of error."""
-
-        # TODO (jaeyoo): cleanup this hacky wordkaround so variable
-        #   assignment doesn't need to take place like this.
-        differentiator.stochastic_cost, eps = stochastic_cost_eps
-        differentiator.refresh()
-        op = differentiator.generate_differentiable_op(analytic_op=op)
-
-        qubits = cirq.GridQubit.rect(1, n_qubits)
-        circuit_batch, resolver_batch = \
-            util.random_symbol_circuit_resolver_batch(
-                cirq.GridQubit.rect(1, n_qubits), symbol_names, n_programs)
-
-        psums = [
-            util.random_pauli_sums(qubits, 1, n_ops) for _ in circuit_batch
-        ]
-
-        symbol_values_array = np.array(
-            [[resolver[symbol]
-              for symbol in symbol_names]
-             for resolver in resolver_batch],
-            dtype=np.float32)
-
-        # calculate tfq gradient
-        symbol_values_tensor = tf.convert_to_tensor(symbol_values_array)
-        programs = util.convert_to_tensor(circuit_batch)
-        ops = util.convert_to_tensor(psums)
-
-        # calculate gradients in cirq using a very simple forward differencing
-        # scheme
-        cirq_grads = _cirq_simple_finite_difference(circuit_batch,
-                                                    resolver_batch,
-                                                    symbol_names, psums)
-
-        def _get_gradient():
-            with tf.GradientTape() as g:
-                g.watch(symbol_values_tensor)
-                expectations = op(programs, symbol_names, symbol_values_tensor,
-                                  ops)
-            return g.gradient(expectations, symbol_values_tensor)
-
-        def _abs_diff(grad, mask):
-            return np.sum(np.abs(grad - cirq_grads * mask))
-
-        def _get_nonzero_mask(grad):
-            return (grad.numpy() != 0.0).astype(np.float32)
-
-        # Get the non-zero mask because a few initial gradients have not sampled
-        # zero values.
-        tfq_grads_1 = _get_gradient()
-        mask_1 = _get_nonzero_mask(tfq_grads_1)
-
-        if not np.allclose(tfq_grads_1, cirq_grads * mask_1, atol=eps):
-            tfq_grads_2 = 0.5 * (tfq_grads_1 + _get_gradient())
-            mask_2 = _get_nonzero_mask(tfq_grads_2)
-            # Check if the 2nd error becomes smaller that 1st one.
-            if not _abs_diff(tfq_grads_1, mask_1) > _abs_diff(
-                    tfq_grads_2, mask_2):
-                cnt = 2
-                tfq_grads = (cnt * tfq_grads_2 + _get_gradient()) / (cnt + 1)
-                while (cnt < 10 and
-                       not np.allclose(cirq_grads, tfq_grads, atol=eps)):
-                    cnt += 1
-                    tfq_grads = (cnt * tfq_grads + _get_gradient()) / (cnt + 1)
-                self.assertAllClose(cirq_grads, tfq_grads, atol=eps)
+    # @parameterized.parameters(
+    #     list(
+    #         util.kwargs_cartesian_product(
+    #             **{
+    #                 'differentiator': DIFFS + STOCHASTIC_DIFFS,
+    #                 'op': OPS,
+    #                 'stochastic_cost': [False, True]
+    #             })))
+    # def test_analytic_value_with_simple_circuit(self, differentiator, op,
+    #                                             stochastic_cost):
+    #     """Test the value of differentiator with simple circuit.
+    #     Since there are only one symbol, one gate and one op, there is only one
+    #     samling result, STOCHATIC_DIFFS shows the same result with that of
+    #     deterministic differentiators."""
+    #     # Get an expectation op, with this differentiator attached.
+    #     differentiator.refresh()
+    #     differentiator.stochastic_cost = stochastic_cost
+    #     op = differentiator.generate_differentiable_op(analytic_op=op)
+    #     qubit = cirq.GridQubit(0, 0)
+    #     circuit = util.convert_to_tensor(
+    #         [cirq.Circuit(cirq.X(qubit)**sympy.Symbol('alpha'))])
+    #     psums = util.convert_to_tensor([[cirq.Z(qubit)]])
+    #     symbol_values_array = np.array([[0.123]], dtype=np.float32)
+    #     # Calculate tfq gradient.
+    #     symbol_values_tensor = tf.convert_to_tensor(symbol_values_array)
+    #     with tf.GradientTape() as g:
+    #         g.watch(symbol_values_tensor)
+    #         expectations = op(circuit, ['alpha'], symbol_values_tensor, psums)
+    #     grads = g.gradient(expectations, symbol_values_tensor)
+    #     ground_truth_grads = np.array([[-1.1839752]])
+    #     self.assertAllClose(ground_truth_grads, grads, rtol=1e-2, atol=1e-2)
 
 
 if __name__ == '__main__':

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
@@ -89,31 +89,31 @@ class GradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
                     total_spin, tf.cast(1 - bitstrings[i][j] * 2, tf.float32))
         return total_spin / count
 
-    # @parameterized.parameters([{'sim': sim} for sim in SIM_LIST])
-    # def test_backprop(self, sim):
-    #     """Compare utility sample-op gradients to analytic gradients."""
+    @parameterized.parameters([{'sim': sim} for sim in SIM_LIST])
+    def test_backprop(self, sim):
+        """Compare utility sample-op gradients to analytic gradients."""
 
-    #     def exact_grad(theta):
-    #         new_theta = 2 * np.pi * theta
-    #         return -2 * np.pi * np.sin(new_theta) * np.exp(np.cos(new_theta))
+        def exact_grad(theta):
+            new_theta = 2 * np.pi * theta
+            return -2 * np.pi * np.sin(new_theta) * np.exp(np.cos(new_theta))
 
-    #     op = sampling_op_parameter_shift.get_sample_op_postprocessor(
-    #         backend=sim, post_process_func=self.post_process_func)
+        op = sampling_op_parameter_shift.get_sample_op_postprocessor(
+            backend=sim, post_process_func=self.post_process_func)
 
-    #     bit = cirq.GridQubit(0, 0)
-    #     circuits = util.convert_to_tensor(
-    #         [cirq.Circuit(cirq.X(bit)**sympy.Symbol('rx')) for _ in range(2)])
-    #     base_rot_angles = tf.constant([[0.25], [0.125]])
-    #     repetitions = 10000
-    #     with tf.GradientTape() as g:
-    #         g.watch(base_rot_angles)
-    #         input_angles = 2 * base_rot_angles
-    #         exp_res = tf.exp(op(circuits, ['rx'], input_angles, [repetitions]))
+        bit = cirq.GridQubit(0, 0)
+        circuits = util.convert_to_tensor(
+            [cirq.Circuit(cirq.X(bit)**sympy.Symbol('rx')) for _ in range(2)])
+        base_rot_angles = tf.constant([[0.25], [0.125]])
+        repetitions = 10000
+        with tf.GradientTape() as g:
+            g.watch(base_rot_angles)
+            input_angles = 2 * base_rot_angles
+            exp_res = tf.exp(op(circuits, ['rx'], input_angles, [repetitions]))
 
-    #     grad = g.gradient(exp_res, base_rot_angles)
-    #     exact = [[exact_grad(0.25)], [exact_grad(0.125)]]
+        grad = g.gradient(exp_res, base_rot_angles)
+        exact = [[exact_grad(0.25)], [exact_grad(0.125)]]
 
-    #     self.assertAllClose(exact, grad.numpy(), rtol=0.025, atol=0.025)
+        self.assertAllClose(exact, grad.numpy(), rtol=0.025, atol=0.025)
 
     @parameterized.parameters(
         list(

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
@@ -38,7 +38,8 @@ def _cirq_evaluate_post_process(circuit_batch, resolvers, n_samples,
         state = simulator.simulate(circuit, resolver).final_state
         qubits = sorted(circuit.all_qubits())
         raw_results = cirq.sample_state_vector(
-            state, len(qubits), repetitions=n_samples).astype(np.int32)
+            state, list(range(len(qubits))), repetitions=n_samples
+        ).astype(np.int32)
         results.append(post_process_func(raw_results))
     return results
 

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
@@ -100,10 +100,11 @@ class GradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
         circuits = util.convert_to_tensor(
             [cirq.Circuit(cirq.X(bit)**sympy.Symbol('rx')) for _ in range(2)])
         base_rot_angles = tf.constant([[0.25], [0.125]])
+        repetitions = 1000
         with tf.GradientTape() as g:
             g.watch(base_rot_angles)
             input_angles = 2 * base_rot_angles
-            exp_res = tf.exp(op(circuits, ['rx'], input_angles, pstring))
+            exp_res = tf.exp(op(circuits, ['rx'], input_angles, [repetitions]))
 
         grad = g.gradient(exp_res, base_rot_angles)
         exact = [[exact_grad(0.25)], [exact_grad(0.125)]]

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
@@ -100,7 +100,7 @@ class GradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
         circuits = util.convert_to_tensor(
             [cirq.Circuit(cirq.X(bit)**sympy.Symbol('rx')) for _ in range(2)])
         base_rot_angles = tf.constant([[0.25], [0.125]])
-        repetitions = 1000
+        repetitions = 100000
         with tf.GradientTape() as g:
             g.watch(base_rot_angles)
             input_angles = 2 * base_rot_angles

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Test parameter shift gradients over the TFQ sampling op."""
+"""Test parameter shift gradients over the post-processed TFQ sampling op."""
 import copy
 
 import numpy as np

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
@@ -1,0 +1,331 @@
+# Copyright 2020 The TensorFlow Quantum Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Testing for gradient calculation consistency in TFQ."""
+import copy
+
+import numpy as np
+import sympy
+import tensorflow as tf
+from absl.testing import parameterized
+
+import cirq
+from tensorflow_quantum.python import util
+from tensorflow_quantum.python.differentiators import linear_combination
+from tensorflow_quantum.python.differentiators import parameter_shift
+from tensorflow_quantum.python.differentiators import stochastic_differentiator
+from tensorflow_quantum.core.ops import circuit_execution_ops, batch_util
+
+DIFFS = [
+    linear_combination.ForwardDifference(grid_spacing=0.0001),
+    linear_combination.ForwardDifference(error_order=2, grid_spacing=0.0001),
+    linear_combination.CentralDifference(grid_spacing=0.0001),
+    linear_combination.CentralDifference(error_order=4, grid_spacing=0.0001),
+    parameter_shift.ParameterShift(),
+]
+
+STOCHASTIC_DIFFS = [
+    stochastic_differentiator.SGDifferentiator(stochastic_coordinate=False,
+                                               stochastic_generator=False,
+                                               stochastic_cost=False),
+    stochastic_differentiator.SGDifferentiator(stochastic_coordinate=True,
+                                               stochastic_generator=False,
+                                               stochastic_cost=False),
+    stochastic_differentiator.SGDifferentiator(stochastic_coordinate=False,
+                                               stochastic_generator=True,
+                                               stochastic_cost=False),
+    stochastic_differentiator.SGDifferentiator(stochastic_coordinate=True,
+                                               stochastic_generator=True,
+                                               stochastic_cost=False),
+]
+
+OPS = [
+    circuit_execution_ops.get_expectation_op(cirq.sim.Simulator()),  # WF
+    circuit_execution_ops.get_expectation_op(
+        cirq.DensityMatrixSimulator()),  # DM
+    circuit_execution_ops.get_expectation_op()  # C++
+]
+
+
+def _cirq_simple_finite_difference(circuit_batch,
+                                   resolvers,
+                                   symbol_names,
+                                   op_batch,
+                                   grid_spacing=0.0001):
+    """A simple finite difference code that calculates the gradient of a
+    batch of circuits using cirq."""
+    simulator = cirq.sim.Simulator()
+
+    init_vals = batch_util.batch_calculate_expectation(circuit_batch, resolvers,
+                                                       op_batch, simulator)
+    grad_circuits = []
+    grad_resolvers = []
+    grad_pauli_sums = []
+    for this_program, this_pauli_sums, this_resolver in \
+        zip(circuit_batch, op_batch, resolvers):
+        for symbol in symbol_names:
+            perturbed_resolver = copy.deepcopy(this_resolver)
+            perturbed_resolver.param_dict[symbol] += grid_spacing
+            grad_circuits.append(this_program)
+            grad_pauli_sums.append(this_pauli_sums)
+            grad_resolvers.append(perturbed_resolver)
+
+    # shape: [n_programs * len(symbol_names), n_pauli_sums]
+    results = np.array(
+        batch_util.batch_calculate_expectation(circuits=grad_circuits,
+                                               param_resolvers=grad_resolvers,
+                                               ops=grad_pauli_sums,
+                                               simulator=simulator))
+
+    # shape: [n_pauli_sums, n_programs, len(symbol_names)]
+    gradient_generator = results.transpose().reshape(
+        (len(op_batch[0]), len(circuit_batch), len(symbol_names)))
+
+    # shape: [n_pauli_sums, n_programs, len(symbol_names)]
+    forward_pass_vals = np.transpose(
+        np.vstack([np.expand_dims(init_vals, axis=0)] * len(symbol_names)),
+        (2, 1, 0))
+
+    return np.sum(1 / grid_spacing * (gradient_generator - forward_pass_vals),
+                  axis=0)
+
+
+class GradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
+    """Test correctness of the differentiators to reference cirq algorithm."""
+
+    @parameterized.parameters(
+        list(
+            util.kwargs_cartesian_product(
+                **{
+                    'differentiator': DIFFS + STOCHASTIC_DIFFS,
+                    'op': OPS,
+                    'stochastic_cost': [False, True]
+                })))
+    def test_backprop(self, differentiator, op, stochastic_cost):
+        """Test that gradients are correctly backpropagated through a quantum
+        circuit via comparison to analytical results.
+        """
+        # hack to add stoachastic cost. TODO (jaeyoo): remove this hack.
+        differentiator.stochastic_cost = stochastic_cost
+        differentiator.refresh()
+        op = differentiator.generate_differentiable_op(analytic_op=op)
+
+        def exact_grad(theta):
+            new_theta = 2 * np.pi * theta
+            return -2 * np.pi * np.sin(new_theta) * np.exp(np.cos(new_theta))
+
+        bit = cirq.GridQubit(0, 0)
+        circuits = util.convert_to_tensor(
+            [cirq.Circuit(cirq.X(bit)**sympy.Symbol('rx')) for _ in range(2)])
+        pstring = util.convert_to_tensor([[
+            cirq.PauliSum.from_pauli_strings([cirq.PauliString({bit: cirq.Z})])
+        ] for _ in circuits])
+        base_rot_angles = tf.constant([[0.25], [0.125]])
+        with tf.GradientTape() as g:
+            g.watch(base_rot_angles)
+            input_angles = 2 * base_rot_angles
+            exp_res = tf.exp(op(circuits, ['rx'], input_angles, pstring))
+
+        grad = g.gradient(exp_res, base_rot_angles)
+        exact = [[exact_grad(0.25)], [exact_grad(0.125)]]
+
+        # will this be too tight? time will tell.
+        self.assertAllClose(exact, grad.numpy(), rtol=0.01, atol=0.01)
+
+    @parameterized.parameters(
+        list(
+            util.kwargs_cartesian_product(
+                **{
+                    'differentiator': DIFFS,
+                    'op': OPS,
+                    'n_qubits': [5],
+                    'n_programs': [3],
+                    'n_ops': [3],
+                    'symbol_names': [['a', 'b']]
+                })))
+    def test_gradients_vs_cirq_finite_difference(self, differentiator, op,
+                                                 n_qubits, n_programs, n_ops,
+                                                 symbol_names):
+        """Compare TFQ differentiators to fine-grained noiseless cirq finite
+        differencing.
+        DISCLAIMER : the consistency of STOCHASTIC_DIFFS is hard to be checked.
+        Its expectation value should be checked, but it takes long time because
+        SGDifferentiator is not optimized. Until optimized, the consistency
+        will be performed in benchmarks/scripts/differentiators:convergence_test
+        TODO(jaeyoo) : move convergence_test here once SGDifferentiator is
+         optimized.
+        """
+        differentiator.refresh()
+        op = differentiator.generate_differentiable_op(analytic_op=op)
+
+        qubits = cirq.GridQubit.rect(1, n_qubits)
+        circuit_batch, resolver_batch = \
+            util.random_symbol_circuit_resolver_batch(
+                cirq.GridQubit.rect(1, n_qubits), symbol_names, n_programs)
+
+        psums = [
+            util.random_pauli_sums(qubits, 1, n_ops) for _ in circuit_batch
+        ]
+
+        symbol_values_array = np.array(
+            [[resolver[symbol]
+              for symbol in symbol_names]
+             for resolver in resolver_batch],
+            dtype=np.float32)
+
+        # calculate tfq gradient
+        symbol_values_tensor = tf.convert_to_tensor(symbol_values_array)
+        programs = util.convert_to_tensor(circuit_batch)
+        ops = util.convert_to_tensor(psums)
+        with tf.GradientTape() as g:
+            g.watch(symbol_values_tensor)
+            expectations = op(programs, symbol_names, symbol_values_tensor, ops)
+        tfq_grads = g.gradient(expectations, symbol_values_tensor)
+
+        # calculate gradients in cirq using a very simple forward differencing
+        # scheme
+        cirq_grads = _cirq_simple_finite_difference(circuit_batch,
+                                                    resolver_batch,
+                                                    symbol_names, psums)
+
+        # will this be too tight? time will tell.
+        self.assertAllClose(cirq_grads, tfq_grads, rtol=1e-2, atol=1e-2)
+
+    @parameterized.parameters(
+        list(
+            util.kwargs_cartesian_product(
+                **{
+                    'differentiator': DIFFS + STOCHASTIC_DIFFS,
+                    'op': OPS,
+                    'stochastic_cost': [False, True]
+                })))
+    def test_analytic_value_with_simple_circuit(self, differentiator, op,
+                                                stochastic_cost):
+        """Test the value of differentiator with simple circuit.
+        Since there are only one symbol, one gate and one op, there is only one
+        samling result, STOCHATIC_DIFFS shows the same result with that of
+        deterministic differentiators."""
+        # Get an expectation op, with this differentiator attached.
+        differentiator.refresh()
+        differentiator.stochastic_cost = stochastic_cost
+        op = differentiator.generate_differentiable_op(analytic_op=op)
+        qubit = cirq.GridQubit(0, 0)
+        circuit = util.convert_to_tensor(
+            [cirq.Circuit(cirq.X(qubit)**sympy.Symbol('alpha'))])
+        psums = util.convert_to_tensor([[cirq.Z(qubit)]])
+        symbol_values_array = np.array([[0.123]], dtype=np.float32)
+        # Calculate tfq gradient.
+        symbol_values_tensor = tf.convert_to_tensor(symbol_values_array)
+        with tf.GradientTape() as g:
+            g.watch(symbol_values_tensor)
+            expectations = op(circuit, ['alpha'], symbol_values_tensor, psums)
+        grads = g.gradient(expectations, symbol_values_tensor)
+        ground_truth_grads = np.array([[-1.1839752]])
+        self.assertAllClose(ground_truth_grads, grads, rtol=1e-2, atol=1e-2)
+
+
+class StochasticDifferentiatorCorrectnessTest(tf.test.TestCase,
+                                              parameterized.TestCase):
+    """Test correctness of the stochastic differentiators to reference cirq
+    algorithm.
+    DISCLAIMER: this test allows for a larger margin of error and as long
+    as convergence is happening then it passes"""
+
+    # TODO(zaqqwerty): only this test was failing after adding cirq.I
+    #    support, so it is disabled pending diagnosis
+    @parameterized.parameters(
+        list(
+            util.kwargs_cartesian_product(
+                **{
+                    'differentiator': STOCHASTIC_DIFFS,
+                    'op': OPS,
+                    'n_qubits': [5],
+                    'n_programs': [3],
+                    'n_ops': [3],
+                    'symbol_names': [['a', 'b']],
+                    'stochastic_cost_eps': [(False, 5e-1), (True, 7e-1)],
+                })))
+    def gradients_vs_cirq_finite_difference(self, differentiator, op, n_qubits,
+                                            n_programs, n_ops, symbol_names,
+                                            stochastic_cost_eps):
+        """Compare TFQ differentiators to fine-grained noiseless cirq finite
+        differencing with a larger margin of error."""
+
+        # TODO (jaeyoo): cleanup this hacky wordkaround so variable
+        #   assignment doesn't need to take place like this.
+        differentiator.stochastic_cost, eps = stochastic_cost_eps
+        differentiator.refresh()
+        op = differentiator.generate_differentiable_op(analytic_op=op)
+
+        qubits = cirq.GridQubit.rect(1, n_qubits)
+        circuit_batch, resolver_batch = \
+            util.random_symbol_circuit_resolver_batch(
+                cirq.GridQubit.rect(1, n_qubits), symbol_names, n_programs)
+
+        psums = [
+            util.random_pauli_sums(qubits, 1, n_ops) for _ in circuit_batch
+        ]
+
+        symbol_values_array = np.array(
+            [[resolver[symbol]
+              for symbol in symbol_names]
+             for resolver in resolver_batch],
+            dtype=np.float32)
+
+        # calculate tfq gradient
+        symbol_values_tensor = tf.convert_to_tensor(symbol_values_array)
+        programs = util.convert_to_tensor(circuit_batch)
+        ops = util.convert_to_tensor(psums)
+
+        # calculate gradients in cirq using a very simple forward differencing
+        # scheme
+        cirq_grads = _cirq_simple_finite_difference(circuit_batch,
+                                                    resolver_batch,
+                                                    symbol_names, psums)
+
+        def _get_gradient():
+            with tf.GradientTape() as g:
+                g.watch(symbol_values_tensor)
+                expectations = op(programs, symbol_names, symbol_values_tensor,
+                                  ops)
+            return g.gradient(expectations, symbol_values_tensor)
+
+        def _abs_diff(grad, mask):
+            return np.sum(np.abs(grad - cirq_grads * mask))
+
+        def _get_nonzero_mask(grad):
+            return (grad.numpy() != 0.0).astype(np.float32)
+
+        # Get the non-zero mask because a few initial gradients have not sampled
+        # zero values.
+        tfq_grads_1 = _get_gradient()
+        mask_1 = _get_nonzero_mask(tfq_grads_1)
+
+        if not np.allclose(tfq_grads_1, cirq_grads * mask_1, atol=eps):
+            tfq_grads_2 = 0.5 * (tfq_grads_1 + _get_gradient())
+            mask_2 = _get_nonzero_mask(tfq_grads_2)
+            # Check if the 2nd error becomes smaller that 1st one.
+            if not _abs_diff(tfq_grads_1, mask_1) > _abs_diff(
+                    tfq_grads_2, mask_2):
+                cnt = 2
+                tfq_grads = (cnt * tfq_grads_2 + _get_gradient()) / (cnt + 1)
+                while (cnt < 10 and
+                       not np.allclose(cirq_grads, tfq_grads, atol=eps)):
+                    cnt += 1
+                    tfq_grads = (cnt * tfq_grads + _get_gradient()) / (cnt + 1)
+                self.assertAllClose(cirq_grads, tfq_grads, atol=eps)
+
+
+if __name__ == '__main__':
+    tf.test.main()

--- a/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
+++ b/tensorflow_quantum/python/differentiators/sampling_op_parameter_shift_test.py
@@ -25,7 +25,6 @@ from tensorflow_quantum.python import util
 from tensorflow_quantum.python.differentiators import \
     sampling_op_parameter_shift
 
-
 SIM_LIST = [
     None,
     cirq.sim.sparse_simulator.Simulator(),


### PR DESCRIPTION
Resolves #299.  Allows the user to pair a function on lists of bitstrings with the TFQ sample op and differentiate across them.