### PR TITLE
Updated nightly to tf 2.3.0 and bazel 3.1.0.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,17 +1,16 @@
 # This file includes external dependencies that are required to compile the
 # TensorFlow op. Maybe of them are specific versions used by the TensorFlow
-# binary used. These are extracted from TF v2.0.0, but are also compatible
-# with v1.14.0.
+# binary used. These are extracted from TF v2.3.0, tensorflow/workspace.bzl.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "com_google_absl",
-    sha256 = "acd93f6baaedc4414ebd08b33bebca7c7a46888916101d8c0b8083573526d070",
-    strip_prefix = "abseil-cpp-43ef2148c0936ebf7cb4be6b19927a9d9d145b8f",
+    sha256 = "f368a8476f4e2e0eccf8a7318b98dafbe30b2600f4e3cf52636e5eb145aba06a",
+    strip_prefix = "abseil-cpp-df3ea785d8c30a9503321a3d35ee7d35808f190d",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/abseil/abseil-cpp/archive/43ef2148c0936ebf7cb4be6b19927a9d9d145b8f.tar.gz",
-        "https://github.com/abseil/abseil-cpp/archive/43ef2148c0936ebf7cb4be6b19927a9d9d145b8f.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
+        "https://github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
     ],
 )
 
@@ -27,11 +26,11 @@ http_archive(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "b9e92f9af8819bbbc514e2902aec860415b70209f31dfc8c4fa72515a5df9d59",
-    strip_prefix = "protobuf-310ba5ee72661c081129eb878c1bbcec936b20f0",
+    sha256 = "cfcba2df10feec52a84208693937c17a4b5df7775e1635c1e3baffc487b24c9b",
+    strip_prefix = "protobuf-3.9.2",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/protocolbuffers/protobuf/archive/310ba5ee72661c081129eb878c1bbcec936b20f0.tar.gz",
-        "https://github.com/protocolbuffers/protobuf/archive/310ba5ee72661c081129eb878c1bbcec936b20f0.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/protocolbuffers/protobuf/archive/v3.9.2.zip",
+        "https://github.com/protocolbuffers/protobuf/archive/v3.9.2.zip",
     ],
 )
 
@@ -41,14 +40,17 @@ http_archive(
     build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
     sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
     strip_prefix = "zlib-1.2.11",
-    urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],
+    urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/zlib.net/zlib-1.2.11.tar.gz",
+        "https://zlib.net/zlib-1.2.11.tar.gz",
+    ],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-# com_google_protobuf depends on @bazel_skylib
+# com_google_protobuf depends on @bazel_skylib ??
 http_archive(
     name = "bazel_skylib",
     sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
@@ -83,10 +85,10 @@ http_archive(
 
 http_archive(
     name = "org_tensorflow",
-    sha256 = "e82f3b94d863e223881678406faa5071b895e1ff928ba18578d2adbbc6b42a4c",
-    strip_prefix = "tensorflow-2.1.0",
+    sha256 = "fd3e6580cfe2035aa80d569b76bba5f33119362907f3d77039b6bedf76172712",
+    strip_prefix = "tensorflow-2.2.0",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/v2.1.0.zip",
+        "https://github.com/tensorflow/tensorflow/archive/v2.2.0.zip",
     ],
 )
 

--- a/configure.sh
+++ b/configure.sh
@@ -124,6 +124,7 @@ fi
 
 write_to_bazelrc "build --spawn_strategy=standalone"
 write_to_bazelrc "build --strategy=Genrule=standalone"
+write_to_bazelrc "build --experimental_repo_remote_exec"
 write_to_bazelrc "build -c opt"
 
 

--- a/release/build_all_wheels.sh
+++ b/release/build_all_wheels.sh
@@ -24,7 +24,7 @@ cd ..
 
 # Upgrade existing 3.6 pip.
 python3 -m pip install --upgrade pip
-python3 -m pip install tensorflow==2.1.0
+python3 -m pip install tensorflow==2.3.0
 
 cp -r custom-op/third_party/toolchains quantum/third_party/
 cd /quantum
@@ -51,7 +51,7 @@ sudo make altinstall
 cd /quantum
 
 python3.7 -m pip install --upgrade pip setuptools
-python3.7 -m pip install tensorflow==2.1.0
+python3.7 -m pip install tensorflow==2.3.0
 sed -i 's/python3/python3.7/g' configure.sh
 sed -i 's/python3/python3.7/g' release/build_pip_package.sh
 

--- a/release/setup.py
+++ b/release/setup.py
@@ -54,7 +54,7 @@ REQUIRED_PACKAGES = ['cirq == 0.8.0', 'sympy == 1.5']
 
 # placed as extra to not have required overwrite existing nightly installs if
 # they exist.
-EXTRA_PACKAGES = ['tensorflow == 2.1.0']
+EXTRA_PACKAGES = ['tensorflow == 2.3.0']
 CUR_VERSION = '0.4.0'
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ nbconvert==5.6.1
 nbformat==4.4.0
 pylint==2.4.4
 yapf==0.28.0
-tensorflow==2.1.0
+tensorflow==2.3.0
 google-api-python-client==1.8.0

--- a/scripts/build_pip_package_test.sh
+++ b/scripts/build_pip_package_test.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-pip install tensorflow==2.1.0 cirq==0.7.0
+pip install tensorflow==2.3.0 cirq==0.7.0
 
 # cd tensorflow_quantum
 echo "Y\n" | ./configure.sh

--- a/scripts/build_pip_package_test.sh
+++ b/scripts/build_pip_package_test.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-pip install tensorflow==2.3.0 cirq==0.7.0
+pip install tensorflow==2.3.0 cirq==0.8.0
 
 # cd tensorflow_quantum
 echo "Y\n" | ./configure.sh

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-wget https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel_0.26.0-linux-x86_64.deb
-sudo dpkg -i bazel_0.26.0-linux-x86_64.deb
+wget https://github.com/bazelbuild/bazel/releases/download/3.1.0/bazel_3.1.0-linux-x86_64.deb
+sudo dpkg -i bazel_3.1.0-linux-x86_64.deb
 pip install --upgrade pip setuptools wheel
 pip install -r requirements.txt

--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 echo "Testing All Bazel py_test and cc_tests.";
-test_outputs=$(bazel test -c opt --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" --cxxopt="-msse2" --cxxopt="-msse3" --cxxopt="-msse4" --notest_keep_going --test_output=errors $(bazel query //tensorflow_quantum/...))
+test_outputs=$(bazel test -c opt --experimental_repo_remote_exec --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" --cxxopt="-msse2" --cxxopt="-msse3" --cxxopt="-msse4" --notest_keep_going --test_output=errors //tensorflow_quantum/...)
 exit_code=$?
 if [ "$exit_code" == "0" ]; then
 	echo "Testing Complete!";

--- a/tensorflow_quantum/python/differentiators/gradient_test.py
+++ b/tensorflow_quantum/python/differentiators/gradient_test.py
@@ -135,7 +135,9 @@ class GradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
         with tf.GradientTape() as g:
             g.watch(base_rot_angles)
             input_angles = 2 * base_rot_angles
-            exp_res = tf.exp(op(circuits, ['rx'], input_angles, pstring))
+            exp_res = tf.exp(
+                op(circuits, tf.convert_to_tensor(['rx']), input_angles,
+                   pstring))
 
         grad = g.gradient(exp_res, base_rot_angles)
         exact = [[exact_grad(0.25)], [exact_grad(0.125)]]
@@ -190,7 +192,8 @@ class GradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
         ops = util.convert_to_tensor(psums)
         with tf.GradientTape() as g:
             g.watch(symbol_values_tensor)
-            expectations = op(programs, symbol_names, symbol_values_tensor, ops)
+            expectations = op(programs, tf.convert_to_tensor(symbol_names),
+                              symbol_values_tensor, ops)
         tfq_grads = g.gradient(expectations, symbol_values_tensor)
 
         # calculate gradients in cirq using a very simple forward differencing
@@ -229,7 +232,8 @@ class GradientCorrectnessTest(tf.test.TestCase, parameterized.TestCase):
         symbol_values_tensor = tf.convert_to_tensor(symbol_values_array)
         with tf.GradientTape() as g:
             g.watch(symbol_values_tensor)
-            expectations = op(circuit, ['alpha'], symbol_values_tensor, psums)
+            expectations = op(circuit, tf.convert_to_tensor(['alpha']),
+                              symbol_values_tensor, psums)
         grads = g.gradient(expectations, symbol_values_tensor)
         ground_truth_grads = np.array([[-1.1839752]])
         self.assertAllClose(ground_truth_grads, grads, rtol=1e-2, atol=1e-2)
@@ -297,8 +301,8 @@ class StochasticDifferentiatorCorrectnessTest(tf.test.TestCase,
         def _get_gradient():
             with tf.GradientTape() as g:
                 g.watch(symbol_values_tensor)
-                expectations = op(programs, symbol_names, symbol_values_tensor,
-                                  ops)
+                expectations = op(programs, tf.convert_to_tesor(symbol_names),
+                                  symbol_values_tensor, ops)
             return g.gradient(expectations, symbol_values_tensor)
 
         def _abs_diff(grad, mask):


### PR DESCRIPTION
When a new relaease is cut, we will need to upgrade the version in all of the tutorials and docs too. Just want to confirm with @yashk2810 that we won't upgrade anything in the `docs/` folder (including tutorials) until we cut a new pip release, then we will upgrade all the 2.1.0 -> 2.3.0 in there.