### PR TITLE
Add explicit use_cxx11_abi=0 to configuration.

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -126,6 +126,7 @@ write_to_bazelrc "build --spawn_strategy=standalone"
 write_to_bazelrc "build --strategy=Genrule=standalone"
 write_to_bazelrc "build --experimental_repo_remote_exec"
 write_to_bazelrc "build -c opt"
+write_to_bazelrc "build --cxxopt=\"-D_GLIBCXX_USE_CXX11_ABI=0\""
 
 
 if is_windows; then


### PR DESCRIPTION
Just a small quality of life improvement to allow us to write statements like 
`bazel test ...` without having to worry about adding in the long abi flag everytime.