### PR TITLE
Adjoint 4/n: Added basic functioning op.

### DIFF
--- a/tensorflow_quantum/core/ops/BUILD
+++ b/tensorflow_quantum/core/ops/BUILD
@@ -350,8 +350,8 @@ py_library(
     srcs = ["tfq_unitary_op.py"],
     data = [":_tfq_calculate_unitary_op.so"],
     deps = [
-        ":tfq_utility_ops_py",
         ":load_module",
+        ":tfq_utility_ops_py",
     ],
 )
 

--- a/tensorflow_quantum/core/ops/BUILD
+++ b/tensorflow_quantum/core/ops/BUILD
@@ -11,6 +11,61 @@ config_setting(
 )
 
 cc_binary(
+    name = "_tfq_adj_grad.so",
+    srcs = [
+        "tfq_adj_grad_op.cc",
+    ],
+    copts = select({
+        ":windows": [
+            "/D__CLANG_SUPPORT_DYN_ANNOTATION__",
+            "/D_USE_MATH_DEFINES",
+            "/DEIGEN_MPL2_ONLY",
+            "/DEIGEN_MAX_ALIGN_BYTES=64",
+            "/DEIGEN_HAS_TYPE_TRAITS=0",
+            "/DTF_USE_SNAPPY",
+            "/showIncludes",
+            "/MD",
+            "/O2",
+            "/DNDEBUG",
+            "/w",
+            "-DWIN32_LEAN_AND_MEAN",
+            "-DNOGDI",
+            "/d2ReducedOptimizeHugeFunctions",
+            "/arch:AVX",
+            "/std:c++14",
+            "-DTENSORFLOW_MONOLITHIC_BUILD",
+            "/DPLATFORM_WINDOWS",
+            "/DEIGEN_HAS_C99_MATH",
+            "/DTENSORFLOW_USE_EIGEN_THREADPOOL",
+            "/DEIGEN_AVOID_STL_ARRAY",
+            "/Iexternal/gemmlowp",
+            "/wd4018",
+            "/wd4577",
+            "/DNOGDI",
+            "/UTF_COMPILE_LIBRARY",
+        ],
+        "//conditions:default": [
+            "-pthread",
+            "-std=c++11",
+            "-D_GLIBCXX_USE_CXX11_ABI=0",
+        ],
+    }),
+    features = select({
+        ":windows": ["windows_export_all_symbols"],
+        "//conditions:default": [],
+    }),
+    linkshared = 1,
+    deps = [
+        ":parse_context",
+        ":tfq_simulate_utils",
+        "//tensorflow_quantum/core/src:util_qsim",
+        "//tensorflow_quantum/core/src:circuit_parser_qsim",
+        "//tensorflow_quantum/core/src:adj_util",
+        "@qsim//lib:qsim_lib",
+    ],
+)
+
+cc_binary(
     name = "_tfq_ps_utils.so",
     srcs = [
         "tfq_ps_decompose_op.cc",
@@ -282,13 +337,32 @@ cc_library(
 )
 
 py_library(
+    name = "tfq_adj_grad_op_py",
+    srcs = ["tfq_adj_grad_op.py"],
+    data = [":_tfq_adj_grad.so"],
+    deps = [
+        ":load_module",
+    ]
+)
+
+py_library(
     name = "tfq_unitary_op_py",
     srcs = ["tfq_unitary_op.py"],
     data = [":_tfq_calculate_unitary_op.so"],
     deps = [
-        ":load_module",
         ":tfq_utility_ops_py",
+        ":load_module",
     ],
+)
+
+py_test(
+    name = "tfq_adj_grad_op_test",
+    srcs = ["tfq_adj_grad_op_test.py"],
+    python_version = "PY3",
+    deps = [
+        ":tfq_adj_grad_op_py",
+        "//tensorflow_quantum/python:util",
+    ]
 )
 
 py_test(
@@ -324,7 +398,7 @@ py_library(
     name = "circuit_execution_ops",
     srcs = ["circuit_execution_ops.py"],
     deps = [
-        "tfq_utility_ops_py",
+        ":tfq_utility_ops_py",
         ":cirq_ops",
         ":tfq_simulate_ops_py",
         "//tensorflow_quantum/python:quantum_context",

--- a/tensorflow_quantum/core/ops/parse_context.h
+++ b/tensorflow_quantum/core/ops/parse_context.h
@@ -81,6 +81,11 @@ tensorflow::Status GetNumSamples(
 tensorflow::Status GetIndividualSample(tensorflow::OpKernelContext* context,
                                        int* n_samples);
 
+// Parses the downstream gradients tensor. Used by adjoint op.
+tensorflow::Status GetPrevGrads(
+    tensorflow::OpKernelContext* context,
+    std::vector<std::vector<float>>* parsed_prev_grads);
+
 }  // namespace tfq
 
 #endif  // TFQ_CORE_OPS_PARSE_CONTEXT

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op.cc
@@ -1,0 +1,403 @@
+/* Copyright 2020 The TensorFlow Quantum Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <memory>
+#include <vector>
+
+#include "../qsim/lib/circuit.h"
+#include "../qsim/lib/gate_appl.h"
+#include "../qsim/lib/gates_cirq.h"
+#include "../qsim/lib/seqfor.h"
+#include "../qsim/lib/simmux.h"
+#include "cirq/google/api/v2/program.pb.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/lib/core/error_codes.pb.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/lib/core/threadpool.h"
+#include "tensorflow_quantum/core/ops/parse_context.h"
+#include "tensorflow_quantum/core/proto/pauli_sum.pb.h"
+#include "tensorflow_quantum/core/src/adj_util.h"
+#include "tensorflow_quantum/core/src/util_qsim.h"
+
+namespace tfq {
+
+using ::cirq::google::api::v2::Program;
+using ::tensorflow::Status;
+using ::tfq::proto::PauliSum;
+
+typedef qsim::Cirq::GateCirq<float> QsimGate;
+typedef qsim::Circuit<QsimGate> QsimCircuit;
+
+class TfqAdjointGradientOp : public tensorflow::OpKernel {
+ public:
+  explicit TfqAdjointGradientOp(tensorflow::OpKernelConstruction* context)
+      : OpKernel(context) {}
+
+  void Compute(tensorflow::OpKernelContext* context) override {
+    // TODO (mbbrough): add more dimension checks for other inputs here.
+    const int num_inputs = context->num_inputs();
+    OP_REQUIRES(context, num_inputs == 5,
+                tensorflow::errors::InvalidArgument(absl::StrCat(
+                    "Expected 5 inputs, got ", num_inputs, " inputs.")));
+
+    // Create the output Tensor.
+    const int output_dim_batch_size = context->input(0).dim_size(0);
+    const int output_dim_op_size = context->input(2).dim_size(1);
+    tensorflow::TensorShape output_shape;
+    output_shape.AddDim(output_dim_batch_size);
+    output_shape.AddDim(output_dim_op_size);
+
+    tensorflow::Tensor* output = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));
+    auto output_tensor = output->matrix<float>();
+
+    // Parse program protos.
+    std::vector<Program> programs;
+    std::vector<int> num_qubits;
+    std::vector<std::vector<PauliSum>> pauli_sums;
+    OP_REQUIRES_OK(context, GetProgramsAndNumQubits(context, &programs,
+                                                    &num_qubits, &pauli_sums));
+
+    std::vector<SymbolMap> maps;
+    OP_REQUIRES_OK(context, GetSymbolMaps(context, &maps));
+
+    OP_REQUIRES(context, pauli_sums.size() == programs.size(),
+                tensorflow::errors::InvalidArgument(absl::StrCat(
+                    "Number of circuits and PauliSums do not match. Got ",
+                    programs.size(), " circuits and ", pauli_sums.size(),
+                    " paulisums.")));
+
+    // Construct qsim circuits.
+    std::vector<QsimCircuit> qsim_circuits(programs.size(), QsimCircuit());
+    std::vector<std::vector<qsim::GateFused<QsimGate>>> unused_fuse(
+        programs.size(), std::vector<qsim::GateFused<QsimGate>>({}));
+    std::vector<std::vector<std::vector<qsim::GateFused<QsimGate>>>>
+        partial_fused_circuits(
+            programs.size(),
+            std::vector<std::vector<qsim::GateFused<QsimGate>>>({}));
+
+    // track metadata.
+    std::vector<std::vector<tfq::GateMetaData>> gate_meta(
+        programs.size(), std::vector<tfq::GateMetaData>({}));
+
+    // track gradients
+    std::vector<std::vector<GradientOfGate>> gradient_gates(
+        programs.size(), std::vector<GradientOfGate>({}));
+
+    auto construct_f = [&](int start, int end) {
+      for (int i = start; i < end; i++) {
+        OP_REQUIRES_OK(
+            context, QsimCircuitFromProgram(programs[i], maps[i], num_qubits[i],
+                                            &qsim_circuits[i], &unused_fuse[i],
+                                            &gate_meta[i]));
+        CreateGradientCircuit(qsim_circuits[i], gate_meta[i],
+                              &partial_fused_circuits[i], &gradient_gates[i]);
+      }
+    };
+
+    const int num_cycles = 1000;
+    context->device()->tensorflow_cpu_worker_threads()->workers->ParallelFor(
+        programs.size(), num_cycles, construct_f);
+
+    // Get downstream gradients.
+    std::vector<std::vector<float>> downstream_grads;
+    OP_REQUIRES_OK(context, GetPrevGrads(context, &downstream_grads));
+
+    OP_REQUIRES(context, downstream_grads.size() == programs.size(),
+                tensorflow::errors::InvalidArgument(absl::StrCat(
+                    "Number of gradients and circuits do not match. Got ",
+                    downstream_grads.size(), " gradients and ", programs.size(),
+                    " circuits.")));
+
+    OP_REQUIRES(
+        context, downstream_grads[0].size() == pauli_sums[0].size(),
+        tensorflow::errors::InvalidArgument(absl::StrCat(
+            "Number of gradients and pauli sum dimension do not match. Got ",
+            downstream_grads[0].size(), " gradient entries and ",
+            pauli_sums[0].size(), " paulis per circuit.")));
+
+    int max_num_qubits = 0;
+    for (const int num : num_qubits) {
+      max_num_qubits = std::max(max_num_qubits, num);
+    }
+
+    output_tensor.setZero();
+
+    // Cross reference with standard google cloud compute instances
+    // Memory ~= 2 * num_threads * (2 * 64 * 2 ** num_qubits in circuits)
+    // e2s2 = 2 CPU, 8GB -> Can safely do 25 since Memory = 4GB
+    // e2s4 = 4 CPU, 16GB -> Can safely do 25 since Memory = 8GB
+    // ...
+    // This method creates 3 big state vectors per thread so reducing size
+    // here slightly.
+    if (max_num_qubits >= 25 || programs.size() == 1) {
+      ComputeLarge(num_qubits, qsim_circuits, maps, partial_fused_circuits,
+                   pauli_sums, gradient_gates, downstream_grads, context,
+                   &output_tensor);
+    } else {
+      ComputeSmall(num_qubits, max_num_qubits, qsim_circuits, maps,
+                   partial_fused_circuits, pauli_sums, gradient_gates,
+                   downstream_grads, context, &output_tensor);
+    }
+    // just to be on the safe side.
+    qsim_circuits.clear();
+    unused_fuse.clear();
+    gate_meta.clear();
+    gradient_gates.clear();
+    num_qubits.clear();
+    maps.clear();
+    pauli_sums.clear();
+    programs.clear();
+    downstream_grads.clear();
+  }
+
+ private:
+  void ComputeSmall(
+      const std::vector<int>& num_qubits, const int max_num_qubits,
+      const std::vector<QsimCircuit>& qsim_circuits,
+      const std::vector<SymbolMap>& maps,
+      const std::vector<std::vector<std::vector<qsim::GateFused<QsimGate>>>>&
+          partial_fused_circuits,
+      const std::vector<std::vector<PauliSum>>& pauli_sums,
+      const std::vector<std::vector<tfq::GradientOfGate>>& gradient_gates,
+      const std::vector<std::vector<float>>& downstream_grads,
+      tensorflow::OpKernelContext* context,
+      tensorflow::TTypes<float, 1>::Matrix* output_tensor) {
+    // Instantiate qsim objects.
+    const auto tfq_for = qsim::SequentialFor(1);
+    using Simulator = qsim::Simulator<const qsim::SequentialFor&>;
+    using StateSpace = Simulator::StateSpace;
+    using State = StateSpace::State;
+
+    auto DoWork = [&](int start, int end) {
+      // Begin simulation.
+      int largest_nq = 1;
+      State sv = StateSpace(largest_nq, tfq_for).CreateState();
+      State scratch = StateSpace(largest_nq, tfq_for).CreateState();
+      State scratch2 = StateSpace(largest_nq, tfq_for).CreateState();
+
+      for (int i = start; i < end; i++) {
+        int nq = num_qubits[i];
+        Simulator sim = Simulator(nq, tfq_for);
+        StateSpace ss = StateSpace(nq, tfq_for);
+        if (nq > largest_nq) {
+          // need to switch to larger statespace.
+          largest_nq = nq;
+          sv = ss.CreateState();
+          scratch = ss.CreateState();
+          scratch2 = ss.CreateState();
+        }
+
+        // (#679) Just ignore empty program
+        if (qsim_circuits[i].gates.size() == 0) {
+          continue;
+        }
+
+        ss.SetStateZero(sv);
+        for (int j = 0; j < partial_fused_circuits[i].size(); j++) {
+          for (int k = 0; k < partial_fused_circuits[i][j].size(); k++) {
+            qsim::ApplyFusedGate(sim, partial_fused_circuits[i][j][k], sv);
+          }
+          if (j == partial_fused_circuits[i].size() - 1) {
+            break;
+          }
+          qsim::ApplyGate(
+              sim, qsim_circuits[i].gates[gradient_gates[i][j].index], sv);
+        }
+
+        // sv now contains psi
+        // scratch contains (sum_i paulis_sums[i] * downstream_grads[i])|psi>
+        // scratch2 now contains psi as well.
+        AccumulateOperators(pauli_sums[i], downstream_grads[i], sim, ss, sv,
+                            scratch2, scratch);
+
+        for (int j = partial_fused_circuits[i].size() - 1; j >= 0; j--) {
+          for (int k = partial_fused_circuits[i][j].size() - 1; k >= 0; k--) {
+            ApplyFusedGateDagger(sim, partial_fused_circuits[i][j][k], sv);
+            ApplyFusedGateDagger(sim, partial_fused_circuits[i][j][k], scratch);
+          }
+          if (j == 0) {
+            // last layer will have no parametrized gates so can break.
+            break;
+          }
+
+          // Hit a parameterized gate.
+          ApplyGateDagger(
+              sim, qsim_circuits[i].gates[gradient_gates[i][j - 1].index], sv);
+          for (int k = 0; k < gradient_gates[i][j - 1].grad_gates.size(); k++) {
+            // Copy sv onto scratch2 in anticipation of non-unitary "gradient
+            // gate".
+            ss.CopyState(sv, scratch2);
+            qsim::ApplyGate(sim, gradient_gates[i][j - 1].grad_gates[k], sv);
+
+            // don't need not-found check since this is done upstream already.
+            const auto it = maps[i].find(gradient_gates[i][j - 1].params[k]);
+            const int loc = it->second.first;
+            (*output_tensor)(i, loc) += ss.RealInnerProduct(sv, scratch) +
+                                        ss.RealInnerProduct(scratch, sv);
+
+            ss.CopyState(scratch2, sv);
+          }
+          ApplyGateDagger(
+              sim, qsim_circuits[i].gates[gradient_gates[i][j - 1].index],
+              scratch);
+        }
+      }
+      sv.release();
+      scratch.release();
+      scratch2.release();
+    };
+
+    const int64_t num_cycles =
+        200 * (int64_t(1) << static_cast<int64_t>(max_num_qubits));
+    context->device()->tensorflow_cpu_worker_threads()->workers->ParallelFor(
+        partial_fused_circuits.size(), num_cycles, DoWork);
+  }
+
+  void ComputeLarge(
+      const std::vector<int>& num_qubits,
+      const std::vector<QsimCircuit>& qsim_circuits,
+      const std::vector<SymbolMap>& maps,
+      const std::vector<std::vector<std::vector<qsim::GateFused<QsimGate>>>>&
+          partial_fused_circuits,
+      const std::vector<std::vector<PauliSum>>& pauli_sums,
+      const std::vector<std::vector<tfq::GradientOfGate>>& gradient_gates,
+      const std::vector<std::vector<float>>& downstream_grads,
+      tensorflow::OpKernelContext* context,
+      tensorflow::TTypes<float, 1>::Matrix* output_tensor) {
+    // Instantiate qsim objects.
+    const auto tfq_for = tfq::QsimFor(context);
+    using Simulator = qsim::Simulator<const tfq::QsimFor&>;
+    using StateSpace = Simulator::StateSpace;
+    using State = StateSpace::State;
+
+    // Begin simulation.
+    int largest_nq = 1;
+    State sv = StateSpace(largest_nq, tfq_for).CreateState();
+    State scratch = StateSpace(largest_nq, tfq_for).CreateState();
+    State scratch2 = StateSpace(largest_nq, tfq_for).CreateState();
+
+    for (int i = 0; i < partial_fused_circuits.size(); i++) {
+      int nq = num_qubits[i];
+      Simulator sim = Simulator(nq, tfq_for);
+      StateSpace ss = StateSpace(nq, tfq_for);
+      if (nq > largest_nq) {
+        // need to switch to larger statespace.
+        largest_nq = nq;
+        sv = ss.CreateState();
+        scratch = ss.CreateState();
+        scratch2 = ss.CreateState();
+      }
+
+      // (#679) Just ignore empty program
+      if (qsim_circuits[i].gates.size() == 0) {
+        continue;
+      }
+
+      ss.SetStateZero(sv);
+      for (int j = 0; j < partial_fused_circuits[i].size(); j++) {
+        for (int k = 0; k < partial_fused_circuits[i][j].size(); k++) {
+          qsim::ApplyFusedGate(sim, partial_fused_circuits[i][j][k], sv);
+        }
+        if (j == partial_fused_circuits[i].size() - 1) {
+          break;
+        }
+        qsim::ApplyGate(sim, qsim_circuits[i].gates[gradient_gates[i][j].index],
+                        sv);
+      }
+
+      // sv now contains psi
+      // scratch contains (sum_i paulis_sums[i] * downstream_grads[i])|psi>
+      // scratch2 now contains psi as well.
+      AccumulateOperators(pauli_sums[i], downstream_grads[i], sim, ss, sv,
+                          scratch2, scratch);
+
+      for (int j = partial_fused_circuits[i].size() - 1; j >= 0; j--) {
+        for (int k = partial_fused_circuits[i][j].size() - 1; k >= 0; k--) {
+          ApplyFusedGateDagger(sim, partial_fused_circuits[i][j][k], sv);
+          ApplyFusedGateDagger(sim, partial_fused_circuits[i][j][k], scratch);
+        }
+        if (j == 0) {
+          // last layer will have no parametrized gates so can break.
+          break;
+        }
+
+        // Hit a parameterized gate.
+        ApplyGateDagger(
+            sim, qsim_circuits[i].gates[gradient_gates[i][j - 1].index], sv);
+        for (int k = 0; k < gradient_gates[i][j - 1].grad_gates.size(); k++) {
+          // Copy sv onto scratch2 in anticipation of non-unitary "gradient
+          // gate".
+          ss.CopyState(sv, scratch2);
+          qsim::ApplyGate(sim, gradient_gates[i][j - 1].grad_gates[k], sv);
+
+          // don't need not-found check since this is done upstream already.
+          const auto it = maps[i].find(gradient_gates[i][j - 1].params[k]);
+          const int loc = it->second.first;
+          (*output_tensor)(i, loc) += ss.RealInnerProduct(sv, scratch) +
+                                      ss.RealInnerProduct(scratch, sv);
+
+          ss.CopyState(scratch2, sv);
+        }
+        ApplyGateDagger(sim,
+                        qsim_circuits[i].gates[gradient_gates[i][j - 1].index],
+                        scratch);
+      }
+    }
+    sv.release();
+    scratch.release();
+    scratch2.release();
+  }
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("TfqAdjointGradient").Device(tensorflow::DEVICE_CPU),
+    TfqAdjointGradientOp);
+
+REGISTER_OP("TfqAdjointGradient")
+    .Input("programs: string")
+    .Input("symbol_names: string")
+    .Input("symbol_values: float")
+    .Input("pauli_sums: string")
+    .Input("downstream_grads: float")
+    .Output("grads: float")
+    .SetShapeFn([](tensorflow::shape_inference::InferenceContext* c) {
+      tensorflow::shape_inference::ShapeHandle programs_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 1, &programs_shape));
+
+      tensorflow::shape_inference::ShapeHandle symbol_names_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &symbol_names_shape));
+
+      tensorflow::shape_inference::ShapeHandle symbol_values_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 2, &symbol_values_shape));
+
+      tensorflow::shape_inference::ShapeHandle pauli_sums_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 2, &pauli_sums_shape));
+
+      tensorflow::shape_inference::ShapeHandle downstream_grads_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 2, &downstream_grads_shape));
+
+      tensorflow::shape_inference::DimensionHandle output_rows =
+          c->Dim(programs_shape, 0);
+      tensorflow::shape_inference::DimensionHandle output_cols =
+          c->Dim(symbol_names_shape, 0);
+      c->set_output(0, c->Matrix(output_rows, output_cols));
+
+      return tensorflow::Status::OK();
+    });
+
+}  // namespace tfq

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op.cc
@@ -244,7 +244,8 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
             // Copy sv onto scratch2 in anticipation of non-unitary "gradient
             // gate".
             ss.CopyState(sv, scratch2);
-            qsim::ApplyGate(sim, gradient_gates[i][j - 1].grad_gates[k], sv);
+            qsim::ApplyGate(sim, gradient_gates[i][j - 1].grad_gates[k],
+                            scratch2);
 
             // don't need not-found check since this is done upstream already.
             const auto it = maps[i].find(gradient_gates[i][j - 1].params[k]);
@@ -254,10 +255,8 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
             // of a symbol at the same circuit. For analytic methods like
             // parameter-shift we need to apply a single `gradient_gate`
             // per a symbol.
-            (*output_tensor)(i, loc) += ss.RealInnerProduct(sv, scratch) +
-                                        ss.RealInnerProduct(scratch, sv);
-
-            ss.CopyState(scratch2, sv);
+            (*output_tensor)(i, loc) += ss.RealInnerProduct(scratch2, scratch) +
+                                        ss.RealInnerProduct(scratch, scratch2);
           }
           ApplyGateDagger(
               sim, qsim_circuits[i].gates[gradient_gates[i][j - 1].index],
@@ -352,7 +351,8 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
           // Copy sv onto scratch2 in anticipation of non-unitary "gradient
           // gate".
           ss.CopyState(sv, scratch2);
-          qsim::ApplyGate(sim, gradient_gates[i][j - 1].grad_gates[k], sv);
+          qsim::ApplyGate(sim, gradient_gates[i][j - 1].grad_gates[k],
+                          scratch2);
 
           // don't need not-found check since this is done upstream already.
           const auto it = maps[i].find(gradient_gates[i][j - 1].params[k]);
@@ -362,10 +362,8 @@ class TfqAdjointGradientOp : public tensorflow::OpKernel {
           // of a symbol at the same circuit. For analytic methods like
           // parameter-shift we need to apply a single `gradient_gate`
           // per a symbol.
-          (*output_tensor)(i, loc) += ss.RealInnerProduct(sv, scratch) +
-                                      ss.RealInnerProduct(scratch, sv);
-
-          ss.CopyState(scratch2, sv);
+          (*output_tensor)(i, loc) += ss.RealInnerProduct(scratch2, scratch) +
+                                      ss.RealInnerProduct(scratch, scratch2);
         }
         ApplyGateDagger(sim,
                         qsim_circuits[i].gates[gradient_gates[i][j - 1].index],

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op.py
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op.py
@@ -1,0 +1,48 @@
+# Copyright 2020 The TensorFlow Quantum Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Module to register python op gradient."""
+import tensorflow as tf
+from tensorflow_quantum.core.ops.load_module import load_module
+
+SIM_OP_MODULE = load_module("_tfq_adj_grad.so")
+
+
+def tfq_adj_grad(programs, symbol_names, symbol_values, pauli_sums, prev_grad):
+    """Calculate gradient of expectation value of circuits wrt some operator(s).
+
+    Args:
+        programs: `tf.Tensor` of strings with shape [batch_size] containing
+            the string representations of the circuits to be executed.
+        symbol_names: `tf.Tensor` of strings with shape [n_params], which
+            is used to specify the order in which the values in
+            `symbol_values` should be placed inside of the circuits in
+            `programs`.
+        symbol_values: `tf.Tensor` of real numbers with shape
+            [batch_size, n_params] specifying parameter values to resolve
+            into the circuits specificed by programs, following the ordering
+            dictated by `symbol_names`.
+        pauli_sums: `tf.Tensor` of strings with shape [batch_size, n_ops]
+            containing the string representation of the operators that will
+            be used on all of the circuits in the expectation calculations.
+        prev_grad: `tf.Tensor` of real numbers with shape [batch_size, n_ops]
+            backprop of values from downstream in the compute graph.
+    Returns:
+        `tf.Tensor` with shape [batch_size, n_params] that holds the gradient of
+            expectation value for each circuit with each op applied to it
+            (after resolving the corresponding parameters in).
+    """
+    return SIM_OP_MODULE.tfq_adjoint_gradient(
+        programs, symbol_names, tf.cast(symbol_values, tf.float32), pauli_sums,
+        tf.cast(prev_grad, tf.float32))

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op_test.py
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op_test.py
@@ -231,6 +231,7 @@ class ADJGradTest(tf.test.TestCase, parameterized.TestCase):
             tf.convert_to_tensor([[]]),
             tf.convert_to_tensor([[]], dtype=tf.dtypes.string),
             tf.convert_to_tensor([[]]))
+        self.assertShapeEqual(np.zeros((1, 0)), out)
 
     def test_calculate_adj_grad_simple_case(self):
         """Make sure that adjoint gradient works on simple input case."""
@@ -306,7 +307,9 @@ class ADJGradTest(tf.test.TestCase, parameterized.TestCase):
         [cirq.Circuit(cirq.X(qubits[0]) ** sympy.Symbol('alpha'),
             cirq.Y(qubits[1]) ** sympy.Symbol('beta'),
             cirq.CNOT(qubits[0], qubits[1]),
-            cirq.FSimGate(sympy.Symbol('gamma'), sympy.Symbol('gamma'))(qubits[0], qubits[1]))
+            cirq.FSimGate(
+                sympy.Symbol('gamma'),
+                sympy.Symbol('gamma'))(qubits[0], qubits[1]))
         ], [{'alpha': 0.123, 'beta': 0.456, 'gamma': 0.789}]
 
         op_batch = [

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op_test.py
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op_test.py
@@ -1,0 +1,335 @@
+# Copyright 2020 The TensorFlow Quantum Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests that specifically target tfq_unitary_op."""
+import numpy as np
+from absl.testing import parameterized
+import tensorflow as tf
+import cirq
+import sympy
+
+from tensorflow_quantum.python import util
+from tensorflow_quantum.core.ops import tfq_adj_grad_op
+
+
+class ADJGradTest(tf.test.TestCase, parameterized.TestCase):
+    """Tests tfq_calculate_unitary."""
+
+    def test_adj_grad_inputs(self):
+        """Make sure that the expectation op fails gracefully on bad inputs."""
+        n_qubits = 5
+        batch_size = 5
+        symbol_names = ['alpha']
+        qubits = cirq.GridQubit.rect(1, n_qubits)
+        circuit_batch, resolver_batch = \
+            util.random_symbol_circuit_resolver_batch(
+                qubits, symbol_names, batch_size)
+
+        symbol_values_array = np.array(
+            [[resolver[symbol]
+              for symbol in symbol_names]
+             for resolver in resolver_batch])
+
+        pauli_sums = util.random_pauli_sums(qubits, 3, batch_size)
+        upstream_grads = np.ones((batch_size, len(symbol_names)))
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'programs must be rank 1'):
+            # Circuit tensor has too many dimensions.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor([circuit_batch]), symbol_names,
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'symbol_names must be rank 1.'):
+            # symbol_names tensor has too many dimensions.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), np.array([symbol_names]),
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'symbol_values must be rank 2.'):
+            # symbol_values_array tensor has too many dimensions.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                tf.convert_to_tensor(np.array([symbol_values_array])),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'symbol_values must be rank 2.'):
+            # symbol_values_array tensor has too few dimensions.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                tf.convert_to_tensor(symbol_values_array[0]),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'pauli_sums must be rank 2.'):
+            # pauli_sums tensor has too few dimensions.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([x for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'pauli_sums must be rank 2.'):
+            # pauli_sums tensor has too many dimensions.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([[[x]] for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'Unparseable proto'):
+            # circuit tensor has the right type but invalid values.
+            tfq_adj_grad_op.tfq_adj_grad(
+                ['junk'] * batch_size, symbol_names,
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'Could not find symbol in parameter map'):
+            # symbol_names tensor has the right type but invalid values.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), ['junk'],
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'qubits not found in circuit'):
+            # pauli_sums tensor has the right type but invalid values.
+            new_qubits = [cirq.GridQubit(5, 5), cirq.GridQubit(9, 9)]
+            new_pauli_sums = util.random_pauli_sums(new_qubits, 2, batch_size)
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([[x] for x in new_pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'Unparseable proto'):
+            # pauli_sums tensor has the right type but invalid values 2.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                tf.convert_to_tensor(symbol_values_array),
+                [['junk']] * batch_size, tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(TypeError, 'Cannot convert'):
+            # circuits tensor has the wrong type.
+            tfq_adj_grad_op.tfq_adj_grad(
+                [1.0] * batch_size, symbol_names,
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(TypeError, 'Cannot convert'):
+            # symbol_names tensor has the wrong type.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), [0.1234],
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(tf.errors.UnimplementedError, ''):
+            # symbol_values tensor has the wrong type.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                [['junk']] * batch_size,
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(TypeError, 'Cannot convert'):
+            # pauli_sums tensor has the wrong type.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                tf.convert_to_tensor(symbol_values_array), [[1.0]] * batch_size,
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(TypeError, 'missing'):
+            # we are missing an argument.
+            # pylint: disable=no-value-for-parameter
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                tf.convert_to_tensor(symbol_values_array),
+                tf.convert_to_tensor(upstream_grads))
+            # pylint: enable=no-value-for-parameter
+
+        with self.assertRaisesRegex(TypeError, 'positional arguments'):
+            # pylint: disable=too-many-function-args
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads), [])
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    expected_regex='do not match'):
+            # wrong op size.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor([cirq.Circuit()]), symbol_names,
+                symbol_values_array.astype(np.float64),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor(upstream_grads))
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    expected_regex='rank 2'):
+            # wrong grad shape.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor([upstream_grads]))
+
+        with self.assertRaisesRegex(
+                tf.errors.InvalidArgumentError,
+                expected_regex='gradients and circuits do not match'):
+            # wrong grad batch size.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor([[0 for i in range(len(symbol_names))]]))
+
+        with self.assertRaisesRegex(
+                tf.errors.InvalidArgumentError,
+                expected_regex='gradients and pauli sum dimension do not match'
+        ):
+            # wrong grad inner size.
+            tfq_adj_grad_op.tfq_adj_grad(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                tf.convert_to_tensor(symbol_values_array),
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                tf.convert_to_tensor([[0, 0] for _ in range(len(circuit_batch))
+                                     ]))
+
+    def test_calculate_adj_grad_empty(self):
+        """Verify that the empty case is handled gracefully."""
+        out = tfq_adj_grad_op.tfq_adj_grad(
+            util.convert_to_tensor([cirq.Circuit()]),
+            tf.convert_to_tensor([], dtype=tf.dtypes.string),
+            tf.convert_to_tensor([[]]),
+            tf.convert_to_tensor([[]], dtype=tf.dtypes.string),
+            tf.convert_to_tensor([[]]))
+
+    def test_calculate_adj_grad_simple_case(self):
+        """Make sure that adjoint gradient works on simple input case."""
+        n_qubits = 2
+        batch_size = 1
+        symbol_names = ['alpha', 'beta']
+        qubits = cirq.GridQubit.rect(1, n_qubits)
+        circuit_batch, resolver_batch = \
+        [cirq.Circuit(cirq.X(qubits[0]) ** sympy.Symbol('alpha'),
+            cirq.Y(qubits[1]) ** sympy.Symbol('beta'),
+            cirq.CNOT(qubits[0], qubits[1]))], [{'alpha': 0.123, 'beta': 0.456}]
+
+        op_batch = [
+            [cirq.Z(qubits[0]), cirq.X(qubits[1])] for _ in range(batch_size)
+        ]
+
+        symbol_values_array = np.array(
+            [[resolver[symbol]
+              for symbol in symbol_names]
+             for resolver in resolver_batch])
+
+        prev_grads = tf.ones([batch_size, len(symbol_names)])
+
+        out = tfq_adj_grad_op.tfq_adj_grad(
+            util.convert_to_tensor(circuit_batch),
+            tf.convert_to_tensor(symbol_names),
+            tf.convert_to_tensor(symbol_values_array),
+            util.convert_to_tensor(op_batch), prev_grads)
+
+        self.assertAllClose(out, np.array([[-1.18392, 0.43281]]), atol=1e-3)
+
+    def test_calculate_adj_grad_simple_case2(self):
+        """Make sure the adjoint gradient works on another simple input case."""
+        n_qubits = 2
+        batch_size = 1
+        symbol_names = ['alpha', 'beta', 'gamma']
+        qubits = cirq.GridQubit.rect(1, n_qubits)
+        circuit_batch, resolver_batch = \
+        [cirq.Circuit(cirq.X(qubits[0]) ** sympy.Symbol('alpha'),
+            cirq.Y(qubits[1]) ** sympy.Symbol('beta'),
+            cirq.CNOT(qubits[0], qubits[1]),
+            cirq.FSimGate(sympy.Symbol('gamma'), 0.5)(qubits[0], qubits[1]))
+        ], [{'alpha': 0.123, 'beta': 0.456, 'gamma': 0.789}]
+
+        op_batch = [
+            [cirq.Z(qubits[0]), cirq.X(qubits[1])] for _ in range(batch_size)
+        ]
+
+        symbol_values_array = np.array(
+            [[resolver[symbol]
+              for symbol in symbol_names]
+             for resolver in resolver_batch])
+
+        prev_grads = tf.ones([batch_size, len(op_batch[0])])
+
+        out = tfq_adj_grad_op.tfq_adj_grad(
+            util.convert_to_tensor(circuit_batch),
+            tf.convert_to_tensor(symbol_names),
+            tf.convert_to_tensor(symbol_values_array),
+            util.convert_to_tensor(op_batch), prev_grads)
+
+        self.assertAllClose(out,
+                            np.array([[-2.100, -1.7412, -1.5120]]),
+                            atol=1e-3)
+
+    def test_calculate_adj_grad_simple_case3(self):
+        """Make sure the adjoint gradient works on ANOTHER simple input case."""
+        n_qubits = 2
+        batch_size = 1
+        symbol_names = ['alpha', 'beta', 'gamma']
+        qubits = cirq.GridQubit.rect(1, n_qubits)
+        circuit_batch, resolver_batch = \
+        [cirq.Circuit(cirq.X(qubits[0]) ** sympy.Symbol('alpha'),
+            cirq.Y(qubits[1]) ** sympy.Symbol('beta'),
+            cirq.CNOT(qubits[0], qubits[1]),
+            cirq.FSimGate(sympy.Symbol('gamma'), sympy.Symbol('gamma'))(qubits[0], qubits[1]))
+        ], [{'alpha': 0.123, 'beta': 0.456, 'gamma': 0.789}]
+
+        op_batch = [
+            [cirq.Z(qubits[0]), cirq.X(qubits[1])] for _ in range(batch_size)
+        ]
+
+        symbol_values_array = np.array(
+            [[resolver[symbol]
+              for symbol in symbol_names]
+             for resolver in resolver_batch])
+
+        prev_grads = tf.ones([batch_size, len(op_batch[0])])
+
+        out = tfq_adj_grad_op.tfq_adj_grad(
+            util.convert_to_tensor(circuit_batch),
+            tf.convert_to_tensor(symbol_names),
+            tf.convert_to_tensor(symbol_values_array),
+            util.convert_to_tensor(op_batch), prev_grads)
+
+        self.assertAllClose(out,
+                            np.array([[-2.3484, -1.7532, -1.64264]]),
+                            atol=1e-3)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/tensorflow_quantum/core/src/circuit_parser_qsim.cc
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim.cc
@@ -506,6 +506,9 @@ tensorflow::Status QsimCircuitFromProgram(
   }
 
   circuit->gates.reserve(program.circuit().moments_size() * num_qubits);
+  if (metadata != nullptr) {
+    metadata->reserve(program.circuit().moments_size() * num_qubits);
+  }
   for (const Moment& moment : program.circuit().moments()) {
     for (const Operation& op : moment.operations()) {
       Status status =


### PR DESCRIPTION
Adds a basic functioning op for the adjoint gradient. I'm thinking that we should NOT expose this op to the user and instead force them to make use of the differentiatiors interface with an appropriately linked op, that is why I haven't made any modifications to the `__init__.py` files. My thinking behind this is that if a user wanted to call into this op they could just as easily do an appropriate `with tf.GradientTape() ...` style statement that sticks more closely to the expected TF logic for getting out gradients instead of `tfq.adj_grad(...)`.

What do @zaqqwerty and @jaeyoo think ?

Yet more progress on #256 . One or two more PRs should do it.