### PR TITLE
Misclassified fashion-MNIST dataset image level.

### DIFF
--- a/docs/tutorials/quantum_data.ipynb
+++ b/docs/tutorials/quantum_data.ipynb
@@ -174,7 +174,7 @@
     "id": "jq3eeFv2PyQz"
    },
    "source": [
-    "Filter the dataset to keep just the shirts and dresses, remove the other classes. At the same time convert the label, `y`, to boolean: True for 0 and False for 3."
+    "Filter the dataset to keep just the T-shirts/tops and dresses, remove the other classes. At the same time convert the label, `y`, to boolean: True for 0 and False for 3."
    ]
   },
   {


### PR DESCRIPTION
In fashion-MNIST dataset level 0 = T-shirt/top and level 3 = dress but mistakenly they mention level 0 = shirt (actually, shirt = level 6), this text doesn't match with below code. So, I change this text according to the code.
After modification it looks -

![Screenshot (242)](https://user-images.githubusercontent.com/61170452/102613268-32caa180-4158-11eb-8fd3-774881cdf9bb.png)

**Reference-** 
https://github.com/zalandoresearch/fashion-mnist#labels