### PR TITLE
Remove eigen library

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -113,8 +113,7 @@ cc_library(
     sha256 = "7e7a57e33c59280a17a66e521396cd8b1a55d0676c9f807078522fda52114b5c",
     strip_prefix = "eigen-eigen-8071cda5714d",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/bitbucket.org/eigen/eigen/get/8071cda5714d.tar.gz",
-        "https://bitbucket.org/eigen/eigen/get/8071cda5714d.tar.gz",
+        "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,23 +101,6 @@ load("//third_party/tf:tf_configure.bzl", "tf_configure")
 tf_configure(name = "local_config_tf")
 
 http_archive(
-    name = "eigen",
-    # TODO(pmassey): Probably move this content in a third_party/eigen.BUILD file
-    build_file_content = """
-cc_library(
-  name = "eigen3",
-  textual_hdrs = glob(["Eigen/**", "unsupported/**"]),
-  visibility = ["//visibility:public"],
-)
-    """,
-    sha256 = "7e7a57e33c59280a17a66e521396cd8b1a55d0676c9f807078522fda52114b5c",
-    strip_prefix = "eigen-eigen-8071cda5714d",
-    urls = [
-        "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz",
-    ],
-)
-
-http_archive(
     name = "six_archive",
     build_file = "@com_google_protobuf//:six.BUILD",
     sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,6 +101,23 @@ load("//third_party/tf:tf_configure.bzl", "tf_configure")
 tf_configure(name = "local_config_tf")
 
 http_archive(
+    name = "eigen",
+    # TODO(pmassey): Probably move this content in a third_party/eigen.BUILD file
+    build_file_content = """
+cc_library(
+  name = "eigen3",
+  textual_hdrs = glob(["Eigen/**", "unsupported/**"]),
+  visibility = ["//visibility:public"],
+)
+    """,
+    sha256 = "7e7a57e33c59280a17a66e521396cd8b1a55d0676c9f807078522fda52114b5c",
+    strip_prefix = "eigen-eigen-8071cda5714d",
+    urls = [
+        "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz",
+    ],
+)
+
+http_archive(
     name = "six_archive",
     build_file = "@com_google_protobuf//:six.BUILD",
     sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",

--- a/tensorflow_quantum/core/qsim/BUILD
+++ b/tensorflow_quantum/core/qsim/BUILD
@@ -174,7 +174,6 @@ cc_test(
         ":unitary_space",
         "//tensorflow_quantum/core/src:circuit",
         "@com_google_googletest//:gtest_main",
-        "@eigen//:eigen3",
     ]
 )
 

--- a/tensorflow_quantum/core/qsim/BUILD
+++ b/tensorflow_quantum/core/qsim/BUILD
@@ -174,6 +174,7 @@ cc_test(
         ":unitary_space",
         "//tensorflow_quantum/core/src:circuit",
         "@com_google_googletest//:gtest_main",
+        "@eigen//:eigen3",
     ]
 )
 


### PR DESCRIPTION
The old bitbucket source of eigen seems to have disappeared; since the only place it was used is in the old custom qsim folder, simply removed it from WORKSPACE.  Resolves #350 