### PR TITLE
Parsing functionality for program-program.

### DIFF
--- a/tensorflow_quantum/core/src/program_resolution.h
+++ b/tensorflow_quantum/core/src/program_resolution.h
@@ -39,6 +39,14 @@ tensorflow::Status ResolveQubitIds(
     cirq::google::api::v2::Program* program, unsigned int* num_qubits,
     std::vector<tfq::proto::PauliSum>* p_sums = nullptr);
 
+// Overload which allows for strict resolution of multiple programs.
+// Will resolve GridQubits in `program` and then double check that
+// all qubits in `other_programs` match and resolve them.
+// Note: no nullptr default is done here to avoid signature resolutions issues.
+tensorflow::Status ResolveQubitIds(
+    cirq::google::api::v2::Program* program, unsigned int* num_qubits,
+    std::vector<cirq::google::api::v2::Program>* other_programs);
+
 // Resolves all of the symbols present in the Program. Iterates through all
 // operations in all moments, and if any Args have a symbol, replaces the one-of
 // with an ArgValue representing the value in the parameter map keyed by the

--- a/tensorflow_quantum/core/src/program_resolution_test.cc
+++ b/tensorflow_quantum/core/src/program_resolution_test.cc
@@ -360,12 +360,12 @@ TEST(ProgramResolutionTest, ResolveQubitIdsPrograms) {
     }
   )";
 
-  Program program, program_copy;
+  Program program, program_copy, empty_program;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(text, &program));
   ASSERT_TRUE(
       google::protobuf::TextFormat::ParseFromString(text, &program_copy));
 
-  unsigned int num_qubits, num_qubits_copy;
+  unsigned int num_qubits, num_qubits_empty;
   std::vector<Program> vec({program_copy});
   EXPECT_TRUE(ResolveQubitIds(&program, &num_qubits, &vec).ok());
 
@@ -410,6 +410,11 @@ TEST(ProgramResolutionTest, ResolveQubitIdsPrograms) {
       tensorflow::Status(
           tensorflow::error::INVALID_ARGUMENT,
           "A reference circuit contains qubits not found in paired circuit."));
+
+  // Ensure empty case is consistent.
+  std::vector<Program> vec4;
+  EXPECT_TRUE(ResolveQubitIds(&empty_program, &num_qubits_empty, &vec4).ok());
+  EXPECT_EQ(num_qubits_empty, 0);
 }
 
 TEST(ProgramResolutionTest, ResolveSymbolsInvalidArg) {


### PR DESCRIPTION
In order to support ops like `tfq.math.overlap` or any other program to program based operations, we will need a way to parse them in pairs and ensure they operate on the same qubits etc. This PR adds that functionality.