### PR TITLE
Use all cores when batch_size==1.

### DIFF
--- a/tensorflow_quantum/core/ops/tfq_simulate_expectation_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_expectation_op.cc
@@ -107,12 +107,12 @@ class TfqSimulateExpectationOp : public tensorflow::OpKernel {
     // e2s2 = 2 CPU, 8GB -> Can safely do 25 since Memory = 4GB
     // e2s4 = 4 CPU, 16GB -> Can safely do 25 since Memory = 8GB
     // ...
-    if (max_num_qubits < 26) {
-      ComputeSmall(num_qubits, max_num_qubits, fused_circuits, pauli_sums,
-                   context, &output_tensor);
-    } else {
+    if (max_num_qubits >= 26 || programs.size() == 1) {
       ComputeLarge(num_qubits, fused_circuits, pauli_sums, context,
                    &output_tensor);
+    } else {
+      ComputeSmall(num_qubits, max_num_qubits, fused_circuits, pauli_sums,
+                   context, &output_tensor);
     }
 
     // just to be on the safe side.

--- a/tensorflow_quantum/core/ops/tfq_simulate_sampled_expectation_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_sampled_expectation_op.cc
@@ -123,12 +123,12 @@ class TfqSimulateSampledExpectationOp : public tensorflow::OpKernel {
     // e2s2 = 2 CPU, 8GB -> Can safely do 25 since Memory = 4GB
     // e2s4 = 4 CPU, 16GB -> Can safely do 25 since Memory = 8GB
     // ...
-    if (max_num_qubits < 26) {
-      ComputeSmall(num_qubits, max_num_qubits, fused_circuits, pauli_sums,
-                   num_samples, context, &output_tensor);
-    } else {
+    if (max_num_qubits >= 26 || programs.size() == 1) {
       ComputeLarge(num_qubits, fused_circuits, pauli_sums, num_samples, context,
                    &output_tensor);
+    } else {
+      ComputeSmall(num_qubits, max_num_qubits, fused_circuits, pauli_sums,
+                   num_samples, context, &output_tensor);
     }
 
     // just to be on the safe side.

--- a/tensorflow_quantum/core/ops/tfq_simulate_samples_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_samples_op.cc
@@ -107,11 +107,11 @@ class TfqSimulateSamplesOp : public tensorflow::OpKernel {
     // e2s2 = 2 CPU, 8GB -> Can safely do 25 since Memory = 4GB
     // e2s4 = 4 CPU, 16GB -> Can safely do 25 since Memory = 8GB
     // ...
-    if (max_num_qubits < 26) {
-      ComputeSmall(num_qubits, max_num_qubits, num_samples, fused_circuits,
+    if (max_num_qubits >= 26 || programs.size() == 1) {
+      ComputeLarge(num_qubits, max_num_qubits, num_samples, fused_circuits,
                    context, &output_tensor);
     } else {
-      ComputeLarge(num_qubits, max_num_qubits, num_samples, fused_circuits,
+      ComputeSmall(num_qubits, max_num_qubits, num_samples, fused_circuits,
                    context, &output_tensor);
     }
 

--- a/tensorflow_quantum/core/ops/tfq_simulate_state_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_state_op.cc
@@ -102,11 +102,11 @@ class TfqSimulateStateOp : public tensorflow::OpKernel {
     // e2s2 = 2 CPU, 8GB -> Can safely do 25 since Memory = 4GB
     // e2s4 = 4 CPU, 16GB -> Can safely do 25 since Memory = 8GB
     // ...
-    if (max_num_qubits < 26) {
-      ComputeSmall(num_qubits, max_num_qubits, fused_circuits, context,
+    if (max_num_qubits >= 26 || programs.size() == 1) {
+      ComputeLarge(num_qubits, max_num_qubits, fused_circuits, context,
                    &output_tensor);
     } else {
-      ComputeLarge(num_qubits, max_num_qubits, fused_circuits, context,
+      ComputeSmall(num_qubits, max_num_qubits, fused_circuits, context,
                    &output_tensor);
     }
 


### PR DESCRIPTION
Seems like more and more people are using TFQ for single circuit experiments. It makes sense to have us use all cores in that case.