### PR TITLE
Adjoint differentiatior part 1/n.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,9 +67,9 @@ http_archive(
 
 http_archive(
     name = "qsim",
-    sha256 = "60bb22766decd63c800e99ce1cd8eff2c9bede4f922ae967fbb67d7af1000096",
-    strip_prefix = "qsim-0.3.0",
-    urls = ["https://github.com/quantumlib/qsim/archive/v0.3.0.zip"],
+    sha256 = "7e5fe6c909d0007488f910d57ed765729133437f5c5f88085fa6deb544cb97dc",
+    strip_prefix = "qsim-0.3.1",
+    urls = ["https://github.com/quantumlib/qsim/archive/v0.3.1.zip"],
 )
 
 # Added for crosstool in tensorflow.

--- a/tensorflow_quantum/core/src/util_qsim.h
+++ b/tensorflow_quantum/core/src/util_qsim.h
@@ -24,7 +24,7 @@ limitations under the License.
 #include "../qsim/lib/fuser.h"
 #include "../qsim/lib/gate_appl.h"
 #include "../qsim/lib/gates_cirq.h"
-#include "absl/container/flat_hash_map.h"
+#include "../qsim/lib/matrix.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/threadpool.h"
@@ -33,7 +33,6 @@ limitations under the License.
 
 namespace tfq {
 
-typedef absl::flat_hash_map<std::string, std::pair<int, float>> SymbolMap;
 typedef qsim::Cirq::GateCirq<float> QsimGate;
 typedef qsim::Circuit<QsimGate> QsimCircuit;
 
@@ -254,6 +253,98 @@ tensorflow::Status ComputeSampledExpectationQsim(
                           term.coefficient_real() /
                           static_cast<float>(num_samples);
   }
+  return status;
+}
+
+template <typename Gate, typename Simulator, typename State>
+inline void ApplyGateDagger(const Simulator& simulator, const Gate& gate,
+                            State& state) {
+  typename Simulator::fp_type matrix[32];
+
+  if (gate.num_qubits == 1 && gate.matrix.size() == 8) {
+    std::copy(gate.matrix.begin(), gate.matrix.begin() + 8, matrix);
+    qsim::Matrix2Dagger(matrix);
+    simulator.ApplyGate1(gate.qubits[0], matrix, state);
+  } else if (gate.num_qubits == 2 && gate.matrix.size() == 32) {
+    std::copy(gate.matrix.begin(), gate.matrix.begin() + 32, matrix);
+    qsim::Matrix4Dagger(matrix);
+    // Here we should have gate.qubits[0] < gate.qubits[1].
+    simulator.ApplyGate2(gate.qubits[0], gate.qubits[1], matrix, state);
+  }
+}
+
+// Fuse gates. Dagger. Then apply. Slight modification from qsim.
+template <typename Gate, typename Simulator, typename State>
+inline void ApplyFusedGateDagger(const Simulator& simulator, const Gate& gate,
+                                 State& state) {
+  typename Simulator::fp_type matrix[32];
+
+  if (gate.num_qubits == 1 && gate.pmaster->matrix.size() == 8) {
+    qsim::CalcMatrix2(gate.gates, matrix);
+    qsim::Matrix2Dagger(matrix);
+    simulator.ApplyGate1(gate.qubits[0], matrix, state);
+  } else if (gate.num_qubits == 2 && gate.pmaster->matrix.size() == 32) {
+    // Here we should have gate.qubits[0] < gate.qubits[1].
+    qsim::CalcMatrix4(gate.qubits[0], gate.qubits[1], gate.gates, matrix);
+    qsim::Matrix4Dagger(matrix);
+    simulator.ApplyGate2(gate.qubits[0], gate.qubits[1], matrix, state);
+  }
+}
+
+// Assumes p_sums.size() == op_coeffs.size()
+// state stores |psi>. scratch has been created, but does not
+// require initialization.
+template <typename SimT, typename StateSpaceT, typename StateT>
+tensorflow::Status AccumulateOperators(
+    const std::vector<tfq::proto::PauliSum>& p_sums,
+    const std::vector<float>& op_coeffs, const SimT& sim, const StateSpaceT& ss,
+    StateT& state, StateT& scratch) {
+  // apply the  gates of the pauliterms to a copy of the wavefunction
+  // accumulating results as we go. Effectively doing O|psi> for an arbitrary
+  // O. Result is stored on scratch.
+  tensorflow::Status status = tensorflow::Status::OK();
+  ss.SetAllZeros(scratch);
+
+  for (int i = 0; i < p_sums.size(); i++) {
+    for (const tfq::proto::PauliTerm& term : p_sums[i].terms()) {
+      const float leading_coeff = op_coeffs[i] * term.coefficient_real();
+      if (std::fabs(leading_coeff) < 1e-5) {
+        // skip really small terms that will just induce more rounding
+        // errors.
+        continue;
+      }
+      if (term.paulis_size() == 0) {
+        // identity term. Scalar multiply, add, then revert.
+        ss.Multiply(leading_coeff, state);
+        ss.AddState(state, scratch);
+        ss.Multiply(1. / leading_coeff, state);
+        continue;
+      }
+
+      QsimCircuit main_circuit;
+      std::vector<qsim::GateFused<QsimGate>> fused_circuit;
+
+      status = QsimCircuitFromPauliTerm(term, ss.num_qubits_, &main_circuit,
+                                        &fused_circuit);
+      if (!status.ok()) {
+        return status;
+      }
+
+      // Apply scaled gates, accumulate, undo.
+      for (int j = 0; j < fused_circuit.size(); j++) {
+        qsim::ApplyFusedGate(sim, fused_circuit[j], state);
+      }
+
+      ss.Multiply(leading_coeff, state);
+      ss.AddState(state, scratch);
+      ss.Multiply(1. / leading_coeff, state);
+      for (int j = fused_circuit.size() - 1; j >= 0; j--) {
+        ApplyFusedGateDagger(sim, fused_circuit[j], state);
+      }
+      // state should now be reverted back to original state.
+    }
+  }
+
   return status;
 }
 

--- a/tensorflow_quantum/core/src/util_qsim_test.cc
+++ b/tensorflow_quantum/core/src/util_qsim_test.cc
@@ -333,5 +333,194 @@ TEST(UtilQsimTest, CompoundCase) {
   EXPECT_NEAR(exp_v, 4.1234, 1e-5);
 }
 
+TEST(UtilQsimTest, ApplyGateDagger) {
+  // Create circuit to prepare initial state.
+  QsimCircuit simple_circuit;
+  simple_circuit.num_qubits = 2;
+  simple_circuit.gates.push_back(
+      qsim::Cirq::XPowGate<float>::Create(0, 1, 0.25, 0.0));
+  simple_circuit.gates.push_back(
+      qsim::Cirq::CXPowGate<float>::Create(1, 1, 0, 1.0, 0.0));
+  simple_circuit.gates.push_back(
+      qsim::Cirq::YPowGate<float>::Create(2, 0, 0.5, 0.0));
+  // Instantiate qsim objects.
+  qsim::Simulator<qsim::SequentialFor> sim(2, 1);
+  qsim::Simulator<qsim::SequentialFor>::StateSpace ss(2, 1);
+  auto sv = ss.CreateState();
+  ss.SetStateZero(sv);
+  auto scratch = ss.CreateState();
+
+  // Prepare initial state.
+  ss.SetStateZero(sv);
+  for (int i = 0; i < simple_circuit.gates.size(); i++) {
+    qsim::ApplyGate(sim, simple_circuit.gates[i], sv);
+  }
+  for (int i = simple_circuit.gates.size() - 1; i >= 0; i--) {
+    ApplyGateDagger(sim, simple_circuit.gates[i], sv);
+  }
+
+  // Test that we reverted back to zero.
+  EXPECT_NEAR(ss.GetAmpl(sv, 0).real(), 1.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 0).imag(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 1).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 1).imag(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 2).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 2).imag(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 3).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 3).imag(), 0.0, 1e-5);
+}
+
+TEST(UtilQsimTest, ApplyFusedGateDagger) {
+  // Create circuit to prepare initial state.
+  QsimCircuit simple_circuit;
+  simple_circuit.num_qubits = 2;
+  simple_circuit.gates.push_back(
+      qsim::Cirq::XPowGate<float>::Create(0, 1, 0.25, 0.0));
+  simple_circuit.gates.push_back(
+      qsim::Cirq::CXPowGate<float>::Create(1, 1, 0, 1.0, 0.0));
+  simple_circuit.gates.push_back(
+      qsim::Cirq::YPowGate<float>::Create(2, 0, 0.5, 0.0));
+  // Instantiate qsim objects.
+  qsim::Simulator<qsim::SequentialFor> sim(2, 1);
+  qsim::Simulator<qsim::SequentialFor>::StateSpace ss(2, 1);
+  auto sv = ss.CreateState();
+  ss.SetStateZero(sv);
+  auto scratch = ss.CreateState();
+
+  // Prepare initial state.
+  ss.SetStateZero(sv);
+  auto fused_circuit = qsim::BasicGateFuser<qsim::IO, QsimGate>().FuseGates(
+      simple_circuit.num_qubits, simple_circuit.gates);
+
+  // Prepare initial state.
+  ss.SetStateZero(sv);
+  for (int j = 0; j < fused_circuit.size(); j++) {
+    qsim::ApplyFusedGate(sim, fused_circuit[j], sv);
+  }
+  for (int i = fused_circuit.size() - 1; i >= 0; i--) {
+    ApplyFusedGateDagger(sim, fused_circuit[i], sv);
+  }
+
+  // Test that we reverted back to zero.
+  EXPECT_NEAR(ss.GetAmpl(sv, 0).real(), 1.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 0).imag(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 1).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 1).imag(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 2).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 2).imag(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 3).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 3).imag(), 0.0, 1e-5);
+}
+
+TEST(UtilQsimTest, AccumulateOperatorsBasic) {
+  // Create circuit to prepare initial state.
+  QsimCircuit simple_circuit;
+  simple_circuit.num_qubits = 2;
+  simple_circuit.gates.push_back(
+      qsim::Cirq::XPowGate<float>::Create(0, 1, 0.25, 0.0));
+  simple_circuit.gates.push_back(
+      qsim::Cirq::CXPowGate<float>::Create(1, 1, 0, 1.0, 0.0));
+  simple_circuit.gates.push_back(
+      qsim::Cirq::YPowGate<float>::Create(2, 0, 0.5, 0.0));
+
+  auto fused_circuit = qsim::BasicGateFuser<qsim::IO, QsimGate>().FuseGates(
+      simple_circuit.num_qubits, simple_circuit.gates);
+
+  // Instantiate qsim objects.
+  qsim::Simulator<qsim::SequentialFor> sim(2, 1);
+  qsim::Simulator<qsim::SequentialFor>::StateSpace ss(2, 1);
+  auto sv = ss.CreateState();
+  ss.SetStateZero(sv);
+  auto scratch = ss.CreateState();
+
+  // Prepare initial state.
+  ss.SetStateZero(sv);
+  for (int j = 0; j < fused_circuit.size(); j++) {
+    qsim::ApplyFusedGate(sim, fused_circuit[j], sv);
+  }
+
+  PauliSum p_sum;
+
+  // Initialize pauli sum.
+  // 0.1234 ZX
+  PauliTerm* p_term_scratch = p_sum.add_terms();
+  p_term_scratch->set_coefficient_real(0.1234);
+  PauliQubitPair* pair_proto = p_term_scratch->add_paulis();
+  pair_proto->set_qubit_id(std::to_string(0));
+  pair_proto->set_pauli_type("Z");
+  pair_proto = p_term_scratch->add_paulis();
+  pair_proto->set_qubit_id(std::to_string(1));
+  pair_proto->set_pauli_type("X");
+
+  // -3.0 X
+  p_term_scratch = p_sum.add_terms();
+  p_term_scratch->set_coefficient_real(-3.0);
+  pair_proto = p_term_scratch->add_paulis();
+  pair_proto->set_qubit_id(std::to_string(0));
+  pair_proto->set_pauli_type("X");
+
+  // 4.0 I
+  p_term_scratch = p_sum.add_terms();
+  p_term_scratch->set_coefficient_real(4.0);
+
+  // A second sum.
+  PauliSum p_sum2;
+  PauliTerm* p_term_scratch2 = p_sum2.add_terms();
+  p_term_scratch2->set_coefficient_real(-5.0);
+
+  AccumulateOperators({p_sum, p_sum2}, {0.5, 0.25}, sim, ss, sv, scratch);
+
+  // Check that scratch got accumulated onto.
+  EXPECT_NEAR(ss.GetAmpl(scratch, 0).real(), 0.577925, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 0).imag(), 0.334574, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 1).real(), -0.172075, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 1).imag(), 0.645234, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 2).real(), -0.577925, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 2).imag(), -0.821275, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 3).real(), -0.172075, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 3).imag(), -0.989384, 1e-5);
+
+  // Check that sv remains (up to rounding) unchanged.
+  EXPECT_NEAR(ss.GetAmpl(sv, 0).real(), 0.25, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 0).imag(), 0.60355, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 1).real(), 0.25, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 1).imag(), 0.60355, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 2).real(), -0.25, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 2).imag(), 0.10355, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 3).real(), 0.25, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 3).imag(), -0.10355, 1e-5);
+}
+
+TEST(UtilQsimTest, AccumulateOperatorsEmpty) {
+  // Instantiate qsim objects.
+  qsim::Simulator<qsim::SequentialFor> sim(2, 1);
+  qsim::Simulator<qsim::SequentialFor>::StateSpace ss(2, 1);
+  auto sv = ss.CreateState();
+  ss.SetStateZero(sv);
+  auto scratch = ss.CreateState();
+
+  AccumulateOperators({}, {}, sim, ss, sv, scratch);
+
+  // Check sv is still in zero state.
+  EXPECT_NEAR(ss.GetAmpl(sv, 0).real(), 1.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 0).imag(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 1).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 1).imag(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 2).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 2).imag(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 3).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(sv, 3).imag(), 0.0, 1e-5);
+
+  // Check scratch is still in zero state.
+  EXPECT_NEAR(ss.GetAmpl(scratch, 0).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 0).imag(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 1).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 1).imag(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 2).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 2).imag(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 3).real(), 0.0, 1e-5);
+  EXPECT_NEAR(ss.GetAmpl(scratch, 3).imag(), 0.0, 1e-5);
+}
+
 }  // namespace
 }  // namespace tfq


### PR DESCRIPTION
Adds basic qsim utilities needed by adjoint differentiation. In this PR I've added:

1. `ApplyGateDagger` like `ApplyGate` in qsim, but daggers the gate before paplying.
2. `ApplyFusedGateDagger` same as above.
3. `AccumulateOperators`. Applies a large operator matrix multiplication in place to a state. Takes you from `|psi> -> O|psi>` for any O