### PR TITLE
Adds support for resolving qubit ids in controlled gates

### DIFF
--- a/tensorflow_quantum/core/src/program_resolution.cc
+++ b/tensorflow_quantum/core/src/program_resolution.cc
@@ -247,8 +247,7 @@ Status ResolveQubitIds(Program* program, unsigned int* num_qubits,
                                                ->at("control_qubits")
                                                .arg_value()
                                                .string_value();
-        if (control_qubits ==
-            "") {  // explicit empty value set in serializer.py.
+        if (control_qubits == "") {  // explicit empty value.
           continue;
         }
         std::vector<absl::string_view> control_ids =

--- a/tensorflow_quantum/core/src/program_resolution.cc
+++ b/tensorflow_quantum/core/src/program_resolution.cc
@@ -50,7 +50,7 @@ Status RegisterQubits(
   }
 
   const std::vector<absl::string_view> qb_list = absl::StrSplit(qb_string, ',');
-  for (const auto qb : qb_list) {
+  for (auto qb : qb_list) {
     int r, c;
     const std::vector<absl::string_view> splits = absl::StrSplit(qb, '_');
     if (splits.size() != 2) {
@@ -66,7 +66,7 @@ Status RegisterQubits(
                     absl::StrCat("Unable to parse qubit: ", qb));
     }
     auto locs = std::pair<std::pair<int, int>, std::string>(
-        std::pair<int, int>(r, c), qb);
+        std::pair<int, int>(r, c), std::string(qb));
     id_set->insert(locs);
   }
   return Status::OK();

--- a/tensorflow_quantum/core/src/program_resolution.cc
+++ b/tensorflow_quantum/core/src/program_resolution.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "cirq/google/api/v2/program.pb.h"
 #include "tensorflow/core/lib/core/error_codes.pb.h"
@@ -39,6 +40,38 @@ using tfq::proto::PauliQubitPair;
 using tfq::proto::PauliSum;
 using tfq::proto::PauliTerm;
 
+Status RegisterQubits(
+    const std::string& qb_string,
+    absl::flat_hash_set<std::pair<std::pair<int, int>, std::string>>* id_set) {
+  // Inserts qubits found in qb_string into id_set.
+
+  if (qb_string == "") {
+    return Status::OK();  // no control-default value specified in serializer.py
+  }
+
+  const std::vector<absl::string_view> qb_list = absl::StrSplit(qb_string, ',');
+  for (const auto qb : qb_list) {
+    int r, c;
+    const std::vector<absl::string_view> splits = absl::StrSplit(qb, '_');
+    if (splits.size() != 2) {
+      return Status(tensorflow::error::INVALID_ARGUMENT,
+                    absl::StrCat("Unable to parse qubit: ", qb));
+    }
+    if (!absl::SimpleAtoi(splits[0], &r)) {
+      return Status(tensorflow::error::INVALID_ARGUMENT,
+                    absl::StrCat("Unable to parse qubit: ", qb));
+    }
+    if (!absl::SimpleAtoi(splits[1], &c)) {
+      return Status(tensorflow::error::INVALID_ARGUMENT,
+                    absl::StrCat("Unable to parse qubit: ", qb));
+    }
+    auto locs = std::pair<std::pair<int, int>, std::string>(
+        std::pair<int, int>(r, c), qb);
+    id_set->insert(locs);
+  }
+  return Status::OK();
+}
+
 Status ResolveQubitIds(Program* program, unsigned int* num_qubits,
                        std::vector<PauliSum>* p_sums /*=nullptr*/) {
   if (program->circuit().moments().empty()) {
@@ -51,24 +84,18 @@ Status ResolveQubitIds(Program* program, unsigned int* num_qubits,
   absl::flat_hash_set<std::pair<std::pair<int, int>, std::string>> id_set;
   for (const Moment& moment : program->circuit().moments()) {
     for (const Operation& operation : moment.operations()) {
+      Status s;
       for (const Qubit& qubit : operation.qubits()) {
-        int r, c;
-        const std::vector<std::string> splits = absl::StrSplit(qubit.id(), "_");
-        if (splits.size() != 2) {
-          return Status(tensorflow::error::INVALID_ARGUMENT,
-                        "Unable to parse qubit: " + qubit.id());
+        s = RegisterQubits(qubit.id(), &id_set);
+        if (!s.ok()) {
+          return s;
         }
-        if (!absl::SimpleAtoi(splits[0], &r)) {
-          return Status(tensorflow::error::INVALID_ARGUMENT,
-                        "Unable to parse qubit: " + qubit.id());
-        }
-        if (!absl::SimpleAtoi(splits[1], &c)) {
-          return Status(tensorflow::error::INVALID_ARGUMENT,
-                        "Unable to parse qubit: " + qubit.id());
-        }
-        auto locs = std::pair<std::pair<int, int>, std::string>(
-            std::pair<int, int>(r, c), qubit.id());
-        id_set.insert(locs);
+      }
+      s = RegisterQubits(
+          operation.args().at("control_qubits").arg_value().string_value(),
+          &id_set);
+      if (!s.ok()) {
+        return s;
       }
     }
   }
@@ -87,9 +114,27 @@ Status ResolveQubitIds(Program* program, unsigned int* num_qubits,
   // Replace the Program Qubit ids with the indices.
   for (Moment& moment : *program->mutable_circuit()->mutable_moments()) {
     for (Operation& operation : *moment.mutable_operations()) {
+      // Resolve qubit ids.
       for (Qubit& qubit : *operation.mutable_qubits()) {
         qubit.set_id(id_to_index.at(qubit.id()));
       }
+      // Resolve control qubit ids found in the control_qubits arg.
+      absl::string_view control_qubits =
+          operation.args().at("control_qubits").arg_value().string_value();
+      if (control_qubits == "") {  // explicit empty value set in serializer.py.
+        continue;
+      }
+      std::vector<absl::string_view> control_ids =
+          absl::StrSplit(control_qubits, ',');
+      std::vector<std::string> control_indexs;
+      control_indexs.reserve(control_ids.size());
+      for (auto id : control_ids) {
+        control_indexs.push_back(id_to_index.at(id));
+      }
+      operation.mutable_args()
+          ->at("control_qubits")
+          .mutable_arg_value()
+          ->set_string_value(absl::StrJoin(control_indexs, ","));
     }
   }
 
@@ -125,24 +170,18 @@ Status ResolveQubitIds(Program* program, unsigned int* num_qubits,
   absl::flat_hash_set<std::pair<std::pair<int, int>, std::string>> id_set;
   for (const Moment& moment : program->circuit().moments()) {
     for (const Operation& operation : moment.operations()) {
+      Status s;
       for (const Qubit& qubit : operation.qubits()) {
-        int r, c;
-        const std::vector<std::string> splits = absl::StrSplit(qubit.id(), "_");
-        if (splits.size() != 2) {
-          return Status(tensorflow::error::INVALID_ARGUMENT,
-                        "Unable to parse qubit: " + qubit.id());
+        s = RegisterQubits(qubit.id(), &id_set);
+        if (!s.ok()) {
+          return s;
         }
-        if (!absl::SimpleAtoi(splits[0], &r)) {
-          return Status(tensorflow::error::INVALID_ARGUMENT,
-                        "Unable to parse qubit: " + qubit.id());
-        }
-        if (!absl::SimpleAtoi(splits[1], &c)) {
-          return Status(tensorflow::error::INVALID_ARGUMENT,
-                        "Unable to parse qubit: " + qubit.id());
-        }
-        auto locs = std::pair<std::pair<int, int>, std::string>(
-            std::pair<int, int>(r, c), qubit.id());
-        id_set.insert(locs);
+      }
+      s = RegisterQubits(
+          operation.args().at("control_qubits").arg_value().string_value(),
+          &id_set);
+      if (!s.ok()) {
+        return s;
       }
     }
   }
@@ -166,6 +205,23 @@ Status ResolveQubitIds(Program* program, unsigned int* num_qubits,
       for (Qubit& qubit : *operation.mutable_qubits()) {
         qubit.set_id(id_to_index.at(qubit.id()));
       }
+      // Resolve control qubit ids found in the control_qubits arg.
+      absl::string_view control_qubits =
+          operation.args().at("control_qubits").arg_value().string_value();
+      if (control_qubits == "") {  // explicit empty value set in serializer.py.
+        continue;
+      }
+      std::vector<absl::string_view> control_ids =
+          absl::StrSplit(control_qubits, ',');
+      std::vector<std::string> control_indexs;
+      control_indexs.reserve(control_ids.size());
+      for (auto id : control_ids) {
+        control_indexs.push_back(id_to_index.at(id));
+      }
+      operation.mutable_args()
+          ->at("control_qubits")
+          .mutable_arg_value()
+          ->set_string_value(absl::StrJoin(control_indexs, ","));
     }
   }
 
@@ -175,6 +231,7 @@ Status ResolveQubitIds(Program* program, unsigned int* num_qubits,
     for (Moment& moment :
          *(other_programs->at(i)).mutable_circuit()->mutable_moments()) {
       for (Operation& operation : *moment.mutable_operations()) {
+        // Resolve qubit ids.
         for (Qubit& qubit : *operation.mutable_qubits()) {
           visited_qubits.erase(qubit.id());
           const auto result = id_to_index.find(qubit.id());
@@ -185,6 +242,33 @@ Status ResolveQubitIds(Program* program, unsigned int* num_qubits,
           }
           qubit.set_id(result->second);
         }
+        // Resolve control qubit ids.
+        absl::string_view control_qubits = operation.mutable_args()
+                                               ->at("control_qubits")
+                                               .arg_value()
+                                               .string_value();
+        if (control_qubits ==
+            "") {  // explicit empty value set in serializer.py.
+          continue;
+        }
+        std::vector<absl::string_view> control_ids =
+            absl::StrSplit(control_qubits, ',');
+        std::vector<std::string> control_indexs;
+        control_indexs.reserve(control_ids.size());
+        for (auto id : control_ids) {
+          visited_qubits.erase(id);
+          const auto result = id_to_index.find(id);
+          if (result == id_to_index.end()) {
+            return Status(tensorflow::error::INVALID_ARGUMENT,
+                          "A paired circuit contains qubits not found in "
+                          "reference circuit.");
+          }
+          control_indexs.push_back(result->second);
+        }
+        operation.mutable_args()
+            ->at("control_qubits")
+            .mutable_arg_value()
+            ->set_string_value(absl::StrJoin(control_indexs, ","));
       }
     }
     if (!visited_qubits.empty()) {

--- a/tensorflow_quantum/core/src/program_resolution_test.cc
+++ b/tensorflow_quantum/core/src/program_resolution_test.cc
@@ -16,7 +16,6 @@ limitations under the License.
 #include "tensorflow_quantum/core/src/program_resolution.h"
 
 #include <google/protobuf/text_format.h>
-
 #include <string>
 
 #include "absl/container/flat_hash_map.h"
@@ -28,437 +27,370 @@ namespace tfq {
 namespace {
 
 using cirq::google::api::v2::Program;
+using tensorflow::Status;
+using tfq::proto::PauliSum;
 
-TEST(ProgramResolutionTest, ResolveQubitIdsInvalidArg) {
-  const std::string text = R"(
-    circuit {
-      moments {
-        operations {
-          qubits {
-            id: "0_0"
+const std::string valid_program = R"(
+  circuit {
+    moments {
+      operations {
+        args {
+          key: "control_qubits"
+          value {
+            arg_value {
+              string_value: "0_0"
+            }
           }
-          qubits {
-            id: "1_0"
+        }
+        qubits {
+          id: "0_1"
+        }
+        qubits {
+          id: "0_2"
+        }
+      }
+    }
+  }
+)";
+
+const std::string valid_psum = R"(
+  terms {
+    coefficient_real: 1.0
+    coefficient_imag: 0.0
+    paulis {
+      qubit_id: "0_0"
+      pauli_type: "X"
+    }
+  }
+  terms {
+    coefficient_real: 5.0
+    coefficient_imag: 0.0
+    paulis {
+      qubit_id: "0_2"
+      pauli_type: "Y"
+    }
+    paulis {
+      qubit_id: "0_1"
+      pauli_type: "Z"
+    }
+  }
+)";
+
+const std::string valid_symbol_program = R"(
+  circuit {
+    scheduling_strategy: MOMENT_BY_MOMENT
+    moments {
+      operations {
+        args {
+          key: "exponent"
+          value {
+            symbol: "v1"
           }
         }
       }
     }
-  )";
-
-  const std::string bad_text = R"(
-    circuit {
-      moments {
-        operations {
-          qubits {
-            id: "0_0"
-          }
-          qubits {
-            id: "1_junk"
+    moments {
+      operations {
+        args {
+          key: "exponent"
+          value {
+            symbol: "v2"
           }
         }
       }
     }
-  )";
+  }
+)";
 
-  const std::string bad_text2 = R"(
-    circuit {
-      moments {
-        operations {
-          qubits {
-            id: "0_0"
-          }
-          qubits {
-            id: "junk_1"
-          }
-        }
-      }
-    }
-  )";
-
-  const std::string bad_text3 = R"(
-    circuit {
-      moments {
-        operations {
-          qubits {
-            id: "0_0"
-          }
-          qubits {
-            id: "1_2_3"
-          }
-        }
-      }
-    }
-  )";
-
-  const std::string text_good_p_sum = R"(
-    terms {
-      coefficient_real: 1.0
-      coefficient_imag: 0.0
-      paulis {
-        qubit_id: "0_0"
-        pauli_type: "Z"
-      }
-    }
-  )";
-
-  const std::string text_bad_p_sum = R"(
-    terms {
-      coefficient_real: 1.0
-      coefficient_imag: 0.0
-      paulis {
-        qubit_id: "0_1"
-        pauli_type: "X"
-      }
-    }
-  )";
-
-  std::vector<tfq::proto::PauliSum> p_sums;
-  tfq::proto::PauliSum p_sum_good, p_sum_bad;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(text_good_p_sum,
-                                                            &p_sum_good));
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(text_bad_p_sum,
-                                                            &p_sum_bad));
-  p_sums.push_back(p_sum_good);
-  p_sums.push_back(p_sum_bad);
-
+TEST(ProgramResolutionTest, ResolveQubitIdsValid) {
   Program program;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(text, &program));
+  unsigned int qubit_count;
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &program));
 
-  unsigned int num_qubits;
-  EXPECT_EQ(ResolveQubitIds(&program, &num_qubits, &p_sums),
+  EXPECT_EQ(ResolveQubitIds(&program, &qubit_count), Status::OK());
+  EXPECT_EQ(qubit_count, 3);
+  EXPECT_EQ(program.circuit().moments(0).operations(0).qubits(0).id(), "1");
+  EXPECT_EQ(program.circuit().moments(0).operations(0).qubits(1).id(), "2");
+  EXPECT_EQ(program.circuit()
+                .moments(0)
+                .operations(0)
+                .args()
+                .at("control_qubits")
+                .arg_value()
+                .string_value(),
+            "0");
+}
+
+TEST(ProgramResolutionTest, ResolveQubitIdsInvalidControlQubit) {
+  Program program;
+  unsigned int qubit_count;
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &program));
+
+  program.mutable_circuit()
+      ->mutable_moments(0)
+      ->mutable_operations(0)
+      ->mutable_args()
+      ->at("control_qubits")
+      .mutable_arg_value()
+      ->set_string_value("junk");
+  EXPECT_EQ(ResolveQubitIds(&program, &qubit_count),
+            tensorflow::Status(tensorflow::error::INVALID_ARGUMENT,
+                               "Unable to parse qubit: junk"));
+}
+
+TEST(ProgramResolutionTest, ResolveQubitIdsInvalidQubit) {
+  Program program;
+  unsigned int qubit_count;
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &program));
+
+  program.mutable_circuit()
+      ->mutable_moments(0)
+      ->mutable_operations(0)
+      ->mutable_qubits(0)
+      ->set_id("junk");
+  EXPECT_EQ(ResolveQubitIds(&program, &qubit_count),
+            tensorflow::Status(tensorflow::error::INVALID_ARGUMENT,
+                               "Unable to parse qubit: junk"));
+}
+
+TEST(ProgramResolutionTest, ResolveQubitIdsWithPauliSum) {
+  Program program;
+  unsigned int qubit_count;
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &program));
+
+  PauliSum p_sum;
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_psum, &p_sum));
+  std::vector<PauliSum> p_sums = {p_sum, p_sum};
+
+  EXPECT_EQ(ResolveQubitIds(&program, &qubit_count, &p_sums), Status::OK());
+  EXPECT_EQ(qubit_count, 3);
+  EXPECT_EQ(program.circuit().moments(0).operations(0).qubits(0).id(), "1");
+  EXPECT_EQ(program.circuit().moments(0).operations(0).qubits(1).id(), "2");
+  EXPECT_EQ(program.circuit()
+                .moments(0)
+                .operations(0)
+                .args()
+                .at("control_qubits")
+                .arg_value()
+                .string_value(),
+            "0");
+
+  for (int i = 0; i < 2; i++) {
+    EXPECT_EQ(p_sums[i].terms(0).paulis(0).qubit_id(), "0");
+    EXPECT_EQ(p_sums[i].terms(1).paulis(0).qubit_id(), "2");
+    EXPECT_EQ(p_sums[i].terms(1).paulis(1).qubit_id(), "1");
+  }
+}
+
+TEST(ProgramResolutionTest, ResolveQubitIdsWithInvalidPauliSum) {
+  Program program;
+  unsigned int qubit_count;
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &program));
+
+  PauliSum p_sum;
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_psum, &p_sum));
+  p_sum.mutable_terms(0)->mutable_paulis(0)->set_qubit_id("1_1");
+  std::vector<PauliSum> p_sums = {p_sum, p_sum};
+
+  EXPECT_EQ(ResolveQubitIds(&program, &qubit_count, &p_sums),
             tensorflow::Status(
                 tensorflow::error::INVALID_ARGUMENT,
                 "Found a Pauli sum operating on qubits not found in circuit."));
-
-  ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(bad_text, &program));
-  EXPECT_EQ(ResolveQubitIds(&program, &num_qubits, &p_sums),
-            tensorflow::Status(tensorflow::error::INVALID_ARGUMENT,
-                               "Unable to parse qubit: 1_junk"));
-
-  ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(bad_text2, &program));
-  EXPECT_EQ(ResolveQubitIds(&program, &num_qubits, &p_sums),
-            tensorflow::Status(tensorflow::error::INVALID_ARGUMENT,
-                               "Unable to parse qubit: junk_1"));
-
-  ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(bad_text3, &program));
-  EXPECT_EQ(ResolveQubitIds(&program, &num_qubits, &p_sums),
-            tensorflow::Status(tensorflow::error::INVALID_ARGUMENT,
-                               "Unable to parse qubit: 1_2_3"));
 }
 
-TEST(ProgramResolutionTest, ResolveQubitIds) {
-  const std::string text = R"(
-    circuit {
-      moments {
-        operations {
-          qubits {
-            id: "0_0"
-          }
-          qubits {
-            id: "1_0"
-          }
-        }
-      }
-      moments {
-        operations {
-          qubits {
-            id: "0_0"
-          }
-          qubits {
-            id: "0_1"
-          }
-        }
-      }
-    }
-  )";
-
-  const std::string text_p_sum_0 = R"(
-    terms {
-      coefficient_real: 1.0
-      coefficient_imag: 0.0
-      paulis {
-        qubit_id: "0_0"
-        pauli_type: "Z"
-      }
-    }
-  )";
-
-  const std::string text_p_sum_1 = R"(
-    terms {
-      coefficient_real: 1.0
-      coefficient_imag: 0.0
-      paulis {
-        qubit_id: "1_0"
-        pauli_type: "X"
-      }
-    }
-  )";
-
-  const std::string text_alphabet = R"(
-    circuit {
-      moments {
-        operations {
-          qubits {
-            id: "0_0"
-          }
-          qubits {
-            id: "0_1"
-          }
-        }
-      }
-      moments {
-        operations {
-          qubits {
-            id: "0_2"
-          }
-          qubits {
-            id: "0_3"
-          }
-        }
-      }
-    }
-  )";
-
-  const std::string text_alphabet_p_sum_0 = R"(
-    terms {
-      coefficient_real: 1.0
-      coefficient_imag: 0.0
-      paulis {
-        qubit_id: "0_1"
-        pauli_type: "Z"
-      }
-    }
-  )";
-
-  const std::string text_alphabet_p_sum_1 = R"(
-    terms {
-      coefficient_real: 1.0
-      coefficient_imag: 0.0
-      paulis {
-        qubit_id: "0_0"
-        pauli_type: "X"
-      }
-    }
-  )";
-
-  const std::string text_empty = R"(
-    circuit {
-    }
-  )";
-
-  std::vector<tfq::proto::PauliSum> p_sums, p_sums_alphabet;
-  tfq::proto::PauliSum p_sum_0, p_sum_1;
+TEST(ProgramResolutionTest, ResolveQubitIdsMultiProgram) {
+  Program program, other;
+  unsigned int qubit_count;
   ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(text_p_sum_0, &p_sum_0));
+      google::protobuf::TextFormat::ParseFromString(valid_program, &program));
   ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(text_p_sum_1, &p_sum_1));
-  p_sums.push_back(p_sum_0);
-  p_sums.push_back(p_sum_1);
-  tfq::proto::PauliSum alphabet_p_sum_0, alphabet_p_sum_1;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      text_alphabet_p_sum_0, &alphabet_p_sum_0));
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      text_alphabet_p_sum_1, &alphabet_p_sum_1));
-  p_sums_alphabet.push_back(alphabet_p_sum_0);
-  p_sums_alphabet.push_back(alphabet_p_sum_1);
+      google::protobuf::TextFormat::ParseFromString(valid_program, &other));
 
-  Program program, empty_program, alphabet_program;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(text, &program));
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(text_empty,
-                                                            &empty_program));
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(text_alphabet,
-                                                            &alphabet_program));
+  // Re-arrange qubits on other.
+  other.mutable_circuit()
+      ->mutable_moments(0)
+      ->mutable_operations(0)
+      ->mutable_qubits(1)
+      ->set_id("0_0");  // turn 0_2 -> 0_0!
+  other.mutable_circuit()
+      ->mutable_moments(0)
+      ->mutable_operations(0)
+      ->mutable_args()
+      ->at("control_qubits")
+      .mutable_arg_value()
+      ->set_string_value("0_2");  // turn 0_0 -> 0_2!
 
-  unsigned int num_qubits, num_qubits_empty, num_qubits_alphabet;
-  EXPECT_TRUE(ResolveQubitIds(&program, &num_qubits, &p_sums).ok());
-  EXPECT_TRUE(ResolveQubitIds(&empty_program, &num_qubits_empty).ok());
-  EXPECT_TRUE(
-      ResolveQubitIds(&alphabet_program, &num_qubits_alphabet, &p_sums_alphabet)
-          .ok());
-
-  EXPECT_EQ(program.circuit().moments(0).operations(0).qubits(0).id(), "0");
+  std::vector<Program> other_programs = {other, other};
+  EXPECT_EQ(ResolveQubitIds(&program, &qubit_count, &other_programs),
+            Status::OK());
+  EXPECT_EQ(qubit_count, 3);
+  EXPECT_EQ(program.circuit().moments(0).operations(0).qubits(0).id(), "1");
   EXPECT_EQ(program.circuit().moments(0).operations(0).qubits(1).id(), "2");
-  EXPECT_EQ(program.circuit().moments(1).operations(0).qubits(0).id(), "0");
-  EXPECT_EQ(program.circuit().moments(1).operations(0).qubits(1).id(), "1");
-
-  EXPECT_EQ(alphabet_program.circuit().moments(0).operations(0).qubits(0).id(),
+  EXPECT_EQ(program.circuit()
+                .moments(0)
+                .operations(0)
+                .args()
+                .at("control_qubits")
+                .arg_value()
+                .string_value(),
             "0");
-  EXPECT_EQ(alphabet_program.circuit().moments(0).operations(0).qubits(1).id(),
-            "1");
-  EXPECT_EQ(alphabet_program.circuit().moments(1).operations(0).qubits(0).id(),
-            "2");
-  EXPECT_EQ(alphabet_program.circuit().moments(1).operations(0).qubits(1).id(),
-            "3");
 
-  EXPECT_EQ(p_sums.at(0).terms(0).paulis(0).qubit_id(), "0");
-  EXPECT_EQ(p_sums.at(1).terms(0).paulis(0).qubit_id(), "2");
-
-  EXPECT_EQ(p_sums_alphabet.at(0).terms(0).paulis(0).qubit_id(), "1");
-  EXPECT_EQ(p_sums_alphabet.at(1).terms(0).paulis(0).qubit_id(), "0");
-
-  EXPECT_EQ(num_qubits, 3);
-  EXPECT_EQ(num_qubits_empty, 0);
-  EXPECT_EQ(num_qubits_alphabet, 4);
+  for (int i = 0; i < 2; i++) {
+    EXPECT_EQ(
+        other_programs[i].circuit().moments(0).operations(0).qubits(0).id(),
+        "1");
+    EXPECT_EQ(
+        other_programs[i].circuit().moments(0).operations(0).qubits(1).id(),
+        "0");
+    EXPECT_EQ(other_programs[i]
+                  .circuit()
+                  .moments(0)
+                  .operations(0)
+                  .args()
+                  .at("control_qubits")
+                  .arg_value()
+                  .string_value(),
+              "2");
+  }
 }
 
-TEST(ProgramResolutionTest, ResolveQubitIdsPrograms) {
-  const std::string text = R"(
-    circuit {
-      moments {
-        operations {
-          qubits {
-            id: "0_0"
-          }
-          qubits {
-            id: "1_0"
-          }
-        }
-      }
-      moments {
-        operations {
-          qubits {
-            id: "0_0"
-          }
-          qubits {
-            id: "0_1"
-          }
-        }
-      }
-    }
-  )";
-
-  const std::string text_alphabet = R"(
-    circuit {
-      moments {
-        operations {
-          qubits {
-            id: "0_0"
-          }
-          qubits {
-            id: "1_0"
-          }
-        }
-      }
-      moments {
-        operations {
-          qubits {
-            id: "0_1"
-          }
-          qubits {
-            id: "0_3"
-          }
-        }
-      }
-    }
-  )";
-
-  const std::string text_empty = R"(
-    circuit {
-    }
-  )";
-
-  Program program, program_copy, empty_program;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(text, &program));
+TEST(ProgramResolutionTest, ResolveQubitIdsMultiProgramInvalid) {
+  Program program, other;
+  unsigned int qubit_count;
   ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(text, &program_copy));
+      google::protobuf::TextFormat::ParseFromString(valid_program, &program));
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &other));
+  program.mutable_circuit()
+      ->mutable_moments(0)
+      ->mutable_operations(0)
+      ->mutable_qubits(0)
+      ->set_id("junk");
+  std::vector<Program> others = {other, other};
+  EXPECT_EQ(ResolveQubitIds(&program, &qubit_count, &others),
+            tensorflow::Status(tensorflow::error::INVALID_ARGUMENT,
+                               "Unable to parse qubit: junk"));
+}
 
-  unsigned int num_qubits, num_qubits_empty;
-  std::vector<Program> vec({program_copy});
-  EXPECT_TRUE(ResolveQubitIds(&program, &num_qubits, &vec).ok());
+TEST(ProgramResolutionTest, ResolveQubitIdsMultiProgramInvalidControl) {
+  Program program, other;
+  unsigned int qubit_count;
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &program));
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &other));
+  program.mutable_circuit()
+      ->mutable_moments(0)
+      ->mutable_operations(0)
+      ->mutable_args()
+      ->at("control_qubits")
+      .mutable_arg_value()
+      ->set_string_value("junk");
+  std::vector<Program> others = {other, other};
+  EXPECT_EQ(ResolveQubitIds(&program, &qubit_count, &others),
+            tensorflow::Status(tensorflow::error::INVALID_ARGUMENT,
+                               "Unable to parse qubit: junk"));
+}
 
-  // Test case where circuits are aligned.
-  EXPECT_EQ(program.circuit().moments(0).operations(0).qubits(0).id(), "0");
-  EXPECT_EQ(program.circuit().moments(0).operations(0).qubits(1).id(), "2");
-  EXPECT_EQ(program.circuit().moments(1).operations(0).qubits(0).id(), "0");
-  EXPECT_EQ(program.circuit().moments(1).operations(0).qubits(1).id(), "1");
-
-  EXPECT_EQ(vec[0].circuit().moments(0).operations(0).qubits(0).id(), "0");
-  EXPECT_EQ(vec[0].circuit().moments(0).operations(0).qubits(1).id(), "2");
-  EXPECT_EQ(vec[0].circuit().moments(1).operations(0).qubits(0).id(), "0");
-  EXPECT_EQ(vec[0].circuit().moments(1).operations(0).qubits(1).id(), "1");
-
-  // Test case where source circuit is smaller than paired circuit:
-  program.Clear();
-  program_copy.Clear();
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(text, &program));
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(text_alphabet,
-                                                            &program_copy));
-
-  std::vector<Program> vec2({program_copy});
-
+TEST(ProgramResolutionTest, ResolveQubitIdsMultiProgramMismatch) {
+  Program program, other;
+  unsigned int qubit_count;
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &program));
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &other));
+  program.mutable_circuit()
+      ->mutable_moments(0)
+      ->mutable_operations(0)
+      ->mutable_qubits(0)
+      ->set_id("0_5");
+  std::vector<Program> others = {other, other};
   EXPECT_EQ(
-      ResolveQubitIds(&program, &num_qubits, &vec2),
+      ResolveQubitIds(&program, &qubit_count, &others),
       tensorflow::Status(
           tensorflow::error::INVALID_ARGUMENT,
           "A paired circuit contains qubits not found in reference circuit."));
+}
 
-  // Test case where paired circuit is smaller than source circuit:
-  program.Clear();
-  program_copy.Clear();
+TEST(ProgramResolutionTest, ResolveQubitIdsMultiProgramMismatchControl) {
+  Program program, other;
+  unsigned int qubit_count;
   ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(text_alphabet, &program));
+      google::protobuf::TextFormat::ParseFromString(valid_program, &program));
   ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(text, &program_copy));
-
-  std::vector<Program> vec3({program_copy});
-
+      google::protobuf::TextFormat::ParseFromString(valid_program, &other));
+  program.mutable_circuit()
+      ->mutable_moments(0)
+      ->mutable_operations(0)
+      ->mutable_args()
+      ->at("control_qubits")
+      .mutable_arg_value()
+      ->set_string_value("0_5");
+  std::vector<Program> others = {other, other};
   EXPECT_EQ(
-      ResolveQubitIds(&program, &num_qubits, &vec3),
+      ResolveQubitIds(&program, &qubit_count, &others),
+      tensorflow::Status(
+          tensorflow::error::INVALID_ARGUMENT,
+          "A paired circuit contains qubits not found in reference circuit."));
+}
+
+TEST(ProgramResolutionTest, ResolveQubitIdsMultiProgramSmaller) {
+  Program program, other;
+  unsigned int qubit_count;
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &program));
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &other));
+  other.mutable_circuit()
+      ->mutable_moments(0)
+      ->mutable_operations(0)
+      ->mutable_qubits(0)
+      ->set_id("0_2");
+  std::vector<Program> others = {other, other};
+  EXPECT_EQ(
+      ResolveQubitIds(&program, &qubit_count, &others),
       tensorflow::Status(
           tensorflow::error::INVALID_ARGUMENT,
           "A reference circuit contains qubits not found in paired circuit."));
-
-  // Ensure empty case is consistent.
-  std::vector<Program> vec4;
-  EXPECT_TRUE(ResolveQubitIds(&empty_program, &num_qubits_empty, &vec4).ok());
-  EXPECT_EQ(num_qubits_empty, 0);
 }
 
-TEST(ProgramResolutionTest, ResolveSymbolsInvalidArg) {
-  const std::string text = R"(
-    circuit {
-      scheduling_strategy: MOMENT_BY_MOMENT
-      moments {
-        operations {
-          args {
-            key: "exponent"
-            value {
-              symbol: "v1"
-            }
-          }
-        }
-      }
-      moments {
-        operations {
-          args {
-            key: "exponent"
-            value {
-              symbol: "v2"
-            }
-          }
-        }
-      }
-    }
-  )";
-
-  // Test with strict replacement
-  Program program_strict;
+TEST(ProgramResolutionTest, ResolveQubitIdsMultiProgramSmallerControl) {
+  Program program, other;
+  unsigned int qubit_count;
   ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(text, &program_strict));
+      google::protobuf::TextFormat::ParseFromString(valid_program, &program));
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(valid_program, &other));
+  other.mutable_circuit()
+      ->mutable_moments(0)
+      ->mutable_operations(0)
+      ->mutable_args()
+      ->at("control_qubits")
+      .mutable_arg_value()
+      ->set_string_value("0_2");
+  std::vector<Program> others = {other, other};
+  EXPECT_EQ(
+      ResolveQubitIds(&program, &qubit_count, &others),
+      tensorflow::Status(
+          tensorflow::error::INVALID_ARGUMENT,
+          "A reference circuit contains qubits not found in paired circuit."));
+}
+
+TEST(ProgramResolutionTest, ResolveSymbolsPartial) {
+  Program symbol_program;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      valid_symbol_program, &symbol_program));
   const absl::flat_hash_map<std::string, std::pair<int, float>> param_map = {
       {"v1", {0, 1.0}}};
-  EXPECT_EQ(ResolveSymbols(param_map, &program_strict, true),
-            tensorflow::Status(tensorflow::error::INVALID_ARGUMENT,
-                               "Could not find symbol in parameter map: v2"));
-
-  // Test with non-strict replacement
-  Program program;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(text, &program));
-  EXPECT_TRUE(ResolveSymbols(param_map, &program, false).ok());
-  EXPECT_EQ(program.circuit()
+  EXPECT_EQ(ResolveSymbols(param_map, &symbol_program, false), Status::OK());
+  EXPECT_EQ(symbol_program.circuit()
                 .moments(0)
                 .operations(0)
                 .args()
@@ -466,9 +398,74 @@ TEST(ProgramResolutionTest, ResolveSymbolsInvalidArg) {
                 .arg_value()
                 .float_value(),
             1.0);
-  EXPECT_EQ(
-      program.circuit().moments(1).operations(0).args().at("exponent").symbol(),
-      "v2");
+  EXPECT_EQ(symbol_program.circuit()
+                .moments(1)
+                .operations(0)
+                .args()
+                .at("exponent")
+                .symbol(),
+            "v2");
+}
+
+TEST(ProgramResolutionTest, ResolveSymbolsFull) {
+  Program symbol_program;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      valid_symbol_program, &symbol_program));
+  const absl::flat_hash_map<std::string, std::pair<int, float>> param_map = {
+      {"v1", {0, 1.0}}, {"v2", {1, 2.0f}}};
+  EXPECT_EQ(ResolveSymbols(param_map, &symbol_program, false), Status::OK());
+  EXPECT_EQ(symbol_program.circuit()
+                .moments(0)
+                .operations(0)
+                .args()
+                .at("exponent")
+                .arg_value()
+                .float_value(),
+            1.0);
+  EXPECT_EQ(symbol_program.circuit()
+                .moments(1)
+                .operations(0)
+                .args()
+                .at("exponent")
+                .arg_value()
+                .float_value(),
+            2.0);
+}
+
+TEST(ProgramResolutionTest, ResolveSymbolsStrictPartial) {
+  Program symbol_program;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      valid_symbol_program, &symbol_program));
+  const absl::flat_hash_map<std::string, std::pair<int, float>> param_map = {
+      {"v1", {0, 1.0}}};
+  EXPECT_EQ(ResolveSymbols(param_map, &symbol_program, true),
+            Status(tensorflow::error::INVALID_ARGUMENT,
+                   "Could not find symbol in parameter map: v2"));
+}
+
+TEST(ProgramResolutionTest, ResolveSymbolsStrictFull) {
+  Program symbol_program;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      valid_symbol_program, &symbol_program));
+  const absl::flat_hash_map<std::string, std::pair<int, float>> param_map = {
+      {"v1", {0, 1.0}}, {"v2", {1, 2.0f}}};
+  EXPECT_EQ(ResolveSymbols(param_map, &symbol_program, true), Status::OK());
+  EXPECT_EQ(symbol_program.circuit()
+                .moments(0)
+                .operations(0)
+                .args()
+                .at("exponent")
+                .arg_value()
+                .float_value(),
+            1.0);
+  EXPECT_EQ(symbol_program.circuit()
+                .moments(1)
+                .operations(0)
+                .args()
+                .at("exponent")
+                .arg_value()
+                .float_value(),
+            2.0);
 }
 
 }  // namespace

--- a/tensorflow_quantum/core/src/program_resolution_test.cc
+++ b/tensorflow_quantum/core/src/program_resolution_test.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tensorflow_quantum/core/src/program_resolution.h"
 
 #include <google/protobuf/text_format.h>
+
 #include <string>
 
 #include "absl/container/flat_hash_map.h"


### PR DESCRIPTION
This is another step on the journey to closing #422 . Now we can resolve qubit ids to their integer values correctly in the `ResolveQubitIDs` functions in the controlled gate case. Next step is to implement changes in `circuit_parser_qsim.cc`.

I also cleaned up the tests so that they are much smaller and each one targets certain behavior more explicitly.