### PR TITLE
Added tf 2.1.0 under extras.

### DIFF
--- a/release/setup.py
+++ b/release/setup.py
@@ -51,6 +51,10 @@ class InstallPlatlib(install):
 
 
 REQUIRED_PACKAGES = ['cirq == 0.8.0', 'sympy == 1.5']
+
+# placed as extra to not have required overwrite existing nightly installs if
+# they exist.
+EXTRA_PACKAGES = ['tensorflow == 2.1.0']
 CUR_VERSION = '0.4.0'
 
 
@@ -83,6 +87,7 @@ setup(
     url='https://github.com/tensorflow/quantum/',
     packages=find_packages(),
     install_requires=REQUIRED_PACKAGES,
+    extras_require={'extras': EXTRA_PACKAGES},
     # Add in any packaged data.
     include_package_data=True,
     #ext_modules=[Extension('_foo', ['stub.cc'])],


### PR DESCRIPTION
Adds the ability to do `python3 -m pip install tensorflow-quantum[extras]` which will also include a known-working version of `tf` version to depend on if the user doesn't have a nightly installed. 