### PR TITLE
Move GLOBAL_OP_LOCK to quantum_context.

### DIFF
--- a/tensorflow_quantum/core/ops/BUILD
+++ b/tensorflow_quantum/core/ops/BUILD
@@ -398,9 +398,9 @@ py_library(
     name = "circuit_execution_ops",
     srcs = ["circuit_execution_ops.py"],
     deps = [
-        ":tfq_utility_ops_py",
         ":cirq_ops",
         ":tfq_simulate_ops_py",
+        ":tfq_utility_ops_py",
         "//tensorflow_quantum/python:quantum_context",
     ],
 )

--- a/tensorflow_quantum/python/quantum_context.py
+++ b/tensorflow_quantum/python/quantum_context.py
@@ -16,6 +16,8 @@
 
 import multiprocessing
 
+import tensorflow as tf
+
 
 class QContext:
     """Class for storing quantum execution information."""
@@ -110,3 +112,6 @@ def get_quantum_concurrent_op_mode():
         are blocking graph level parallelism with one another.
     """
     return q_context()._get_quantum_concurrent_op_mode()
+
+
+_GLOBAL_OP_LOCK = tf.CriticalSection()


### PR DESCRIPTION
In the future if we want to link other ops into the same GLOBAL_OP_LOCK instance we will need it in a more global location than `circuit_executions_ops.py`. This move fixes this. Related: #364 