### PR TITLE
Serialize multiqubit

### DIFF
--- a/tensorflow_quantum/core/ops/tfq_ps_decompose_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_ps_decompose_op.cc
@@ -176,6 +176,11 @@ class TfqPsDecomposeOp : public tensorflow::OpKernel {
     new_op_map["exponent_scalar"].mutable_arg_value()->set_float_value(
         cur_exponent_scalar * -0.5);
     new_op_map["exponent"].set_symbol(symbol);
+    // Copy over control metadata.
+    new_op_map["control_qubits"].mutable_arg_value()->set_string_value(
+        cur_op_map["control_qubits"].arg_value().string_value());
+    new_op_map["control_values"].mutable_arg_value()->set_string_value(
+        cur_op_map["control_values"].arg_value().string_value());
     // Step 4. add qubits.
     *new_op.mutable_qubits() = {cur_op_qubits.begin(), cur_op_qubits.end()};
     return new_op;
@@ -215,6 +220,11 @@ class TfqPsDecomposeOp : public tensorflow::OpKernel {
     }
     // Step 4. add qubits.
     *new_op.mutable_qubits() = {cur_op_qubits.begin(), cur_op_qubits.end()};
+    // Copy over control metadata.
+    new_op_map["control_qubits"].mutable_arg_value()->set_string_value(
+        cur_op_map["control_qubits"].arg_value().string_value());
+    new_op_map["control_values"].mutable_arg_value()->set_string_value(
+        cur_op_map["control_values"].arg_value().string_value());
     return new_op;
   }
 
@@ -251,6 +261,11 @@ class TfqPsDecomposeOp : public tensorflow::OpKernel {
     }
     *new_op.mutable_qubits() = {cur_op_qubits.begin() + use_target,
                                 cur_op_qubits.end() - !use_target};
+    // Copy over control metadata.
+    new_op_map["control_qubits"].mutable_arg_value()->set_string_value(
+        cur_op_map["control_qubits"].arg_value().string_value());
+    new_op_map["control_values"].mutable_arg_value()->set_string_value(
+        cur_op_map["control_values"].arg_value().string_value());
     return new_op;
   }
 
@@ -290,6 +305,11 @@ class TfqPsDecomposeOp : public tensorflow::OpKernel {
     }
     // Step 4. add qubits.
     *new_op.mutable_qubits() = {cur_op_qubits.begin(), cur_op_qubits.end()};
+    // Copy over control metadata.
+    new_op_map["control_qubits"].mutable_arg_value()->set_string_value(
+        cur_op_map["control_qubits"].arg_value().string_value());
+    new_op_map["control_values"].mutable_arg_value()->set_string_value(
+        cur_op_map["control_values"].arg_value().string_value());
     return new_op;
   }
 };

--- a/tensorflow_quantum/core/ops/tfq_simulate_ops_test.py
+++ b/tensorflow_quantum/core/ops/tfq_simulate_ops_test.py
@@ -453,8 +453,8 @@ class SimulateSamplesTest(tf.test.TestCase, parameterized.TestCase):
             this_expected_output[:, :max(all_n_qubits) - n_qubits] = -2
             expected_outputs.append(this_expected_output)
             circuits.append(
-                cirq.Circuit(
-                    *cirq.X.on_each(*cirq.GridQubit.rect(1, n_qubits))))
+                cirq.Circuit(*cirq.X.on_each(
+                    *cirq.GridQubit.rect(1, n_qubits))))
         results = op(util.convert_to_tensor(circuits), [], [[]] * len(circuits),
                      [n_samples]).numpy()
         self.assertAllClose(expected_outputs, results)

--- a/tensorflow_quantum/core/ops/tfq_simulate_ops_test.py
+++ b/tensorflow_quantum/core/ops/tfq_simulate_ops_test.py
@@ -453,8 +453,8 @@ class SimulateSamplesTest(tf.test.TestCase, parameterized.TestCase):
             this_expected_output[:, :max(all_n_qubits) - n_qubits] = -2
             expected_outputs.append(this_expected_output)
             circuits.append(
-                cirq.Circuit(*cirq.X.on_each(
-                    *cirq.GridQubit.rect(1, n_qubits))))
+                cirq.Circuit(
+                    *cirq.X.on_each(*cirq.GridQubit.rect(1, n_qubits))))
         results = op(util.convert_to_tensor(circuits), [], [[]] * len(circuits),
                      [n_samples]).numpy()
         self.assertAllClose(expected_outputs, results)

--- a/tensorflow_quantum/core/serialize/serializer.py
+++ b/tensorflow_quantum/core/serialize/serializer.py
@@ -539,7 +539,8 @@ def serialize_circuit(circuit_inp):
     # Demote cirq.controlled_operations (controlled gates) to their sub_gate
     # types with _tfq_control_qubits and _tfq_control_values fields so that
     # the gates can still get picked up by the serializer. There would be no way
-    # to discern controlledgates from one another otherwise.
+    # to discern controlledgates from one another otherwise. This
+    # "momentary demotion" occurs with the help of the DelayedAssignmentGate.
     for i, moment in enumerate(circuit):
         for op in moment:
             if isinstance(op,

--- a/tensorflow_quantum/core/serialize/serializer.py
+++ b/tensorflow_quantum/core/serialize/serializer.py
@@ -153,7 +153,6 @@ def _optional_control_promote(gate, control_qubits_message,
         r = int(r)
         c = int(c)
         cv = int(cv)
-        # gate = gate.controlled_by(cirq.GridQubit(r, c), controlled_value=[cv])
         qbs.append(cirq.GridQubit(r, c))
         vals.append([cv])
 

--- a/tensorflow_quantum/core/serialize/serializer.py
+++ b/tensorflow_quantum/core/serialize/serializer.py
@@ -140,21 +140,12 @@ class DelayedAssignmentGate(cirq.Gate):
             *self._control_qubits, control_values=self._control_values)
 
 
-def _optional_control_promote(gate, control_qubits_message,
-                              control_values_message):
+def _optional_control_promote(gate, qubits_message, values_message):
     """Optionally promote to controlled gate based on serialized control msg."""
-    if control_qubits_message == '' and control_values_message == '':
+    if qubits_message == '' and values_message == '':
         return gate
-    qbs = []
-    vals = []
-    for qb, cv in zip(control_qubits_message.split(','),
-                      control_values_message.split(',')):
-        r, c = qb.split('_')
-        r = int(r)
-        c = int(c)
-        cv = int(cv)
-        qbs.append(cirq.GridQubit(r, c))
-        vals.append([cv])
+    qbs = [v2.qubit_from_proto_id(qb) for qb in qubits_message.split(',')]
+    vals = [int(cv) for cv in values_message.split(',')]
 
     return DelayedAssignmentGate(gate, qbs, vals)
 

--- a/tensorflow_quantum/core/serialize/serializer.py
+++ b/tensorflow_quantum/core/serialize/serializer.py
@@ -135,9 +135,13 @@ class DelayedAssignmentGate(cirq.Gate):
     def _qid_shape_(self):
         raise ValueError("Called qid_shape on workaround class.")
 
+    # pylint: disable=invalid-name
     def on(self, *qubits):
+        """Returns gate_callable on qubits controlled by contol_qubits."""
         return self._gate_callable(*qubits).controlled_by(
             *self._control_qubits, control_values=self._control_values)
+
+    # pylint: enable=invalid-name
 
 
 def _optional_control_promote(gate, qubits_message, values_message):

--- a/tensorflow_quantum/core/serialize/serializer.py
+++ b/tensorflow_quantum/core/serialize/serializer.py
@@ -109,6 +109,57 @@ def _symbol_extractor(x):
                      "information.")
 
 
+def _serialize_controls(gate):
+    """Helper to serialize control qubits if applicable."""
+    if hasattr(gate, '_tfq_control_qubits'):
+        return ','.join(
+            v2.qubit_to_proto_id(q) for q in gate._tfq_control_qubits)
+    return ''
+
+
+def _serialize_control_vals(gate):
+    """Helper to serialize control values if applicable.."""
+    if hasattr(gate, '_tfq_control_values'):
+        return ','.join(str(v[0]) for v in gate._tfq_control_values)
+    return ''
+
+
+class DelayedAssignmentGate(cirq.Gate):
+    """Class to do control qubit assignment before sub_gate qubit assignment."""
+
+    def __init__(self, gate_callable, control_qubits, control_values):
+        self._gate_callable = gate_callable
+        self._control_qubits = control_qubits
+        self._control_values = control_values
+
+    def _qid_shape_(self):
+        raise ValueError("Called qid_shape on workaround class.")
+
+    def on(self, *qubits):
+        return self._gate_callable(*qubits).controlled_by(
+            *self._control_qubits, control_values=self._control_values)
+
+
+def _optional_control_promote(gate, control_qubits_message,
+                              control_values_message):
+    """Optionally promote to controlled gate based on serialized control msg."""
+    if control_qubits_message == '' and control_values_message == '':
+        return gate
+    qbs = []
+    vals = []
+    for qb, cv in zip(control_qubits_message.split(','),
+                      control_values_message.split(',')):
+        r, c = qb.split('_')
+        r = int(r)
+        c = int(c)
+        cv = int(cv)
+        # gate = gate.controlled_by(cirq.GridQubit(r, c), controlled_value=[cv])
+        qbs.append(cirq.GridQubit(r, c))
+        vals.append([cv])
+
+    return DelayedAssignmentGate(gate, qbs, vals)
+
+
 def _eigen_gate_serializer(gate_type, serialized_id):
     """Make standard serializer for eigen gates."""
 
@@ -124,7 +175,14 @@ def _eigen_gate_serializer(gate_type, serialized_id):
         cirq.google.SerializingArg(
             serialized_name="global_shift",
             serialized_type=float,
-            op_getter=lambda x: float(x.gate._global_shift))
+            op_getter=lambda x: float(x.gate._global_shift)),
+        cirq.google.SerializingArg(serialized_name="control_qubits",
+                                   serialized_type=str,
+                                   op_getter=lambda x: _serialize_controls(x)),
+        cirq.google.SerializingArg(
+            serialized_name="control_values",
+            serialized_type=str,
+            op_getter=lambda x: _serialize_control_vals(x))
     ]
     return cirq.google.GateOpSerializer(gate_type=gate_type,
                                         serialized_gate_id=serialized_id,
@@ -135,7 +193,8 @@ def _eigen_gate_serializer(gate_type, serialized_id):
 def _eigen_gate_deserializer(gate_type, serialized_id):
     """Make standard deserializer for eigen gates."""
 
-    def _scalar_combiner(exponent, global_shift, exponent_scalar):
+    def _scalar_combiner(exponent, global_shift, exponent_scalar,
+                         control_qubits, control_values):
         """This is a workaround to support symbol scalar multiplication.
         In the future we should likely get rid of this in favor of proper
         expression parsing once cirq supports it. See cirq.op_serializer
@@ -143,10 +202,14 @@ def _eigen_gate_deserializer(gate_type, serialized_id):
         like cirq.rx('alpha').
         """
         if exponent_scalar == 1.0:
-            return gate_type(exponent=_round(exponent),
-                             global_shift=_round(global_shift))
-        return gate_type(exponent=_round(exponent) * _round(exponent_scalar),
-                         global_shift=_round(global_shift))
+            return _optional_control_promote(
+                gate_type(exponent=_round(exponent),
+                          global_shift=_round(global_shift)), control_qubits,
+                control_values)
+        return _optional_control_promote(
+            gate_type(exponent=_round(exponent) * _round(exponent_scalar),
+                      global_shift=_round(global_shift)), control_qubits,
+            control_values)
 
     args = [
         cirq.google.DeserializingArg(serialized_name="exponent",
@@ -154,7 +217,11 @@ def _eigen_gate_deserializer(gate_type, serialized_id):
         cirq.google.DeserializingArg(serialized_name="global_shift",
                                      constructor_arg_name="global_shift"),
         cirq.google.DeserializingArg(serialized_name="exponent_scalar",
-                                     constructor_arg_name="exponent_scalar")
+                                     constructor_arg_name="exponent_scalar"),
+        cirq.google.DeserializingArg(serialized_name="control_qubits",
+                                     constructor_arg_name="control_qubits"),
+        cirq.google.DeserializingArg(serialized_name="control_values",
+                                     constructor_arg_name="control_values")
     ]
     return cirq.google.GateOpDeserializer(serialized_gate_id=serialized_id,
                                           gate_constructor=_scalar_combiner,
@@ -181,6 +248,13 @@ def _fsim_gate_serializer():
             serialized_name="phi_scalar",
             serialized_type=float,
             op_getter=lambda x: _scalar_extractor(x.gate.phi)),
+        cirq.google.SerializingArg(serialized_name="control_qubits",
+                                   serialized_type=str,
+                                   op_getter=lambda x: _serialize_controls(x)),
+        cirq.google.SerializingArg(
+            serialized_name="control_values",
+            serialized_type=str,
+            op_getter=lambda x: _serialize_control_vals(x))
     ]
     return cirq.google.GateOpSerializer(gate_type=cirq.FSimGate,
                                         serialized_gate_id="FSIM",
@@ -191,12 +265,15 @@ def _fsim_gate_serializer():
 def _fsim_gate_deserializer():
     """Make standard deserializer for fsim gate."""
 
-    def _scalar_combiner(theta, theta_scalar, phi, phi_scalar):
+    def _scalar_combiner(theta, theta_scalar, phi, phi_scalar, control_qubits,
+                         control_values):
         """This is a workaround to support symbol scalar multiplication.
         See `_eigen_gate_deserializer` for details.
         """
-        return cirq.FSimGate(theta=_round(theta) * _round(theta_scalar),
-                             phi=_round(phi) * _round(phi_scalar))
+        return _optional_control_promote(
+            cirq.FSimGate(theta=_round(theta) * _round(theta_scalar),
+                          phi=_round(phi) * _round(phi_scalar)), control_qubits,
+            control_values)
 
     args = [
         cirq.google.DeserializingArg(serialized_name="theta",
@@ -207,6 +284,10 @@ def _fsim_gate_deserializer():
                                      constructor_arg_name="theta_scalar"),
         cirq.google.DeserializingArg(serialized_name="phi_scalar",
                                      constructor_arg_name="phi_scalar"),
+        cirq.google.DeserializingArg(serialized_name="control_qubits",
+                                     constructor_arg_name="control_qubits"),
+        cirq.google.DeserializingArg(serialized_name="control_values",
+                                     constructor_arg_name="control_values")
     ]
     return cirq.google.GateOpDeserializer(serialized_gate_id="FSIM",
                                           gate_constructor=_scalar_combiner,
@@ -228,7 +309,14 @@ def _identity_gate_serializer():
     args = [
         cirq.google.SerializingArg(serialized_name="unused",
                                    serialized_type=bool,
-                                   op_getter=_identity_check)
+                                   op_getter=_identity_check),
+        cirq.google.SerializingArg(serialized_name="control_qubits",
+                                   serialized_type=str,
+                                   op_getter=lambda x: _serialize_controls(x)),
+        cirq.google.SerializingArg(
+            serialized_name="control_values",
+            serialized_type=str,
+            op_getter=lambda x: _serialize_control_vals(x))
     ]
     return cirq.google.GateOpSerializer(gate_type=cirq.IdentityGate,
                                         serialized_gate_id="I",
@@ -240,11 +328,15 @@ def _identity_gate_deserializer():
     """Make a standard deserializer for the single qubit identity."""
     args = [
         cirq.google.DeserializingArg(serialized_name="unused",
-                                     constructor_arg_name="unused")
+                                     constructor_arg_name="unused"),
+        cirq.google.DeserializingArg(serialized_name="control_qubits",
+                                     constructor_arg_name="control_qubits"),
+        cirq.google.DeserializingArg(serialized_name="control_values",
+                                     constructor_arg_name="control_values")
     ]
 
-    def _cirq_i_workaround(unused):
-        return cirq.I
+    def _cirq_i_workaround(unused, control_qubits, control_values):
+        return _optional_control_promote(cirq.I, control_qubits, control_values)
 
     return cirq.google.GateOpDeserializer(serialized_gate_id="I",
                                           gate_constructor=_cirq_i_workaround,
@@ -274,7 +366,14 @@ def _phased_eigen_gate_serializer(gate_type, serialized_id):
         cirq.google.SerializingArg(
             serialized_name="global_shift",
             serialized_type=float,
-            op_getter=lambda x: float(x.gate.global_shift))
+            op_getter=lambda x: float(x.gate.global_shift)),
+        cirq.google.SerializingArg(serialized_name="control_qubits",
+                                   serialized_type=str,
+                                   op_getter=lambda x: _serialize_controls(x)),
+        cirq.google.SerializingArg(
+            serialized_name="control_values",
+            serialized_type=str,
+            op_getter=lambda x: _serialize_control_vals(x))
     ]
     return cirq.google.GateOpSerializer(gate_type=gate_type,
                                         serialized_gate_id=serialized_id,
@@ -286,7 +385,8 @@ def _phased_eigen_gate_deserializer(gate_type, serialized_id):
     """Make a standard deserializer for phased eigen gates."""
 
     def _scalar_combiner(exponent, global_shift, exponent_scalar,
-                         phase_exponent, phase_exponent_scalar):
+                         phase_exponent, phase_exponent_scalar, control_qubits,
+                         control_values):
         """This is a workaround to support symbol scalar multiplication.
         In the future we should likely get rid of this in favor of proper
         expression parsing once cirq supports it. See cirq.op_serializer
@@ -302,10 +402,14 @@ def _phased_eigen_gate_deserializer(gate_type, serialized_id):
         if global_shift != 0:
             # needed in case this specific phasedeigengate doesn't
             # have a global_phase in constructor.
-            return gate_type(exponent=exponent,
-                             global_shift=_round(global_shift),
-                             phase_exponent=phase_exponent)
-        return gate_type(exponent=exponent, phase_exponent=phase_exponent)
+            return _optional_control_promote(
+                gate_type(exponent=exponent,
+                          global_shift=_round(global_shift),
+                          phase_exponent=phase_exponent), control_qubits,
+                control_values)
+        return _optional_control_promote(
+            gate_type(exponent=exponent, phase_exponent=phase_exponent),
+            control_qubits, control_values)
 
     args = [
         cirq.google.DeserializingArg(serialized_name="phase_exponent",
@@ -319,6 +423,10 @@ def _phased_eigen_gate_deserializer(gate_type, serialized_id):
                                      constructor_arg_name="exponent_scalar"),
         cirq.google.DeserializingArg(serialized_name="global_shift",
                                      constructor_arg_name="global_shift"),
+        cirq.google.DeserializingArg(serialized_name="control_qubits",
+                                     constructor_arg_name="control_qubits"),
+        cirq.google.DeserializingArg(serialized_name="control_values",
+                                     constructor_arg_name="control_values")
     ]
     return cirq.google.GateOpDeserializer(serialized_gate_id=serialized_id,
                                           gate_constructor=_scalar_combiner,
@@ -433,6 +541,20 @@ def serialize_circuit(circuit_inp):
             filter(lambda x: not any(y in measured_qubits for y in x.qubits),
                    old_moment.operations))
         circuit[moment_ind] = new_moment
+
+    # Demote cirq.controlled_operations (controlled gates) to their sub_gate
+    # types with _tfq_control_qubits and _tfq_control_values fields so that
+    # the gates can still get picked up by the serializer. There would be no way
+    # to discern controlledgates from one another otherwise.
+    for i, moment in enumerate(circuit):
+        for op in moment:
+            if isinstance(op,
+                          cirq.ops.controlled_operation.ControlledOperation):
+                tfq_compatible = op.sub_operation
+                tfq_compatible._tfq_control_qubits = op.controls
+                tfq_compatible._tfq_control_values = op.control_values
+                dropped_moment = moment.without_operations_touching(op.qubits)
+                circuit[i] = dropped_moment.with_operation(tfq_compatible)
 
     return SERIALIZER.serialize(circuit)
 

--- a/tensorflow_quantum/core/serialize/serializer_test.py
+++ b/tensorflow_quantum/core/serialize/serializer_test.py
@@ -579,6 +579,15 @@ class SerializerTest(tf.test.TestCase, parameterized.TestCase):
         with self.assertRaises(ValueError):
             serializer.serialize_circuit(unsupported_circuit2)
 
+    def test_serialize_controlled_circuit_unsupported_value(self):
+        """Ensure serializing invalid controlled gates fails gracefully."""
+        qubits = cirq.GridQubit.rect(1, 2)
+        bad_qubit = cirq.LineQubit(5)
+        simple_circuit = cirq.Circuit(
+            cirq.H(qubits[0]).controlled_by(qubits[1], bad_qubit))
+        with self.assertRaises(ValueError):
+            serializer.serialize_circuit(simple_circuit)
+
     @parameterized.parameters([{'inp': v} for v in ['wrong', 1.0, None, []]])
     def test_serialize_circuit_wrong_type(self, inp):
         """Attempt to serialize invalid objects types."""
@@ -701,23 +710,6 @@ class SerializerTest(tf.test.TestCase, parameterized.TestCase):
             paulisum_with_identity,
             serializer.deserialize_paulisum(
                 serializer.serialize_paulisum(paulisum_with_identity)))
-
-    # def test_controlled_operations(self):
-    #   qubits = cirq.GridQubit.rect(1, 3)
-    #   simple_circuit = cirq.Circuit(cirq.HPowGate(exponent=0.3)(qubits[0]))
-
-    #   # print(simple_circuit)
-    #   # print(serializer.serialize_circuit(simple_circuit))
-    #   xx= _build_gate_proto("HP",
-    #                        ['exponent', 'exponent_scalar', 'global_shift'],
-    #                        [0.3, 1.0, 0.0], ['0_0'])
-    #   rr = _make_controlled_gate_proto(xx, '0_5', '1')
-
-    #   new_circuit = _make_controlled_circuits(
-    #     simple_circuit, [cirq.GridQubit(0, 5)], [1])
-
-    #   rq = serializer.serialize_circuit(new_circuit)
-    #   self.assertProtoEquals(rq, rr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses step 2 in #422 .

The final step is to link these gates into the new qsim simulator. Right now most of the C++ code still ignore `control_qubits` and `control_values` proto fields.

With the help of the `DelayedAssignmentGate` this change adds the `control_qubits` and `control_values` field to every gates [args](https://github.com/quantumlib/Cirq/blob/master/cirq/google/api/v2/program.proto#L110) field. Updates all previous tests to use controlled operations as well and added a test for invalid `control_qubits`. Plz review closely, I'm always a little concerned when touching code in `serializer.py` since it's used so widely.