### PR TITLE
Fixed outputs for quantum_data.

### DIFF
--- a/docs/tutorials/quantum_data.ipynb
+++ b/docs/tutorials/quantum_data.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "cellView": "form",
     "colab": {},
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -99,14 +99,24 @@
     "id": "X3Y5vLL9K_Ai",
     "outputId": "60d15a69-5a45-449f-bf63-29a5af8d8ffc"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip.\r\n",
+      "Please see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue.\r\n",
+      "To avoid this problem you can invoke Python with '-m pip' instead of running pip directly.\r\n"
+     ]
+    }
+   ],
    "source": [
     "!pip -q install tensorflow==2.3.1 tensorflow-quantum"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "id": "FTKfetslL5eE"
    },
@@ -149,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -157,7 +167,16 @@
     "id": "VTKmzeH3MBvR",
     "outputId": "cc705254-3db0-4c53-8b4c-e543f69fae31"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of original training examples: 60000\n",
+      "Number of original test examples: 10000\n"
+     ]
+    }
+   ],
    "source": [
     "(x_train, y_train), (x_test, y_test) = tf.keras.datasets.fashion_mnist.load_data()\n",
     "\n",
@@ -179,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "id": "LmprnNbDP4Z6"
    },
@@ -194,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -202,7 +221,16 @@
     "id": "KycvXPllQH-t",
     "outputId": "7dd10133-1fa3-48ba-e7d9-1cf350107c01"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of filtered training examples: 12000\n",
+      "Number of filtered test examples: 2000\n"
+     ]
+    }
+   ],
    "source": [
     "x_train, y_train = filter_03(x_train, y_train)\n",
     "x_test, y_test = filter_03(x_test, y_test)\n",
@@ -213,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -222,7 +250,37 @@
     "id": "c-2Fx9E1O63h",
     "outputId": "a8cc82ef-de3a-44ee-a3d9-14b3d30c9758"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.colorbar.Colorbar at 0x7f6db42c3460>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAS4AAAD8CAYAAADJwUnTAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/d3fzzAAAACXBIWXMAAAsTAAALEwEAmpwYAAAbxUlEQVR4nO3df5Ac9Xnn8fezq139BgSLhCzJgLEoWxAMjg7s4IvlYDuCSowpuzDynQ8n2HJc1lWc+FxHfFfA4boU9gWIr4rgWwcdkLLBXGwHOSebUJxjHBILSZgCCYJRZBEkCwnxS0LS/pp57o8Zmdkf/Xxnd2a3u1efV9WUZvrp7vlqdvbZ7m8//f2auyMiUiYdeTdARGS8lLhEpHSUuESkdJS4RKR0lLhEpHSUuESkdJS4RGTSmNl6M9tvZtsy4mZm/9PMdpjZE2b2zmb2q8QlIpPpTmB1EL8UWF5/rAVub2anSlwiMmnc/WHg5WCVy4G7veanwElmtji13xntamAzum2mz2LuVL7l9DB3dhiesWwgM3b01VnxtkfiOyesmrizIhEempP9t9FOHIq3HYi/nrN+2R/GfSje/3TUx2EGvN9a2cdvv2+uv/Rypal1tz7Rvx3oa1jU6+6943i7JcDzDa9315ftjTZqKXGZ2Wrga0An8JfuflO0/izmcpFd0spbTh5L/KzzvDXq3F8Lwwtu3ZMZ2/b9t4XbLnwsO+kBdPbHX2AbqIbxA++Yk73v33kp3PalXQvC+Nu+/IswXtm3P4xPR5v8oZb38dLLFR594M1Nrdu5+Nk+d1/Z8puO04QTl5l1ArcBH6CWJTeb2QZ3f6pdjRORqedAlfgPUhvtAZY1vF5aXxZqpY/rQmCHu+909wHgXmrnqyJSYo4z6JWmHm2wAfgP9auL7wJec/fwNBFaO1Uc69z0opErmdlaalcLmEX2aYOIFEe7jrjM7B5gFdBjZruB64EuAHf/OrARuAzYARwBfq+Z/U5653y9o64X4AQ7WWPoiBSc41Ta1Kfr7msScQc+N979tpK4JnRuKiLFV01dLs5ZK4lrM7DczM6klrCuAj7ellaJSG4cqEzXxOXuQ2a2DniAWjnEenff3raWjVer5QwtHBpXVsV3KfzLx+KP+b+977thvM/jy/pndL2YGVv4mR+E254/c2YYn0x3vHZaGB98S2cY//QVz4fxR/qzrz199mf/Ltx2yS1dYdweeTyMl910PuLC3TdS61wTkWnCgcGCD+k+pZXzIlJ8jk/fU0URmaYcKsXOW0pcIjJcrXK+2JS4RGQEo0JL92lPOiUuERmm1jmvxCUiJVKr41LimhotXr7t7DkljB+9Z15m7LOnfyfcttvim1F3DfSE8f0DJ4TxbYeXZMaGPK6Fmt0RD2uzfPa+ML574OQwPhi8f7XFv+rX9i0M4z1dr2fGvnjOg+G2J915JIxfv/13w/hpH346jBddqz+byTZ9EpeItIWOuESkdByjUvBR3ZW4RGQUnSqKSKk4xkCibzRvSlwiMkytAFWniiJSMuqcL4kT7o/LKa465ZHM2KZDZ4XbRiUBALM7B8P40Uo8xEqHZbe92+IpuqJtAZ44vCyMz0iUekS6Wti2GfsH5mfGDgxml7dAuo/ny+fcH8Zvu/AjYZxHn4zjOXI3Kq4jLhEpmaqOuESkTGqd88VODcVunYhMOXXOi0gpVVTHJSJlosp5ESmlqq4qikiZ1G6yVuIqhKHf+vUwftkpcV3OY4fPyIzNSQwNM5O4lmph98Ew/oG58RApb+rMrsXqsvgLeKgat21OR1yD1u/xIL/Ru8/v6A63PVKN69t2DsVf3x8cOi9735X4vVPVAH0e19b9/FOzwvjZj8b7z5NjydrDvB03iUtEmuOOClBFpGxMBagiUi6OjrhEpITUOS8ipeKYBhIUkXKpTU9W7NRQ7NaJSA40IWxh7P6tuG7nlBnZU1kBLJiRPV1VquZlVkdcj3RgMHvcKICr/uILYXzuL7NrqeY/1x9u+/qymWF83p54e++Iv+AdA9ltq8yMP7fBE+L4/gvir++Na76ZGdt6+Mxw21RtXuqI5Nb33RPGb+etYTxPzjSvnDezXcAhoAIMufvKdjRKRPJV9COudqTV97n7+UpaItODu1H1jqYezTCz1Wb2jJntMLNrx4i/2cx+ZGY/M7MnzOyy1D6Pm1NFEWlOrXO+Pbf8mFkncBvwAWA3sNnMNrj7Uw2r/VfgPne/3cxWABuBM6L9tnrE5cDfmdlWM1ub0fC1ZrbFzLYMEveXiEgR1Macb+bRhAuBHe6+090HgHuBy0es48AJ9ecnAr9M7bTVI673uPseM1sIPGhm/+zuDw9rkXsv0Atwgp0cz8wgIrmrdc433cfVY2ZbGl731n/nj1kCPN/wejdw0Yh93EDtAOg/AnOB96fetKXE5e576v/uN7PvUcuuD8dbiUjRjaNy/kAb+rfXAHe6+81m9m7gr8zsXPfsoUcmfKpoZnPNbP6x58AHgW0T3Z+IFMOxyvlmHk3YAzTOcbe0vqzRNcB9AO7+T8AsoCfaaStHXIuA75nZsf18y91/2ML+JtXvXLopjB+uxvVMUS1Wf2JcqJ4Zh8L4s0cXhfE3ffUfw/ihj70rM7bvwtnhtotvjve959rfCOM9T8Y1aoM92eNWeWf8xZ/zQlxLdfr18aBWfR/Lfu9UnVZPV/wz++XgSWH8sydtD+Nf//WR3Txv8K3xtlOhjZNlbAaWm9mZ1BLWVcDHR6zzr8AlwJ1m9nZqievFaKcTTlzuvhN4x0S3F5FicofBansSl7sPmdk64AGgE1jv7tvN7EZgi7tvAL4AfMPM/ohaF9sn3T3sD1c5hIgMUztVbF/lvLtvpFbi0LjsuobnTwEXj2efSlwiMkrRK+eVuERkmHGWQ+RCiUtERmjvqeJkUOISkVE05nxB/MnCn4Txv00MczIzKIdY0BVP0ZXyltnhlV+2cUoY/8ktf5EZ21PJHo4H4L1n/1EY/8XvZu8b4DefvCKMP3jOtzNjcxLTk13/4jlh/KfviKcIOxKUuCztfjncNjX92GA1/tW5//CSML73356YGTtta7jppKtdVdT0ZCJSIhq6WURKSaeKIlIquqooIqWkq4oiUiruxpASl4iUjU4VRaRU1Mc1hfzi88P4pv5/DuOpYW26rJIZm2Xx0C6ndb0Wxn925PQwnnLZRz6ZGes4GrftzcviL+hl130wjM+3uE7so/2/nR1MTG326vvPjt+bn4bxh1/J3n7Vyc+E26bGXE/FXxyKp5zre3cwHd6fh5tOCSUuESkV1XGJSCmpjktESsUdhto0kOBkUeISkVF0qigipaI+LhEpJVfiEpGyUef8FNn3xf4wflrnwTC+i1PDeH81e3ymRYk6rf1DJ4TxI5V4XKqhS94Zxo+emt22oyfHnazBfwuAw6edFcaDYcoAmNGXPVlLpTv+5eg/KY73/cG7w/hvzPtxZmz/YPwzOXvW3jDeSTwp+4mdh8P41W/Pni7vx8RTyk02d/VxiUjpGBVdVRSRslEfl4iUiu5VFJHy8Vo/V5EpcYnIKLqqKCKl4uqcF5Ey0qniFBl6dEEY/0rPpWH8Yws3h/Hl3fszY8s643kV//dr54bx/sQcfRvv/noYH/TsscIGPW5bXyI+y+K/vHM64kKwDrK37/e4CKzL4jGvdg7G269/+eLM2JKZr4TbpsZY67KhMP7jV98Wxh954LzM2On8Y7jtVCj6VcXk8aCZrTez/Wa2rWHZyWb2oJk9W/83zhoiUhrutcTVzCMvzZzI3gmsHrHsWuAhd18OPFR/LSLTRNWtqUdekonL3R8GRs5XfjlwV/35XcCH29ssEcmTe3OPvEy0j2uRux+7mesFYFHWima2FlgLMIs5E3w7EZkqjlEt+FXFllvn7g7Zd5y6e6+7r3T3lV3EE1KISDF4k4+8TDRx7TOzxQD1f7MvuYlIubS5c97MVpvZM2a2w8zG7A83syvN7Ckz225m30rtc6KJawNwdf351cD9E9yPiBRRmw65zKwTuA24FFgBrDGzFSPWWQ78CXCxu58DfD6132Qfl5ndA6wCesxsN3A9cBNwn5ldAzwHXJn+L0yupX8a17689qfx9utPi8d2OnresszYC2v7wm1vOO/7YXz7628K4ze/FNeBPXtkYWZsbudAuO3M1IBak6jD4m9+NJclwEuDc8P4W+dknwjcteNd4bYLL4/n4UwL5k2kGLVakTaWOlwI7HD3nQBmdi+1i3tPNazzaeA2d3+l9t6ePINLJi53X5MRuiS1rYiUjwPVatOJq8fMtjS87nX33obXS4DnG17vBi4asY+zAczsEaATuMHdfxi96bSpnBeRNnGg+SOuA+6+ssV3nAEsp3ZmtxR42Mx+zd1fzdqg2Nc8RSQXbazj2gM09rMsrS9rtBvY4O6D7v4L4OfUElkmJS4RGa199RCbgeVmdqaZdQNXUbu41+hvqB1tYWY91E4dd0Y71amiiIzQvvsQ3X3IzNYBD1Drv1rv7tvN7EZgi7tvqMc+aGZPARXgi+7+UrRfJS4RGa2N1aXuvhHYOGLZdQ3PHfjj+qMpSlx1Qy/sC+NdQXzJ0QvCbWetj0sOUqNNnjjjSBhfPDN7erSZHfHwK4MeDx2T0mnxsDgdwW9A6r17ug6F8YND8TRep87I3r7/0ZPDbY9rDt78VcVcKHGJyBiUuESkbDQCqoiUjhKXiJTK+ApQc6HEJSKjaLIMESkfXVUUkbJJDNyRu+MncVn8F6RjZjw6a7UvGLomcVy9cyB72BmA7hZrrSot3LmVqsOqeHHvCmtlSJ6g9K0pNiP+1fFKPCRPoc/F8h7etAnHT+ISkSaZOudFpIR0xCUipRP3IOROiUtEhlMdl4iUka4qikj5FDxxFfdat4hIhuPniCtRN1Pt75/wrru2/SKM7ziyKIzP7ozrkV4ZiqfhiqTG+orGy4LacJStiOrEUvVpqf/3vBkT/5l1H2zxkKIzMY7ZUFybV3Q6VRSRcnF0y4+IlJCOuESkbHSqKCLlo8QlIqWjxCUiZWKuU0URKSNdVSwHS9TleFCXUzn4erjtwUQ90kldR8P4kUp3GJ/TOZAZS9Vppeq8Wpk3EaDLsivBKhbXP78yNCeML+6OB9XqCO4UtkrBDylyVvQjrmTlvJmtN7P9ZratYdkNZrbHzB6vPy6b3GaKyJTyJh85aeaWnzuB1WMsv9Xdz68/No4RF5Ey8jf6uVKPvCQTl7s/DLw8BW0RkaKYBkdcWdaZ2RP1U8kFWSuZ2Voz22JmWwaZ+L1lIjJ1rNrcIy8TTVy3A2cB5wN7gZuzVnT3Xndf6e4ru4gnpBARacaEEpe773P3irtXgW8AF7a3WSKSq+l4qmhmixteXgFsy1pXREqmBJ3zyTouM7sHWAX0mNlu4HpglZmdTy3n7gI+M3lNnBpebeGnUI1HrRqoxh9zNTF3YTUx/ndUK5UyWO0K47NamLsQoCPoCEm1O/X/To3n1R3sv+X+mVa+L2VQ8P9eMnG5+5oxFt8xCW0RkaIoe+ISkeOLke8Vw2ZozHkRGa7NfVxmttrMnjGzHWZ2bbDeR8zMzWxlap9KXCIyWpuuKppZJ3AbcCmwAlhjZivGWG8+8IfApmaap8QlIqO1rxziQmCHu+909wHgXuDyMdb7MvAVoK+ZnSpxicgo4zhV7Dl2Z0z9sXbErpYAzze83l1f9sZ7mb0TWObu/7fZ9qlzfgqsWvBMGH/qyJvC+MyOeKqrSlBOkSo5SA1bk6dU2w9VZoXxqBQjUUkhzV9VPODuyT6pLGbWAdwCfHI82ylxichw3tarinuAZQ2vl9aXHTMfOBf4ezMDOA3YYGYfcvctWTtV4hKR0dpXx7UZWG5mZ1JLWFcBH//V27i/BvQce21mfw/8pyhpgfq4RGQM7SqHcPchYB3wAPA0cJ+7bzezG83sQxNtn464RGS0NlbO1wca3Thi2XUZ665qZp9KXCIyXM4jPzRDiUtEhjGKP1mGEpeIjKLEVRY+efVMfR4PHZNy4ox4+rK+YGia5PRiHn9DW57eLNj+SKKYat6MeKjvVwbj6cui4YIqXS3OGziJ35dCUOISkdJR4hKRUsl5dNNmKHGJyGhKXCJSNgW+hRVQ4hKRMehUUUTKRQWoIlJKSlxyYHB+GE+Nt3Wk2h1vb9nbp6bwStVhpaYne60yO4xXgv3P6YzrtFLTtr1QPSGMRwZOarGOaxpT5byIlJIVfN5IJS4RGU59XCJSRjpVFJHyUeISkbLREZeIlI8Sl4iUSntn+ZkUycRlZsuAu4FF1PJwr7t/zcxOBr4NnAHsAq5091cmr6nllaqlalU05la1xfdOzW2YGq8rkqrTiuZFbGb7w9WZmbGheErGJC94uUArylDH1cwsP0PAF9x9BfAu4HNmtgK4FnjI3ZcDD9Vfi8h04N7cIyfJxOXue939sfrzQ9SmGFoCXA7cVV/tLuDDk9RGEZli7ZqebLKMq4/LzM4ALgA2AYvcfW899AK1U0kRKbvpVIBqZvOA7wCfd/eD9emyAXB3Nxs7/5rZWmAtwCziMcJFpBiK3jnf1EzWZtZFLWl9092/W1+8z8wW1+OLgf1jbevuve6+0t1XdpHdWSoixWHV5h55SSYuqx1a3QE87e63NIQ2AFfXn18N3N/+5onIlHMK3znfzKnixcAngCfN7PH6si8BNwH3mdk1wHPAlZPSwmkgVVKQGFkmqZIoC2hFVzBkDqSnP4uk2p363Koef3BHonKIOQXvxMlZ0cshkonL3f+B7F+tS9rbHBEphLInLhE5vpShAFWJS0SGc9dAgiJSQsXOW0pcIjKaThVFpFwc0KmiiJROsfOWEtev5FhMl5oCrBWpWqlWhqUBmNlC21NTo6WGtZnREdd59Xn213uSRxoqvXaeKprZauBrQCfwl+5+04j4HwOfojYSzYvA77v7c9E+J69yUURKy6re1CO5H7NO4DbgUmAFsKY+LFajnwEr3f084K+Br6b2q8QlIsP5OB5pFwI73H2nuw8A91IbEuuNt3P/kbsfqb/8KbA0tVOdKorIMLUC1KbPFXvMbEvD61537214vQR4vuH1buCiYH/XAD9IvakSl4iM1vwtqAfcfWU73tLM/j2wEnhval0lLhEZZRxHXCl7gGUNr5fWlw1/P7P3A/8FeK+796d2qj4uERmuvX1cm4HlZnammXUDV1EbEutXzOwC4H8BH3L3Mcf1G0lHXCIyQvvuVXT3ITNbBzxArRxivbtvN7MbgS3uvgH4H8A84P/UR1b+V3f/ULRfJa5jLDEoVguHzgcTc2HN6R6Y8L5TUlOjpWrI+rwrjKfGzGplarbU9GOdiWKj/mp221sewswLPrZxq9pY1+juG4GNI5Zd1/D8/ePdpxKXiAw3HSaEFZHjUI53kjRDiUtERit23lLiEpHRrFrsc0UlLhEZzhlPAWoulLhEZBjD21mAOimUuERkNCUuSenqiOcujOqRIB5TK1VnlYp3JnppK4kxtVLbt7LvVsYS03hcCUpcIlIq6uMSkTLSVUURKRnXqaKIlIyjxCUiJVTsM0UlLhEZTXVcIlI+ZU9cZrYMuBtYRO3st9fdv2ZmNwCfpjYPGsCX6uPulNMk/qC2HlgWxpctfTmMH6l0h/FozKvUeFjzOuNRclPbp+LRvI791fjrN6eztWKr6L29s8Wfd8F/sVviDpVinys2c8Q1BHzB3R8zs/nAVjN7sB671d3/bPKaJyK5KHhiTiYud98L7K0/P2RmT1ObckhEpquCJ65xDWBrZmcAFwCb6ovWmdkTZrbezBZkbLPWzLaY2ZZBkpN3iEjeHKh6c4+cNJ24zGwe8B3g8+5+ELgdOAs4n9oR2c1jbefuve6+0t1XdjGz9RaLyCTz2pj6zTxy0tRVRTPropa0vunu3wVw930N8W8AfzspLRSRqeUUvnM+ecRltfmC7gCedvdbGpYvbljtCmBb+5snIrlwb+6Rk2aOuC4GPgE8aWaP15d9CVhjZudTy8+7gM9MQvumhWXzX43jXXE5xJyOePqyfzN7Z2asO1EC3ZWYzuXEjnjYm1Yc8XjYmlmJ6ce+//rbw/iSrlcyY3POPBhum9SRKNWoTt7nNiUK3jnfzFXFf4AxB0Yqb82WiAR0k7WIlI0DGtZGREpHR1wiUi7T45YfETmeOHiONVrNUOISkdFyrIpvhhKXiIymPq6SsLimqJUf5KZtZ4XxR2eeGe/gtXh6Mu9q4bA+UYLc+XpihUQtFkEtlg3F2ybKuOgYjOMDJ2bv4NQtiXanlL1OK+Kuq4oiUkI64hKRcnG8UuwjSiUuERnu2LA2BabEJSKjFbwcYlwDCYrI9OeAV72pRzPMbLWZPWNmO8zs2jHiM83s2/X4pvqApSElLhEZzts3kKCZdQK3AZcCK6iNKrNixGrXAK+4+1uBW4GvpParxCUio3il0tSjCRcCO9x9p7sPAPcCl49Y53LgrvrzvwYuqY8DmMl8Ci97mtmLwHMNi3qAA1PWgPEpatuK2i5Q2yaqnW073d1PbWUHZvZDam1qxiygr+F1r7v3Nuzro8Bqd/9U/fUngIvcfV3DOtvq6+yuv/6X+jqZn8mUds6P/EDNbIu7r5zKNjSrqG0rartAbZuoorXN3Vfn3YYUnSqKyGTaAzTOiLy0vmzMdcxsBnAi8FK0UyUuEZlMm4HlZnammXUDVwEbRqyzAbi6/vyjwP/zRB9W3nVcvelVclPUthW1XaC2TVSR29YSdx8ys3XAA0AnsN7dt5vZjcAWd99AbTKevzKzHcDL1JJbaEo750VE2kGniiJSOkpcIlI6uSSu1C0AeTKzXWb2pJk9bmZbcm7LejPbX69zObbsZDN70Myerf+7oEBtu8HM9tQ/u8fN7LKc2rbMzH5kZk+Z2XYz+8P68lw/u6BdhfjcymTK+7jqtwD8HPgAsJvaVYc17v7UlDYkg5ntAlZGxW9T2JbfBF4H7nb3c+vLvgq87O431ZP+Anf/zwVp2w3A6+7+Z1PdnhFtWwwsdvfHzGw+sBX4MPBJcvzsgnZdSQE+tzLJ44irmVsABHD3h6ldZWnUeHvEXdS++FMuo22F4O573f2x+vNDwNPAEnL+7IJ2yTjlkbiWAM83vN5NsX54DvydmW01s7V5N2YMi9x9b/35C8CiPBszhnVm9kT9VDKX09hG9ZEGLgA2UaDPbkS7oGCfW9Gpc36097j7O6ndzf65+ilRIdWL9IpUz3I7cBZwPrAXuDnPxpjZPOA7wOfd/WBjLM/Pbox2FepzK4M8ElcztwDkxt331P/dD3yP2qltkeyr95Uc6zPZn3N7fsXd97l7xWuT8n2DHD87M+uilhy+6e7frS/O/bMbq11F+tzKIo/E1cwtALkws7n1TlPMbC7wQWBbvNWUa7w94mrg/hzbMsyxpFB3BTl9dvUhUe4Annb3WxpCuX52We0qyudWJrlUztcv9/45b9wC8N+nvBFjMLO3UDvKgtrtUN/Ks21mdg+witoQI/uA64G/Ae4D3kxtiKAr3X3KO8kz2raK2umOA7uAzzT0KU1l294D/AR4Ejg22t2XqPUn5fbZBe1aQwE+tzLRLT8iUjrqnBeR0lHiEpHSUeISkdJR4hKR0lHiEpHSUeISkdJR4hKR0vn/wFthozecl4IAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "print(y_train[0])\n",
     "\n",
@@ -243,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "id": "0_EvK2kJPKDk"
    },
@@ -272,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -280,7 +338,15 @@
     "id": "0WhtP5RRkYSI",
     "outputId": "cfbfdd7b-7a5f-46fb-b998-4f9d79835b0b"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "New datapoint dimension: 10\n"
+     ]
+    }
+   ],
    "source": [
     "DATASET_DIM = 10\n",
     "x_train, x_test = truncate_x(x_train, x_test, n_components=DATASET_DIM)\n",
@@ -298,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "id": "EMxlW2kZDtvn"
    },
@@ -312,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -320,7 +386,16 @@
     "id": "P7vqUjDMGF2S",
     "outputId": "e4bae463-23a6-43fd-c12e-28ba30e616bf"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "New number of training examples: 1000\n",
+      "New number of test examples: 200\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"New number of training examples:\", len(x_train))\n",
     "print(\"New number of test examples:\", len(x_test))"
@@ -355,7 +430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "id": "hVTlHdGvEuaT"
    },
@@ -382,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -391,7 +466,21 @@
     "id": "tfJkWj88Fqwl",
     "outputId": "b1f802ea-2220-46ed-9bb5-5975290756b0"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"355.99917968750003\" height=\"200.0\"><line x1=\"32.246796875\" x2=\"325.99917968750003\" y1=\"25.0\" y2=\"25.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"32.246796875\" x2=\"325.99917968750003\" y1=\"75.0\" y2=\"75.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"32.246796875\" x2=\"325.99917968750003\" y1=\"125.0\" y2=\"125.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"32.246796875\" x2=\"325.99917968750003\" y1=\"175.0\" y2=\"175.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><rect x=\"10.0\" y=\"5.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(0, 0): </text><rect x=\"10.0\" y=\"55.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(0, 1): </text><rect x=\"10.0\" y=\"105.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(0, 2): </text><rect x=\"10.0\" y=\"155.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"175.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(0, 3): </text><rect x=\"74.49359375\" y=\"5.0\" width=\"68.666015625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"108.8266015625\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">X^0.192</text><rect x=\"74.49359375\" y=\"55.0\" width=\"68.666015625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"108.8266015625\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">X^(11/14)</text><rect x=\"74.49359375\" y=\"105.0\" width=\"68.666015625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"108.8266015625\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">X^0.276</text><rect x=\"74.49359375\" y=\"155.0\" width=\"68.666015625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"108.8266015625\" y=\"175.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">X^0.876</text><rect x=\"163.159609375\" y=\"5.0\" width=\"61.9320703125\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"194.12564453125\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Y^0.622</text><rect x=\"163.159609375\" y=\"55.0\" width=\"61.9320703125\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"194.12564453125\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Y^0.78</text><rect x=\"163.159609375\" y=\"105.0\" width=\"61.9320703125\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"194.12564453125\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Y^0.802</text><rect x=\"163.159609375\" y=\"155.0\" width=\"61.9320703125\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"194.12564453125\" y=\"175.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Y^(5/14)</text><rect x=\"245.0916796875\" y=\"5.0\" width=\"60.9075\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"275.5454296875\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Z^(7/16)</text><rect x=\"245.0916796875\" y=\"55.0\" width=\"60.9075\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"275.5454296875\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Z^(3/11)</text><rect x=\"245.0916796875\" y=\"105.0\" width=\"60.9075\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"275.5454296875\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Z^0.958</text><rect x=\"245.0916796875\" y=\"155.0\" width=\"60.9075\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"275.5454296875\" y=\"175.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Z^0.501</text></svg>"
+      ],
+      "text/plain": [
+       "<cirq.contrib.svg.svg.SVGCircuit at 0x7f6db4231940>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "SVGCircuit(single_qubit_wall(\n",
     "    cirq.GridQubit.rect(1,4), np.random.uniform(size=(4, 3))))"
@@ -408,7 +497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "id": "4w2em6c0HOIO"
    },
@@ -436,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -445,7 +534,28 @@
     "id": "r7YIeOrzJDlT",
     "outputId": "b2c5a762-558f-4974-9661-598ef20179e5"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Symbols found in circuit:[ref_0]\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1092.0008203125\" height=\"100.0\"><line x1=\"32.246796875\" x2=\"1062.0008203125\" y1=\"25.0\" y2=\"25.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"32.246796875\" x2=\"1062.0008203125\" y1=\"75.0\" y2=\"75.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"154.49359375\" x2=\"154.49359375\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"326.14230468750003\" x2=\"326.14230468750003\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"530.091796875\" x2=\"530.091796875\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"701.7405078125\" x2=\"701.7405078125\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"850.352109375\" x2=\"850.352109375\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"1022.0008203125001\" x2=\"1022.0008203125001\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><rect x=\"10.0\" y=\"5.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(0, 0): </text><rect x=\"10.0\" y=\"55.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(0, 1): </text><rect x=\"74.49359375\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"94.49359375\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">H</text><rect x=\"74.49359375\" y=\"5.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"94.49359375\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">H</text><circle cx=\"154.49359375\" cy=\"25.0\" r=\"10.0\" /><rect x=\"134.49359375\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"154.49359375\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><rect x=\"194.49359375\" y=\"55.0\" width=\"91.64871093750001\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"240.31794921875002\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Rz(2.0*ref_0)</text><circle cx=\"326.14230468750003\" cy=\"25.0\" r=\"10.0\" /><rect x=\"306.14230468750003\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"326.14230468750003\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><rect x=\"366.14230468750003\" y=\"5.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"386.14230468750003\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">H</text><rect x=\"366.14230468750003\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"386.14230468750003\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">H</text><rect x=\"426.14230468750003\" y=\"55.0\" width=\"63.9494921875\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"458.11705078125004\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Rx(0.5π)</text><rect x=\"426.14230468750003\" y=\"5.0\" width=\"63.9494921875\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"458.11705078125004\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Rx(0.5π)</text><circle cx=\"530.091796875\" cy=\"25.0\" r=\"10.0\" /><rect x=\"510.091796875\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"530.091796875\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><rect x=\"570.091796875\" y=\"55.0\" width=\"91.64871093750001\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"615.91615234375\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Rz(2.0*ref_0)</text><circle cx=\"701.7405078125\" cy=\"25.0\" r=\"10.0\" /><rect x=\"681.7405078125\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"701.7405078125\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><rect x=\"741.7405078125\" y=\"5.0\" width=\"68.6116015625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"776.04630859375\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Rx(-0.5π)</text><rect x=\"741.7405078125\" y=\"55.0\" width=\"68.6116015625\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"776.04630859375\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Rx(-0.5π)</text><circle cx=\"850.352109375\" cy=\"25.0\" r=\"10.0\" /><rect x=\"830.352109375\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"850.352109375\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><rect x=\"890.352109375\" y=\"55.0\" width=\"91.64871093750001\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"936.1764648437501\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">Rz(2.0*ref_0)</text><circle cx=\"1022.0008203125001\" cy=\"25.0\" r=\"10.0\" /><rect x=\"1002.0008203125001\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"1022.0008203125001\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text></svg>"
+      ],
+      "text/plain": [
+       "<cirq.contrib.svg.svg.SVGCircuit at 0x7f6db41ccbe0>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "test_circuit, test_symbols = v_theta(cirq.GridQubit.rect(1, 2))\n",
     "print(f'Symbols found in circuit:{test_symbols}')\n",
@@ -463,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "id": "LReAUF6CSwn5"
    },
@@ -505,7 +615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "id": "5F47SaRERKx_"
    },
@@ -527,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "id": "cEGko5t-SZ14"
    },
@@ -546,7 +656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -554,7 +664,16 @@
     "id": "xZOEdNMzS8hW",
     "outputId": "5d8f40b0-af85-4afe-dc25-599cd3966385"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "New PQK training dataset has shape: (1000, 11, 3)\n",
+      "New PQK testing dataset has shape: (200, 11, 3)\n"
+     ]
+    }
+   ],
    "source": [
     "x_train_pqk = get_pqk_features(qubits, q_x_train_circuits)\n",
     "x_test_pqk = get_pqk_features(qubits, q_x_test_circuits)\n",
@@ -583,7 +702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {
     "id": "BLyGksxvGINl"
    },
@@ -605,7 +724,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -613,7 +732,42 @@
     "id": "a4AxcKa4RRJr",
     "outputId": "049fc8ce-0ff7-442c-8b7f-861bea0fb658"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Eigenvectors of pqk kernel matrix: tf.Tensor(\n",
+      "[[-2.09569391e-02  1.05973557e-02  2.16634180e-02 ...  2.80352887e-02\n",
+      "   1.55521873e-02  2.82677952e-02]\n",
+      " [-2.29303762e-02  4.66355234e-02  7.91163836e-03 ... -6.14174758e-04\n",
+      "  -7.07804322e-01  2.85902526e-02]\n",
+      " [-1.77853629e-02 -3.00758495e-03 -2.55225878e-02 ... -2.40783971e-02\n",
+      "   2.11018627e-03  2.69009806e-02]\n",
+      " ...\n",
+      " [ 6.05797209e-02  1.32483775e-02  2.69536003e-02 ... -1.38843581e-02\n",
+      "   3.05043962e-02  3.85345481e-02]\n",
+      " [ 6.33309558e-02 -3.04112374e-03  9.77444276e-03 ...  7.48321265e-02\n",
+      "   3.42793856e-03  3.67484428e-02]\n",
+      " [ 5.86028099e-02  5.84433973e-03  2.64811981e-03 ...  2.82612257e-02\n",
+      "  -3.80136147e-02  3.29943895e-02]], shape=(1200, 1200), dtype=float32)\n",
+      "Eigenvectors of original kernel matrix: tf.Tensor(\n",
+      "[[ 0.03835681  0.0283473  -0.01169789 ...  0.02343717  0.0211248\n",
+      "   0.03206972]\n",
+      " [-0.04018159  0.00888097 -0.01388255 ...  0.00582427  0.717551\n",
+      "   0.02881948]\n",
+      " [-0.0166719   0.01350376 -0.03663862 ...  0.02467175 -0.00415936\n",
+      "   0.02195409]\n",
+      " ...\n",
+      " [-0.03015648 -0.01671632 -0.01603392 ...  0.00100583 -0.00261221\n",
+      "   0.02365689]\n",
+      " [ 0.0039777  -0.04998879 -0.00528336 ...  0.01560401 -0.04330755\n",
+      "   0.02782002]\n",
+      " [-0.01665728 -0.00818616 -0.0432341  ...  0.00088256  0.00927396\n",
+      "   0.01875088]], shape=(1200, 1200), dtype=float32)\n"
+     ]
+    }
+   ],
    "source": [
     "S_pqk, V_pqk = get_spectrum(\n",
     "    tf.reshape(tf.concat([x_train_pqk, x_test_pqk], 0), [-1, len(qubits) * 3]))\n",
@@ -647,7 +801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {
     "id": "g-D_939PZoOH"
    },
@@ -673,7 +827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {
     "id": "3IkuiFmZRUby"
    },
@@ -705,7 +859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -713,8 +867,30 @@
     "id": "eK94tGyf--q2",
     "outputId": "36ee9f7f-3532-440d-de23-ebcba8c76976"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"sequential\"\n",
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "dense (Dense)                (None, 32)                1088      \n",
+      "_________________________________________________________________\n",
+      "dense_1 (Dense)              (None, 16)                528       \n",
+      "_________________________________________________________________\n",
+      "dense_2 (Dense)              (None, 1)                 17        \n",
+      "=================================================================\n",
+      "Total params: 1,633\n",
+      "Trainable params: 1,633\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n"
+     ]
+    }
+   ],
    "source": [
+    "#docs_infra: no_execute\n",
     "def create_pqk_model():\n",
     "    model = tf.keras.Sequential()\n",
     "    model.add(tf.keras.layers.Dense(32, activation='sigmoid', input_shape=[len(qubits) * 3,]))\n",
@@ -732,12 +908,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {
     "id": "QUL8ygMn_zOB"
    },
    "outputs": [],
    "source": [
+    "#docs_infra: no_execute\n",
     "pqk_history = pqk_model.fit(tf.reshape(x_train_pqk, [N_TRAIN, -1]),\n",
     "          y_train_new,\n",
     "          batch_size=32,\n",
@@ -758,7 +935,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -766,8 +943,30 @@
     "id": "uHhUYWVh9kGE",
     "outputId": "f586fd89-1157-4a7e-b382-71157a894519"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"sequential_1\"\n",
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "dense_3 (Dense)              (None, 32)                352       \n",
+      "_________________________________________________________________\n",
+      "dense_4 (Dense)              (None, 16)                528       \n",
+      "_________________________________________________________________\n",
+      "dense_5 (Dense)              (None, 1)                 17        \n",
+      "=================================================================\n",
+      "Total params: 897\n",
+      "Trainable params: 897\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n"
+     ]
+    }
+   ],
    "source": [
+    "#docs_infra: no_execute\n",
     "def create_fair_classical_model():\n",
     "    model = tf.keras.Sequential()\n",
     "    model.add(tf.keras.layers.Dense(32, activation='sigmoid', input_shape=[DATASET_DIM,]))\n",
@@ -785,12 +984,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {
     "id": "8N54jMau-1L5"
    },
    "outputs": [],
    "source": [
+    "#docs_infra: no_execute\n",
     "classical_history = model.fit(x_train,\n",
     "          y_train_new,\n",
     "          batch_size=32,\n",
@@ -811,7 +1011,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -819,8 +1019,32 @@
     "id": "t9CDiHTmAEu-",
     "outputId": "18d3ba86-969c-4f65-a0b1-aa86efc6212a"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7f6d846ecee0>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmEAAAE9CAYAAABDUbVaAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/d3fzzAAAACXBIWXMAAAsTAAALEwEAmpwYAAC3PUlEQVR4nOyddZhTV/6H3xvPuCKDDe5WoFCsAtSVurvsVre/drfbtbq7u7srLS0tlLYUirW46yBjjEv0/v44uclNJslkZpIROO/zzDPJ1RO793O+qqiqikQikUgkEomkdTG09QAkEolEIpFIDkSkCJNIJBKJRCJpA6QIk0gkEolEImkDpAiTSCQSiUQiaQOkCJNIJBKJRCJpA6QIk0gkEolEImkDTG09gKaSk5Oj5ufnt/UwJBKJRCKRSBpl6dKlJaqq5oZb1+FEWH5+PkuWLGnrYUgkEolEIpE0iqIo2yOtk+5IiUQikUgkkjZAijCJRCKRSCSSNkCKMIlEIpFIJJI2QIowiUQikUgkkjZAijCJRCKRSCSSNkCKMIlEIpFIJJI2QIowiUQikUgkkjYgYSJMUZRXFEUpUhRlVYT1iqIoTyiKsklRlBWKohyUqLFIJBKJRCKRtDcSaQl7DTg6yvpjgP6+vyuAZxM4FolEIpFIJJJ2RcIq5quqOl9RlPwom5wEvKGqqgosVBQlQ1GUrqqq7knUmCSSROD2eCmqcpBmN1NZ52qwPs1uxmoyUFLtQFUhxWYiyWxEURQMCiiKgsvjxaAoGA1Ki8ejqioOtxdVBZNRweNVsZmNMe/r8aqYjMHzM49XRQEMBgW3xwvQYJv9GbfHi8loCHofWouiqnrcHjXsOovJQJrNzJo9lQAMzUujrNaJxWjAZjbG/Llr1Ls8VNa72LC3mrH5meyrcfrX7SqvY2tJDUPz0qiqd7O1pKb5LypGspMtzBjSGUVp+H67vW5MBnELc3lclNaX+td5vCpeVaXSVUaNs4ayulq6J/dlc+VqimrKAKhzeah2uEi1mqmqd6EoStDrVYB+nVPITLLENFan24vJoFBU5aDO5cFsVCisdODxBj677GQLPbOSqHd5sJiNWIxK2NcWiserYjQo1Djc2MxGjAaFijoXO0prqXN5GmyvKNA5zUbPrCScbi8WU+O/1ap6N2ajQr3L61+WZjdRU++msMpBVpKFZJuJ1bsrsBqN9My2k2ozx/Te1DrdlNW62FtRH/R+JAqjQWFI1zTslsa//8NzhjMwa2DCxxSJtmxb1A3YqXte4FvWQIQpinIFwlpGz549W2VwktbF7fHy8bICzEYDNQ43W0pq2F1ex95KB0O6ptI5zcZPG4rZVFSN26PSPdOO1Wyg3uXFYjTw0OkjGZKXFvbYFXUu3l60nfkbitlX42R4twzKap3s2FeLqoqLm1cVF10V6Jxm5bEzR5ObaqWwsh6z0UBWcsML8b4aJ1e/vYy1eyspr20ovqJhNCgYFYX0JDPpdjObi6u5cmpfbjlmUMzHUFWV5TvLmbeuCIfby7IdZVTWuVlfWBW0XVayhY+uOoQ+uSkNjuFwe5i/oYS3F21nV1kddS4Pu8vryM9JxqAoaLeHvRX1GAwKmUlmtpXWApCfnYTZJ8TG5mdx50lD27Uw21JcTZ3Lw2+bS+mabufPgnK/+I3GhsIqft5YAkCq1USKzcRHf5lItwx7xH20z+bnDSVU1ovvRlmtkzW7Kzl+RFeuPrxf2JvvR0sLWOsTVJuLq9lcXM3OfXVRx5dsMVLj9DR4nJdu47OrJ9EpzRZ1f4CfNxbz5A+bWLu3kqp6NyC+NwFR4sFgLUQx1oHiQXWlg6KC4kQx1ge/dq8VxeAAQDFWY7TtFtuq2us14Cw7GEXxYM5YAqhgrMdgqsTrzMKYtBWvMwfF4AQUOv1Z10AIubwudlTtoFdaL0yKieK6YiqdlY2+ziazN/6HZHMCjhmORJszdiT4+C3kq92xbfe3MX87YEVYzKiq+gLwAsDYsWMTL6MlLcbt8eJwe0m2xvYVe/yHjTz546aw6/7cWQ5Aqs2EghAwaXYz20pq6J5pZ31hFc/M28STZ49ucGObv6GY699bTlmti17ZSfTITOK7NXvxelW6ZtixmIxYTAZqHW7yMuxsLq7m102l3PvNWvrmpvDg7PUc0iebd6+YEHTcjYVVPDV3E79tKaVXdhJ/mz6A7aW19MyyB82+VBU2FlVTVuNkSF4aKVYTW0tqfAJQvBYVlU1F1Xy1YndYEfb71n3UuzwUVznYU1HHsh3leFWV0monK3dVRHxPR/bIIDfFypy1hTz8/QaePqdh2OWL87fw0HcbyE62cHDvLBQFhndLx+H2sr20hr6dUjAaFPp1SkF7a4d3zwDA4xUz5n01Tt79fQc9suz89bB+EcfTEupdHmav3sshfbOp9omELuk2ympdvDh/C5dP7RNVFK3aVcGJT/1CuEl4ssUY1RqRZDGSZDFS6xM3eyrqeXH+Fm47cWiDbb1elWd/2sxz8zZT5XAHHV9RoHtmEg99t4HtpbU8ePpI/36Pz9lISbWDNxduR1Eg2WIixWpiZI90Th/Tg85p1qDzuLxC5BRVqqwpXkdd0ny8Hgt7arcz2NaZyvo6tu1N4tGF26g2/YEBA4v2LqJzUme6JHdhY9lGSupK8bqTUFEwmKpQbQrkQ6qioqoKLtVIukFFUQx4VQ8qXlqC3ZSEgkKtu4Zu3dfh8rgod5ZhVIxYjTZUVNzerbi8Loy2QuymJOrqzajuXnipok96HwxKQORrN87Saidb9qVTX90DvA2vN9kpZgZ1TcVtKCRN6c+oTiNQFFBQ8KoqBkX8B2E96p2TTL3bw4dLCvhoaQFPnjWacb2zgo7p8XqZt76EZ3/aREGZEMk5yRbG5GfSLcNO5zQbigJ2s4lBXVOxGA1sKalme2kdX/25m/6dU1i3t4qtJTVcP60/Zx8cbFy446s1zFrZUEUN756OATFZHJufRbcMO72yk8hKsrBtXw35WckoCmwsqmFTURWbiqr9E4hZ100h1RZ4fz5dXsAbv21ncNc0flxXRO+cZA7pk02v7CQUBeqcXlbtrqBvbgqoKptLavB6Vbqk28nPSeKTZbvYW1HHV9dNwRjm9/PWwu08NXcTB/fOol9uCr1zkrGajQzskkKSObHS4/EfNrBgUyk/3HQogalkgCXb9vHPT1dRVe8ib9zEhI6lMdpShO0Ceuied/ctk3RAymudVNS5qKp3U1zt4PYvVlPr9PD1dVMorKxnWLf0iPu6PV5eW7CNI4d05tLJvdlQWEXXdDuKAoO7pjF3fREDOqcysEsqCuD1QnpSwAz+94/+5IMlBZw+tgeHDgg0qnd5vPz9oxVkp1h589LxUceg54Fv1/HMvMB09bctpUHrPV6VGY/OB8T4vrl+SkzHjcaL87dw96y1FFXWB1ku5q4v4uJXFwdta1AgN9WKxwvnT+jFMcO7cPGri7n5qIFcMqk3RVUOOqdZ/cLiP5+t4v0lO1FVNUhsqKrKx8t20Ss7iVnXTYlZMIfj8jeW8OzczZw/oVfMLopw6Me4o7SWdXsrcXtVXvllK0u2lwVtazEacPpco68t2MbFk/L53wkNhRHA24t24FVhQp8suqbbOWlUHqN7ZlLv8tA5BkvR9tIa7vp6LffOHM4dX67h0+W7+Oexg7CaAoJ7c3E1l72+hK0lNRw+MJejhnZhyoDcIHGoqipXv7OMD5cW8O/jh5BuN1NZ7+LRORsA6JmVxNybDmNb5RaybdmkWlL5cMOH9M3oR6Ytk+2V27GZbDy29DH21uxlQtcJLHJ9Az4tnmXLYnPdGtyqG2sn+GrPd0GvY0vFFgoq95JhzsPrqcKmdicnxY5FsTOkS1e6pWWzs2on+6o91HhKKKoroKiuiJP6nkT31O70Se+DV/Xy9B9P4/Q4md5rOof1OAyzQXzmHtXD5vLN9Ezric1ow6gY6ZXeC5fHRbY9G4B5O+dx7Y/XAnD9Qddz3uDzsJnEZ+DyuCiqK6JbSjcATnr6VzIUM6+ffHDQ65i7rogf1hVy5JAu3P7laiqLazAZFAZ1TaXG4WFrSQ0PnDqCCX2yycuwNctCOzi3Bx/9/h2b9ho5flhn/3KH28NdX63lzYU7AAtg4dsbpjCoS3hLvMaIruL/9YcFlg389zdU1yTTOTlw/GqHm3mrHSQbs3n/ygkc98Qv4r0Ylcf/Thga1ioPMLpb4PGovMDjP3eWc9LTv7Jyh8opowPneer7P6h2WNld6mDGkAE8euYoUppwDeiS3Jlr3lnOzCdWk2438/JFY+memQSIycgni1dzSK8+vHPphEaOFH+m9PHy/UoHiiejwe+7os7FY7PXUVktxoq38d9/ImlLEfYFcI2iKO8B44EKGQ/W8XB7vPy2pZTzX/497Ppxd88BYFCXVCb3y+Ffxw1uYHVYtVu4QE4Ymcf4PtmM75MdtP7c8b2ijuEfRw/igyUFbCysChJhGwqr2FtZz+PHjopZgAFcc0Q/PlxaQPdMO8cO68rds9ZSWu0gO0VYI1YUlPu3vXfm8JiPG40R3cX41uyp9IswVVV59ddt2M1G7pk5DLvZCCgM7JJK75zkoP3X3HG0P56sS3rwRaVbph2n20uN0xN0kf1jZ7n/ZtUSAQZwxdQ+fL+mkJ83lnDs8K5Rty2rcbKhsIqn523mqkP7MLFvDgD//XwVX/65m9cvORiLycDMZxb4rU8ZSWYumdQbi8lAv07CrbpsRxn1Lg+FlfX8uqmUV3/dxhVT+9A1vaFFbOWucib1y+bty4JvCOn22ARjr+xkXrxgLAAnjMzjiz9388eO8qDv6gPfrmNXWR23nziUCw7phcvrot5Tj1e1sql8E1m2LJJMSbgyPsJg68mfu3cwv/hdFhQsJblfCaornSP6X8Qrq17iieVPADCt5zR+2PFDxHF9v/17Dut+GOcMPodady1Tu03FrbpZVvgHl378NOb0P7l1/K2cMeAM/vL1fcxZ0pkqZy6lqgnw8N61hzb629DHXmkc3TtyztWYzmOiHm9Kt8Ck5YgeR/gFGIDZaPYLMIAUq5Fqn0VR4/mfNnPvN+sAeGuh8Indfcowzh7X0x+zuHhbGQf3zmpRjGWqzUy3DDvbQmLfrnt3ObNXF/qf33rsoEYFWCQyksx+96/GNyv3UOP08PFfJjI0L505Nx5Kut1Mbqo1wlGiM7hrGooC20pq/ctWFJRT7XBz9NAuXHFoHw7qmdnk4x47rCs3H1XLq79uY31hFXPXF3P+hF6oqso/Pl7BrvI6bj6qbdx8fXLENWJzcXUDEfbPT1awsaia0T0zuPOkYU26NySChIkwRVHeBQ4DchRFKQD+B5gBVFV9DpgFHAtsAmqBixM1Fknz2VRURbLVFPbGpqoql7y+hPkbihusm33DVH7eWMzjP2ykqt7Nur1VrNtbxWVT+jQQCZqoGZef1eA4sZCVbMFkUCjVBdUCrCwQ5oERPvdZrCRZTMy76TAsJgOLtuwDYO2eKib3FxdBzf0w+4apDOyS2qwxh6JdxNfuqeKwgZ0AmL+xhPkbirnpyAGcMrp71P2j3WyyfPE0ZTXOIBH22fJdWE0Gjh7epaXDp5PvBlEfJkjY6fbyzLxNnDgyj3d/38GLP2/1r+uZZWdi3xy2l9bwxm/bAXj+py3sq3FiMxt54fyxZCSZyc9JbjBLP21M4D35eWMx57/8O0u2lXHCSPFddXu8PDV3E31yU1i1q5IrD+3TotfoVb04PU66plsxZyziX4uf5bXc5+iW0o2HlzzM75VbGTN0GJ8Vv8CSH7tjMVr4bvt3TOk2hZ93/Rx0rOTecPUvz/ifG8yAuZyPd90e5A/QC7AT+pzAOYPPYU/NHgprCpnUbRJZtizSrcE3ETNmJnU7BKW4gpN6/4WzBk5EURSWrxiP1+Hwb3fdtEEx3YBCBVhLMRqMXDv6Wt5f9z690qJPsJItJkqrA+JBVVW/ABvfO4tFW/eRl27jlNHd/MkSJqOBQ/pmhz1eU0m2mIIC390eLz/5rnfnTejJWwt3cLjv99ocUm1mqhzB8aSLtu4jK9nCQT0zAPyTjuZiMRnolGplV3kgtvCz5buxmQ08cPoI0pppuTYYFK4+vB9/Pawv4+/5ga/+3M1543uyeFsZHy4tAOCYOFxbmkPPLGHl0q7Vev7cKe4LV0zp0+YCDBKbHXl2I+tV4OpEnV/SfH7bXIrdYuSZuZv4bk0hAzun8uFfDmnwY/1m1V7mbyjmzLE9GNgllTu+WkOPLDvXHtGfgV2E+/DSyb3ZUlLDQ7PX882qvazdW9lAhO0qr8NsVPw38qaiKArZKRZKqwM3GLfHy8u/bCUnxUIv3w+yKWiWoUFdhcg67+VFzL3pMHrnJLO3QgQih76OlpCeZKZTqpUtxdX+ZZuKxONzGrEENkaGz3VbXuuih0/nqqrKVyv2MH1w52ZfhPVoIjBcFt+jczbw7LzNrNpVwZy1RQBM6pfNoi37KKwUn9mP68TyoXlpzN9QTJXDzf/NGMDk/jkxnV+zDOpvmK8t2MZjczYCkJlk5rwY30dVVSmqLfK7iJYVLsNitPDI0kdYXrScSwZfg63rpxTWwzGfHMMdE+/g9TWvQwqscs2HcthUHohv/HnXz5za/1T21OxhRfEKpvc8is82f4xRsTAoqz+rS1eTVHIdr140iYeWPMTBXQ7myhFXsrRwKRfPFnPTt499m+E5w1EUhWE5w2J6HclWEx5Xmt/yPKBzCsVVgd/IsW10gwS4YsQVXDHiika3S7GagixhWkbmvTOHc/bBPdlRWovJqJBkScytzK6LBQTYXFxDvcvLo2eO5JTR3bnr5JZZwlOspgaWsGXbyzioZ2ZMWZOx0i3Dzi6dICmudtAlzRaX376iKEwf0pl3Fu1g8bYy/6T6s6snBbnrW5NOvhjKworgpJE6p4dd5XWcfXBPjmnEYt9adIjAfEnrUe/ycPaLC4OWrS+sYuYzC5hz46H+ZSsKyvnr28sAuOmogeSmWumWaWdK/5ygC6KiKPTNTeG+U0fwzaq9XPraYjbdfWxQiv+e8nq6pNtalPafnWyltDpgCdtWWsPGomruPHlYi46bkxIQhqt2VdA7J5ndFXUkW4yk2eL780mzm6lxBi7IBWW1JFuMZCa17EKZ6Ysh2Vcr3p/v1xRy4wd/UFXvZlK/2EROY2hZkm5d5Luqqtz+5RpeW7ANwC/A/nv8EC6Z3JsLXvmdosp66l0eVhZUkGYzMW1wZ574QQino4bFLhK0i73DJ8JqHG6/AAO4eFJvekQR48uLlvP7nt+5bPhlvLjyRZ7+42n+d8j/yLRmcsO8G4K2fWH1Y0HP/7vgv0HPfznrFz5Y/4HfpQhwzehryLJlUeuqJcWSwvzfptK/s4Xnjz2Ewx75liGdOzMkewivHPWKf5+xXcZy/UHX0zutNyNyR8T8XmikWI3U6ARMcZWDo4Z25oqpfZmzVkyu2jspNlPQa9jgy/wdlicsGD2zmz7BagpJFiN1OhGmJcIMj5MFJdVmolInwnbuq2VLSQ3njI9vFYBumUlBYRT68Ip4cPHEfN5ZtIPCynpW7qqga7qNUT0y4nb8pmIzG8lKtrC3MliE3f7lakBM9toLUoRJgvh1U0nQ8xcvGMvlbyzxW2U0PlkmfCY9suz+WIWjhka+aabbzYzumcHyHeWU1TqDLgB7KurCujubQnaKhRKdO3JjoRjv6DhcCM4a14P3Fu/0z8j3lNfTNcMe15kq+MoLOAIX/IKyOrpnJrX4PFp6f7lPhN366Ur/7FuLRWspmiVMy5gEMX5NgOWmWimucpBuN3PRxHxAuDBX7arg8Ifmsaeinrx0G8cM68KSbfu4cGI+A5ogEmxmIQK1Gkc7y2qpdrjpkWVn5746LvSdMxxfbP6Cf/3yLwDyUvJ4d927ANz+2+3+bYZkD+GioRfx2abPWLB7AV5XKgazEAQKCkmOqSQbOvHi6eeRbk3nuD7H8cTyJzh/yPkMyx5Gjl2I3RSLcC2N6J7Jsu1lzF1Xws4S+MuU8C6ty4ZfFvN7EEqy1UStTtQXVTkY3zubMb0yGdOr6TFAbUGy1RT0myjxTbRCs0UThd1spEJX+29lQTnJFiO9c1rmItRIs5lZul3ENtrMRuasFbFmM4Z0bmTPppGTYmGfbpJaWu2kVxwFrBZbuaKgnB37aumTm9zIHomnc5rN77UA+PyPXby3eCfdM+2cMbZHlD1bFynCJADMfOZXDu6dHZTCfPKoPGYM6cyFh/Ti3d934vWqfqvSr5tKmNI/h5cuHBvzOS6d3Jtr3llOsW4W5vWqbC+tZWILYzhyUqxBxSM3FlWjKIj06hZy+0lDeW/xTkp8rpydZbVRyyE0lyRL8E1TiLCWn0ezpGk1n7qk2SiucpBmMzVJ6ETDpLkjdZaw3b4YlHH5mYzNz+LZeZvJy7D7v0Od06xBxTHtFiODu6bxzuVNz6bSipJqMWmam/Ph00cxont6UNHSb7d+y+urXycnKYd5O+cFHefWX24Nej4oaxCXDLuEo/OPFm6XntPZWL6Rs55fwrj+Lk4+qBOjsycz+b4F3HTkAPqki7izvJQ8Fp+7GKvRGlZED+qSypd/7ubb1XtJsZo4Y2z0mL/mkKxz5TncHsprXc12+bcVKVYTTo8Xh9uD1WT0W7szI2QIxht7iCVs6Y4yhualx6WoMgAK1Do93P7lGi6elM/tX66hT04yvbLjK2LS7WaqHG5/0dfSGgcHxVGIp/lEmBbveepB8f8+N5UuadYgS9iDs9cDcM3h/WIqXttaSBEmQVVVlu0oZ9mOck4b051ki5Gbjhror13Tr3MqTo+X4moHndNsVNS62FhUzUmj8prk89dceyVVTvAZzX7eVEJRlYPDBzU/uBVEJWq9O3Lnvlo6pVpjqpjcGFaTcD2KivdCNDY3iSAayVYju8sDs+6CsloOzm/5hTIjSSQuaPFAu8vrOGxgLs+ce1DcLkZaCQB9TNge3yz03pnDSbaaeHaeKGGhMX1wZ15fsJ1pgztxzLAu9OvUfEFoNhowGhTq3eKGWeS7+HZJswUJsH31+7h5/s3iia7yyNTuUxmcNZjnVzwfdNwPT/gw5DxmhmQPIcNUSKongxP6jmapr3TG0Lxgq6I+6y+ULr6MrY+WFjCsW1pCitwmW4x+y5H22XdqJQtSvEj2/X5rHD4RVuMgI8nsd38nGn19uJUFFazaVcl/jx8St+NrNRCXbNvnn8jMPKhblD2ah2apqqxzkWY3s6/GSW5K/IRsaGeGvIy2LfsAIulBKyzt9apU1LmYNqgTZ45rP1YwkCJsv0dVVa55dzmbi6r56trJYS/2+qzCLcXVDO+ezsWTevuXdfP9oHaV1+Hxqky870cAJjYxnsgvwnwB9Pp6XC0WYSlW6lweap1ukiwmiqsddEqN34UgJ9VKSbWT0hon1Q53XE35Gkm6TCyt5lq3OFjCjAaFzmk29lTUU1YjXsOkvjlxDWYOZwlb4ctO7ZpuJ9lqYuPdxwTdPEf3zGTZf2ZgjrF1S2PYTAa/O3LDvq0YkzbjNgxnwe4Cvt36LUV1RRTViri0v4/7Ow8sfsC/74icEVwy/JIGIiwSaXaT302ltapKb0Lsnl4M5cQxNkdPstXEdt9NqEgTYXH8TbQGWoJMjcNNlm+ild1KVjAQ7kjtN7l6t/g+x9NV+J/jh3Dlm0tJspp4c+F2JvTJ4urD41/wWBNhFXUuHG4vXhVyY6iP11xaGl4SD6wmg98yvqu8jqp6N9MGh2+B1ZZIEbYfo6oq1767nK9XiPJr6wurGNI1rcGXUJ81s2xHORccEpxFlpUsbhLltU5/XFGq1dTkeCstdqyk2kG9yxNUEDW1hXWqsn2zutJqJ0lZJooqHXHNXuySZqOgvI6d+8RNrWczMi4bI1kXSF1QJs6jFT9sKV3TbeypqGNLiYiV69spvu6O0JiwijoXr/y6FYvR4L+RhrNexNMtYLXWsqTqNa78voIFexaQ1AtO+uLFBtuZDWbOHnQ2jy19DKdXfJ+ndJ+C2WDm2enPkpecx0mfnxT1XPqsPU2MxVpzDAiqXXTXybFlOzYV/RiLfO7Z5taaaiu074dWlLckzgHljWG3mPzuSM2yG0tx31g5amgXJvfL4RdfLO60QYkRCdp3s7zORb3PStycrPFYGdy17ZM+bGYjDncgRhQSc91uKVKE7ccUlNXx1YpA/dvjnviFjCQzx4/oyuEDO1FQVseU/jmc9PSvQfuF1k7R4sSq6t3+C9Ks66c0+WKRZjNhNRnYW1HPluLgAogtvfDk6qxsPbKSKK52xC3oHGBgl1Te+32n3+WZiBuBiAnzzdx8wjhesWddM+ysKCj3J1j0y43vRVKzhLl87khNRF51WN+4nicSe6r34Or+P7Y4YUuEnnE59hxK6kr46pSvMBlMPHb4Y9y58E7OHHgmg7MGAzC52+SYzmcxBQK2myXCdBapeAntUERQuxBhxVXixtvR3JGacNeaPu+uqGNUj9ZLKrCbjTg9XtweL4WV9eSkWOMeT5Tjm0CmWE1cPrVltewioZWpqahz+cs25Mc57kzj4dNHMroZxV/jjdVk8GdL7y4XrzkenoV4I0XYfszLv4ggyXcuH8/XK/bww9oi9lbW89bCHf5K0+EITb/WaslU1rspq9Gyk5o+G1QUhfzsZL5euYeXftna+A5NQG8J83hVSqsdcZ31D+6SRp3L40/zzmjCDTdWkixGapxuUafK5z6KlzWve6adb1ft4ZdNpSRZjHG/GCmKgtGg+G+WmuXlsIG50XZrEUW1RVw15yquHnl1gzISGkf2OpJj+xzLhrINzOw3k03lm8hLET1dpnSfwnenfRd2v7eOfYssW+S4P7OvMjvo3JFN+E6k2U1YjAZumNE/5n2aSrLVRI3Tg9crvk8GRZRy6Ujo68/VuzwUlNUxs5HCxfEkyReTtnxnOe8t3hmUuBQvNHd0PJJwIqF3R24rFS2e4h239fhZo6hzejh1TNsH5QNYzQbqfZYwbVLbNY7ekXghRdh+xMbCKnbsq2Xa4M68tXA7ry3YRlayhYPzs5jYN4e7TxH9FK9/bzmzVu4N2veLayYxLC+dtXsrGdw1uIaKduGprHNRWFlPVrKl2bPBzGQz6321fuKJVoZhX42T0hqHiHmIowjTYsBW764EAjPLeJJkMaGqosyCFjcXqU9cUzlpVB7PztvMl3/u5rCBufHL7tJhNCj+mLDCyvi7biocFRgUA6mWVF5f/ToPLXkIwC/AFNWMqghBpKoKR6bfz/1TZ2AymJjWc5oYT3Js8Twjc0dGXW82GnB5Aq7XJIuxScHiiqKw4e5jYt6+OaRYhYCoc4leil3T7Qn53BOJye/mFgkxqkqrlj/QEnu+XSWul95wHeBbiFbrzJOAY2toISXFVQ72VtbTKdUa92SQk0bFP6GgJdhMRjxeFbfHy+7yOnJTrQ0SCNoD7SdPU9IiVFU0lb709SWU1Ti57YvVTO6Xw5wbDw36sZmNBp45dwwrbzuSW44Z5F8+pGsaBoPSIMMLhG/dYjJQVe+msNLRojR3fTD4x3+JX/d6TShWO9yBTLA4ijCtKXVBWR2KQouaVEci2XfTrHG6Kal2kBnHLLBBXdL8N7Qp/RNjnTIZFH9MmGbJy22B23ZD2Qbm7ZzH8Z8ez67qXZzz9TlMfHci++r38djSx4K2zbHn0Lf2CXp7ruXrE3+mev0dDO80KO4tdzRMRsWfCVpR54pL5fF4ow9qX7Onsl0VqIwVvyXM6+XnjaJdUP8WZNE2Fbvvpq1dU764NjZ3dVPQ+jaGa7ETLzKTzGQkmdlcXE1xlSOhQfntBatWO9AtJrXttTyLFGH7CTv2Bfqrjb7ze9xelcun9oloSUm1mbl0ciADsrFZUZrNxHM/bWbO2kJ/g+nmcNfJwzh9THeOGdaFkb6YrXgUXtTEXY3DHRAAcRVh4vi7yutIs5kTYlHQXkOtw0NJlTPuWXNaP73jRySmXYfRoPhjwlpqMXV5XJz6xalc++O1bK/czqurXmVHlXChH/r+objVQD21wVmDuXX8rdjNJiyOYdz2+UZQzQmtCG8xGvzB4hV1ria5IluLZN/3qajKwdaSmrATrPaOyRCICft42S7G9Mps1aBvzR25vbSGTqnWuNQdDGWQr//sRZPy435sDUVR6N8phU2FPhHWiskNbYVm9XK4PJTUOFs1oaMpSHfkfsIan5tMT2MXK7PRwO0nDo2pCXWqzRyoVt0CcZOXYefB0wOunlnXTYmLWLKYDFiMBqqdAUtYbkr8Znta8+hElaeAQE2kWpeb4mpH3EXYk2ePZnNxTVxdhHrMRoPfpdIUi6lX9bJ231reWvMW03tO55C8Q3hs2WNB27y//v2g56nmVH468ycURfFbu94x/c6CzYHiX0MT2JxXbwmrrG+nIsz3nV26vQxVhSEd2hKmUu1wMbhLaquWGNDckVtLahLWIslkNLDx7mP8lupE0ScnhR/XF+H1qu0icD7RWH0TQIfbS2m1g745bV/FPxxShHVwXv5lKwu3lPL9msKg5TazIabZTrR2Lnr0fRLjaWGK541BK/FQnABLWLKuhEaibrhJfveRh+IqR9x7r2UkWRjTK3E1lvQxYUVV9RHFnqqq/hvp2tK1/PPnf7K5QpQr+WrLV/7tFBRUVH9WI8D1B13PKytf4Z/j/4nZGPw56OM97GZjQoVRcEyYOyEdFFqK5t7+fes+oH31y4sVkzEQE1bn9GCLQ/HlpqC5Iyvr3QmtsdYaxWfTk8yU1zpxe9V265qLJ1oh8dcXbKOgrI5jhrVefbmmIEVYB2ZvRT13frXG/3xQl1TevXwCpTUO+uamxHXGGK8A8USi9ZlbtHUfqTZTXKrla1hMBpHy7PYmrFikZgmrdrjZW1FP1+EdK27DpMsYLKp0NHAHltWXYTFaOOfrc6h2VZNly2LdvnVhjzUwcyBvHPMGq0pWMbrzaG5bcBtVzirOH3I+lwy7BIPS8Kalib50u5nl/5kR51cXjF6EVda5GNK1/QkczXr7x85yUm2mdpkZ1hhGf+kTL3VOD0mtHFitj2Ht0Q7LGzSFJIvRHy6QHcdq+e0VrZ/s8/O3tPFIoiNFWAfF5fFy3suLgpZ9fs0krCZjQvqq6a1K9naYYQLiprOioJzNxTVcfXj861Ol2kw4qp0Jc+dponHnvlqcHi957aDqdFMwGUWJCpfHQ5nlG1KTT0VVVe5ZdA/vrX8PgF5pvdheuR3AX73+prE3+TMdV164kkpnJXaTHbPBzMFdDwbg7sl3N3r+3j53Q9d0m78/ZaIwGwPxb+02JswaiGPsnZPc7iqFx4JJV6Ki1uWJ68QqFuyWgNjvk4B4sNYkWScoE1Fqo70R2lKvvXaL2P8/if0It8fLJ8t3ceLIPG547w9/4c2PrjqEgrK6JvVxbCopVnGTSbWauGxKYgoKtpRkq8nfx29mAhrIau6uliQmREO7SGqfa0ezXJgMBtxelYUFf2LJnc3ssmWUzRvJnB1z/Ntsr9xOz9SedE7uzOK9iwGY2X8mGdYMBmQOACDN0jyrUp7PJZjSwu4LsWAyGnB7RRHPaoebNHv7u5Tq34e0DnrT1SxhtS4PqkobiLDA+9a7ncYUxUqSNfDepVrb36Qh3mjZkQDHDe+a0MSHltAxf5kHEDtKa1EU6JGVxBM/buKJHzYyf0Mx364WdWs+uuoQxuZnMTY/sePQCvv9bcaAVr8QxoqWyZRmM9EnARdMrQVGouIptIvk5mIhwvLaYZxRNIwGhVpPGV9vXgJApbvYL8DunXIvOyp38OyfzzI0eyj/HP9PVpasZGTuSFItqZzUL3qboFjQYuium5a4Aqgawh2pUlkvsjTbsyUMElNSpTXQYqWq6kX9t9a2wuvdn4lKyGktDmRL2JFDO7da0/emsv9/Eh2cqQ/OBUQx1Sd+2AjAvPWiXs5FE/MZmx+5qnc8ueCQfFQVzp3Qs1XO1xy0mX9ehj0hrpdUm4niqsTVm9Euknt9bUXa4409HDWuGq754RpKM3ZS6CmEnYF1pw04jfFdx3N0/tF4VS859hymdp9Kpi2Tqd2nxnUcualWtt13XFyPGQmzz0Kzr0YkgbTHz0ovINqjpS4WNEtYtU/sJrW6JSxwvkSFIbQW+4MobwpWXXmcRHqJWkrH/GUegJz4VKC/Y7XDzeR+Odx24tBWO7/FZEhYX7N4oc3uEtWk+K1Lx/P03E2M752dkONrs/xSX2uo9mpx3F65Ha/qpXe6qDP3R9EfLClcAiHDfWH6i0zIG+8XxAbFwBkDz2jt4SYEs+8Cr9WkS0QHhZZiMCgkWYzUOj3tsphsLGgxYVU+EdbaFc/1N/L2WG29KSTrricHgiVM/3npXZPtjfY7MkkD/jZ9gP9x/84dO0g0EWiNkBMVE5SXYefuU4aTnqAbrnbT3KeJsHZ60T/+0+M58bMTcXgcvLLqFTaVb/Kvs6g54n/tRA7pNqFDBoPHgiYOtCrn7TXoV7N+pLVDS10s+C1hDs0S1rriYX/6/iYFxQh2zO9DUwiyhLVTVyRIS1i7ptYZqAo+vncW103rx6NzNgCt27qjo6DFbNQ6PW08kuaTZDH5x98eZt4frP+ADGsGR+YfSYWjggW7F/jX3TTvJuYVzAPApJjoXfM4drMFh2kjde720cQ3UWidADQRFq9G6/HG4rv5dNTAfK1ifmUbxYTtT+gtYSkd9PvQFDqKJWz//yQ6IPfOWktuqpWjhnbxLztpVLegWVl+TscOEk0E2b4mtTUOdyNbtl+0lHiLydAumi3fufBOAJ4xPcOjyx5lY9lG/zpNgAHkp+djqjPj9qgo7r6kWdvvRS8eaOKgYF8tZqNCVlL7rLvk9vXy7OiWMM0d2VYuemsz22+1J/SWsPZwbUk0euFlMbZf8S5FWDtEKy43ppdoLXH14X05++AeQdt0z5AiLJTRPTMY2DmVfx47qPGN2yma5aI9zPhVVfU//usPf22wfkDmAJ444glWFq9kQNYA/vNhEQ6Xl6r6xLV2ai+YfZXcd5bV0ik18XXJmktFnbAgdbSacxqa27eyru0sYT/dfFirlD1JNLkpVib1y2Zyv9y2HkqroBfOze1h2xp0/G/WfkZ5rdP/+I3fRFHLU0Z3bxCb0F7dH21JstXE7L/FN+OutTG3ExH2Z/GfvLLyFf/zHqk9mN5rOpcOu5RVJau4as5V3Dr+VrqldKNbSjcAjIYS3F4PVfWu/T77SvuctpbU0Cen/cZn1ruEJaxHVscUxUaf2NVakbVFpfde2R27PpiGxWTg7csmtPUwWg2LUZ8dKUWYJAZqHG7unRVo4/Lp8l0cnJ9Fv04NL/LtWdlLmo/2ubaG26WkroTfdv/G0flHU1pfSoWjgudXPE+qJZVPNn7i3+7BQx/k6Pyj/c8ndZvEygtXNjieyaDg9gpL2P6efaWJsJJqJ0cObb8iTKN7B225o1nC9lTUoygkrGWYZP9Db7hoz/fL/ftK2cF447ftvL9EFFka3zuLRVv3MbFfcDmEmaO7UVBe1xbDk7QC2s09UUH5qqriUT2YDCbOm3Ueu6p3cesvt2JQDPTP6M/6svUA9M/sj8vjYlvlNpJNsVkCTAYFl1ul2unusIHgsaI1lgboH2aS1F4Y0T2dFQUVQTWiOhJa7FKdy0NOigVTO85yk7RfpCVM0iibi6u5/1thBZs+uBMXHJLPoq2/M31w56DtHjlzVBuMTtJaaLFG9gRl8zyx/AleWvkSC89ZyK7qXf7lXtXrF2AHdTqIJ6c9SVl9Gff+fi+jO42O6dgmo0JFnQtV7biB4LGid3W0556C71w+wV/otCNiNgTe55yUxNT/k+z/SEuYpFFe+WWr//Fz543BZDSw7s6j20WZAknr4Y8Ja4Y70uVx8cDiB7hgyAX0SAtO5CitK2Vp4VJeWvkSAEd+dGTQ+sndJmMymLj14FvpmtIVED0cn5v+XMznNxoM7PPFNB4o7kho3z0+U6ymDh1UbjAoKAqoauJ6tkr2f2TF/A6Eu7iYulWrALAPG4Ypt3UySVJ01d5NCXZJSdovLcmOXF26mvfWv8e8gnl8f9r3gHA/vrr6VR5d+mjQtpXOSgCOyT+G4/ocx6E9Dm3hyIX1zunrr7m/B+br3ZGd22mh1v0Fk0HB5VHJ2M+tq5LEYTa2z+xlkCKsAXV//knBNdcCkDpjBt2ffKJVzltcKbJ/vrp2cqucT9I+aUlM2NYKYU3dW7OXJXuXUFJXwsI9C/l448dht3/s8MeY1nNa8wcbQnBvuv370tJN11y9o/Zl7CgYfSKso8a1Sdqe9tz5oP06StuIpHHjyP/wQ6wDB+KtqU7ouTYVVVNRK+rf7K2sZ0yvzA7fJFbSMrSehE2xhBXXFrO1Yiubyzf7l108+2Junn+zX4DN7D/Tv+7MgWfy6lGvxlWAQXC7qP3dEqbPNmzPF/j9Aa0wbopVegb2F7wOB9svuJDqn39u8r57/ncbJS++6H9e+OCDFD32WNR9PJWVbDnhRNYOHkL1z7+w9fQzWDtoMBunHsq+d95p8hjiiZxahGBMT8c+PB1jWhqq05XQc01/5CdSrCZW3X4UeyvrGdRFtiI60PEH5keJCVtbupYzvjqDd459h62VW3n2j2cpqC5osJ1RMXL6gNMprivmvxP+S1FtEecOPpfJ3RJjbT2QLGGKopCbag0qaBtvqufPx7lzJ5aevahftxZFUTAkJ2MbMoTapcvw1ossacUo3mvFZMLrqI88ZoMRDAZUt8v33CD2cTpRFAXFZketr8OQnAKoeB0OFEUhecpULD17UPnNt6QdfxwVn3yKt6Ya++jROLduJf2EE1As0UtHVM6aRfKkSRjT0/3LKr76GoD044+Luq+mcVu7b6QkOl6Hg8ovvyT9pJNQzOEnXarXS8Vnn5M6YzqVX8/CU1EBioJzx3Zqf/+dulWryLvnbly7dqO6nCgmE6rLhWKxYExPx5iZSf369YEDut2Uv/++OLbLBarKvpdFPUPFbA58WXycvU60+dt72w84NopuHzsvv9y/3j56NJYewfGzrY38VkdAMZvw1iauFIR28a52uLn9y9UUVtQzuV9Ows4n6RjEEhOmWbceW/YYv+/9PWjd5G6T+WXXLwD8dOZPpFsDN71npz8b7+EGcSCJMICf/354i4+hqip4PKgeD96aGoyZmXgrKlDdbnZecWUcRtlykn79FVNmFpWzZlHx5RfU/rYwaH39+vV0ufXWoGWq1wuqimI04ti6lV03/h+pM6bT7YknwPdad990EwApU6dgTEuLeH6XR8QZJjfTEqa63WA0gteL4mtfoy1THQ68NTUYkpNR6+tR7HbxOaSlic+kOrHekI7MvtffoPSFF/BUV5N+wglht6n9/Xf23HorpS++iHPr1gbr1dpadt3wt2adv+SJJ4OfP/lUg20u8P2vXNdgFdbBg+n2yMP+70Rbsf9fKZuLySR+qAlCq2QN8Oqv24BA70PJgYsW8K3FhJXXl2M0GEm1pLKjcgfZ9mx+KvgJIEiA3Tz2ZsZ3HY/D4+CXXb8wtvPYIAHWGugbBKft5+5IiE/iTNkbb1B4730Y0tLwVlZi6toV9549Me07YMkSDHYb64YO8y/L/stV5F5zTdjtt5x4Es7Nm+n/y88YMzPZcdHF1C5eTN/vZrPtrLPx7NuHPxVRh150hQow8RreJO3II0kaO9a/bM8/b6V26VL6fv8djg3CAlG/YQPFjzxK2dtv0/2pwA3UsWFD0L6haNfK5ljCXHv3sumww4UFzmik/8/z8dbWsmHcweRefx373nxLvG5Jsym6736K7rs/6jbOrVsxJCWhWCx4yssZsGghnrIyNh99jH8bS9++ODdvxjpwIA6d9Sv/ww+xDRkcOJhm7dK+p6HPdfS9dRYAm+85FgwGFEVB9Xj8j9sDUoRFQDGZEyrCquobujqz2qAlh6R94fK4MSZvxG4ZhMvjYsr7UwDok96HLRWip6hRCb75P3LYIxzW/TDMRjMer4cLhlzAuYPPbfWx6y1hB1Jmb9WPc/FUVGDMzMC9dy+mzp2p+OQTPNXVGFNCaogpBjzl5RjTheWn6vs5AEKA5ebi3rMHY24OnuISAHq9+w6OdevYe/sdQYcxJCdjTBFFdPt8MwvV4cC1ezcpkydHnNn3eu1VnDt2YMoRFvduTzyOY/16LD17oljFBLDX22+z/Zxzmvwe7PnPf7H26xt4T3yva+eVV+LesxcA995CSn2xPHtuv92/beG992HO6xrx2P9eJfYfsCudgrebVvnftbcQQLjBgJ2XX4G3Xrhsix8XSVcZp59O+Ycfht0/4+yzsPbv36RzHkgYU9PwVFU2sk0qnqoqbAMGYO7RA9fu3cLVmJ5O92efwVtdg6lTJ2wDB1C/di22YcOo+3MFitmMp6Ic+/BhUY8fjfm3TKOq3h30m2hry1coUoRFQDGZ/LETiaAyTAFF2ZJDsqb+HZJ6fsvyyjoOeisQMKoJMICHD3uYMZ3G+AXajF4z/OuMBiM3j7u59QasoyPXo2oJBX8Nbm5uzsvDtXs3AJb8/KB4KccGEaNi7tEDg92OdeBAnDt2kDRuLNmXXUbRffeTdfFF1K1ciW3wEJJGjyZp9OgGIixHd05r794A2AZFb1xvys0NKrljyszENEH0Euz+2KPse/117COG0/vzzyh56mlMXbtgsCdRs2ABGTNPwVVYSLVPcKafeCK1v/9OyrRpKEYjFZ9/jnP7Dv+xLfn5eMrLce8tBEXBmJ6OqUsX8Hpx7dqFwWoj9WjRCsu5ZUvQvqHk1VSJ11lYi7Oi6d8xJSkJS7c8XHv24i4R4lax27H07ImlZ0+63PY/VKcTU24Ozu07yLroQnb9301Y+/Sh8803Y0jqmH032yvmzoEC5KmHB7v0kw85BICUyZPicq7ume3/s1MSGViaCMaOHasuWbIk4efZdeP/Ub96NX1nfxv3Yy/eto/SaidXvbU0aPl7V0xgQp/sCHtJ9nee+eMZnv0zetzWrJmz6JEqAkl/2vkT1a5qjusTPbC5tfhjZzknP/0rANvuax9jag3WDhoccd2gVStRTAHhsOvmv1P55ZcMWLK4oZUsxnP0evstksaMad5gOyD5t4gA/rcvG88kGTcr6YAoirJUVdWwPvcDc+oaA4o5ce7I05/7zf/4xQvG8sovW/ltS2m77m8liT/bKraRY88hxZLCxrKNUQXYpcMu5bLhl5FiCdy441FgNZ7YfK2WRnZv3Vi01qT4iScpffVVcq68gvSZM9lx8SVB6zPPP5/0k07C2jtfZBeagi+xXe++i04339QkAQYwYNFCFJMJT1UV5i5dWvw6OhIZSWbKa12t0tReImltpAiLhFmkysYbrzfY8tgrO4knzxnNO4t2MLJ7RtzPJ2l/eFUv9/1+H++uexeAf43/F++tew+r0YrD4/Bv1ze9L73Te7O5YjPnDD4nSIC1RwZ0SuWG6f05Z3zPth5Kwih55hkAih97nNqly3BuDtRmyzjzTHKuvMIfc2VIbtj43GCxYOjUqcnn1Uo7hDvm/s60QZ35eFlBUL9OiWR/QYqwCCgJyo6scQYfM8VqIifFynXTZPDngcKDix/0CzCAuxfdDcDFQy9mzZpxzNvxG1NGFvLsMXdjM3Wc4r0Gg8IN0we09TDihqqqqLW1/uuAFtytUaMrNJn/8UfYhw5t1fEdKNx9yjAOG5jL0LzIZSwkko6KFGERSER25Jd/7mZbSQ0A10/rT6rN1K6b/0riT6WzkrfWvhV23Y1jb+Sy1UtwVw/lrD4XdCgBtr9QOWsWu278vybtM3jd2gSNRgIi0/aEkXltPQyJJCFIERaBeFvCvF6Va99d7n/eJzeZk0Z1i9vxJe2TJXuX8I/5/+DmcTezpWILqZaGXRF6p/fmpL4nAeDxippIJkP7qGFzIOHavTusAOt86z/9jxW7HUNSkijwabNhHTiwNYcokUj2M6QIi4BiNkEcY8LK64KPdaCm8x9IlNaVcvHsiwG4eX5w2YgzBpzBBxs+4Pdzf8duCtQ+6pubwtz1xeSmysK9rc2u/7upwbIut/2PzLPOaoPRSCSSAwGpBCIRZ0vYvhpH0PNkKcL2OzxeDx7Vg0Ex8ODiB+md3jvitv+e8G9uOfgWzMbgyvJ/P3oQRwzqxAiZpNHqeMrLGyyTAkwikSQSqQQioJjNoKqoHk9cKuyWVjuDnktL2P7B+n3r6ZvRlzfXvMmPO37kj+I/eH7687yz7p0G2w7OGszafWvJsmWhKEoDAQZgMRmYKGshtSq7/3krFZ9+2tbDkEgkByBSCURAMYkbpOpyxUWEfbJsV9BzKcI6PksLl3LRtxcxo9cMvt/+vX/5lXMaNl5+8ognOazHYbyy6hUm5cWnGrSkZbjLyqj744+wAqzrvfdi6dG9DUYlkUgOJKQSiIBWZDEeLslNRdW8v2Rn0DLpjuyYqKrK8qLlDMsZxtpSkRWnF2Aao3JHUe4oZ1vlNgC/8Lpk2CUNtpW0Dbtu+Bu1ixaFXZdxysmtOxiJRHJAklAloCjK0cDjgBF4SVXV+0LW9wReBzJ829yiquqsRI4pVvwiLA7B+d+s3ON//Pz5Y3h9wTYykxq6oiTtm83lmzn585MBGN9lPIoSOYPxb2P+Rr/Mfry26jXW7lsb1vUoaTtUVQ0SYJ1vvZXCe+5pwxFJJJIDkYSJMEVRjMDTwAygAFisKMoXqqqu0W32b+ADVVWfVRRlCDALyE/UmJqCYva9NXGwhFU53FhNBhbdOo2MJAtHDT2w2o50RP7+09/pld6Lq0ddTXl9Oa+seiWomv2ivYEb+KCsQZwx8Azu+O0ODup0EK8d/ZpfoF130HWtPnZJ43hraoKeG1JT6fXWm2w/7/w2GpFEIjkQSaQl7GBgk6qqWwAURXkPOAnQizAV0MogpwO7EziephEnd+Tu8jo+XlpAstVERpIlHiOTtALfbPsGgBP7nsiTy570P++f2Z97Jt/D6V+ezsXDLub60ddjNBipcdXw/bbvuXnczVEtZJL2gaekJOi5ISWZpLFjST/lFJLGjWujUUkkkgONRIqwboA+EKoAGB+yzW3Ad4qiXAskA9MTOJ4m4Q/Mb4EIW1FQzolP/QpAlzRZ/bw9U++ux+V1kWpJZVnhMv/yYz85Nmi7/0z4D4OyBvHb2b8F9XJMNifzwpEvtNp4JS3DXVoa9Nzo68mYd690SUokktajraPDzwZeU1X1YUVRDgHeVBRlmKqqXv1GiqJcAVwB0LNngpsDb/4RvvkHSpbIcFNdzRdhD323wf/Yq6pRtpS0NefOOpcNZRuY3G0yv+z6JWhdkimJWnctw7KHMbrTaIB230xbEp6qH36g+LHHcGzcFLT8QGyMLZFI2p5EirBdQA/d8+6+ZXouBY4GUFX1N0VRbEAOUKTfSFXVF4AXAMaOHZtYNeN2QskGlCwRkN+SwPxUW+DtlSKs/eLxethQJgRzqAD7vzH/x7lDzsWAoS2GJokzpS++hHPb9gbLpQiTSCRtQSLvLIuB/oqi9FYUxQKcBXwRss0OYBqAoiiDARtQnMAxNY5ZtJBRFA8Aqrv5IqysJlCg1e2VIqy9sb1yO9XOaorrxFfu6lFXk5+WH7TNwKyBmA1mjAYjRkPL68VJ2g7n9u3U/fEH2VddiSEtDWNuDoakJECKMIlE0jYkzBKmqqpbUZRrgNmI8hOvqKq6WlGUO4Alqqp+Afwf8KKiKH9DBOlfpKptbDLSRBhChLUkO7K02onNbKDe5cUjRVi7QlVVjv/0ePpl9PPX8BqSPYQp3aZw18K7eG7Gc2yt2MqoTqPadqCSuFHx5VegKGSceirZl18OwM5LLqV2yRIMdnsje0skEkn8SWhMmK/m16yQZf/VPV4DtK/y4SZfAL3qc0d6vVE2jozXq1Ja4yA/O5l1e6vwShHWbli/bz0mg/jqbyrfxKZyER/UOakzA7MG8u7x7wJIAdbBUb1eSp9/Hkt+PtU//0L1/PkkTRiPuUugREz3p56kdvlyjBkZbTdQiURywNLWgfntD58lDK/PDdkMEba7vI6J9/0IwJhemazbW4VHxoS1C9xeN6d9eVqD5WM7jyU/Pb/1ByRJGI5Nmyh+/AkAFKsVU24uWRdeGLSNMSOD1MMPb4vhSSQSiRRhDdDckR5fPFczRNjTcwOZV/07pTJ7daF0R7YT9tbsDXp+Yt8TObb3sUzq1r4MspKW49iw0f845y9XkXPVVW04GolEImmIFGGhmHyWML87smniqd7l4asVgTZFw7qJWrRShLUdO6t2srJ4JQA7qnYAMCx7GDMHzOT0Aae35dAkCcSxTvT27PHiCySNDy1RKJFIJG2PFGGhmEVMmOL1WcLU2C1hRZX1PP7DRirqAhmVQ7qmA3DM8K7xG6MkJv4o+oMlhUuYu2MuK0pWBK179PBH6ZIs20ftr6iqStWcH0gaN46UKVPaejgSiUQSFinCQtEsYc1wR5741K/sraync5qVTqk2Vu6qoFum3dczUjZwbg1Wl65me8V2ju1zLOd/I/oAdkvpFrRNrj2XTkmd2mJ4klbCXVSEc9s2Ms85p62HIpFIJBGRIiwUgwGMVvBZwtRv/w0bk+HCLxvddW9lPQDpdjNvXnowu8rrMBoUOsuWRa2Cqqqc9dVZABzU+SD/8l3VgRrBFoOF7077DoMii6/uz3gqKgAwdZJiWyKRtF/knSgcZhuKlh25dxVsnd+k3b0qZCRZGJqXnoDBSSKxuXyz//GMj2aE3ea7077zl6eQ7F+oXi8lL76Iu6yM4kcfA8CQKttLSSSS9ou8G4XDZAevAxAVZJuKrAkWP0rqSsix5zRYXuuq5fbfbue0Aadx2XeXMShrEGtK1wRtM77reC4ddilP/fEU/TP6s7d2L1m2rNYauqSVqVnwG8UPP0LZ2+/g3iuyYI2pqW08KolEIomMFGHhMNsCMWFN0FPpdjMVdS6um9Y/MeNqpywtXMru6t2c0PeERrdVVRVFUWI67tdbvuaWn2/h3ePepXd6b15Y8QJnDzqbd9a+Q8+0nszaOotZW0Ut4FABBnD/lPvJtmdzSN4hTXtBkg6Jt64WwC/AAAxShEkkknaMFGHhMCehOIQlDDU2wQCiDMUlk3pz8uhujW+8H3HRtxcB8FPBT1w14ir6ZfYLu90bq9/gwSUPsvjcxdhM0ePk9lTv4ZafbwHg7K/P9i//Zus37KnZE2k3AGb0msH3278n257dhFch6fCEaTEmLWESiaQ9I0VYOIxmUH0NvDVLmKpCFAuOy+Ol2uGOaxakV/Xy2+7fmJg3sYH16OeCn9lbu5ftFdu5cOiF5Cbl4vF68KgeLEYLAAt2LeDBJQ8yMGsgZw08i1GdRrG8aDm90nqRZctiZ9VOPtrwEcf2Ppavt37NX0f+lS+3fEnnpM5M7T4VgC0VW1hVsopZW2extnQtrx79KhvKNrC5fDNH9TqK73d87x/T7G2zKaot4qUjX+LpP57m5H4n0zu9t3/922vfBuCdde9wav9TqXBU8MnGT5jcbTIXz74YgAGZA3B6nAzNGRr2PQkVYO8e9y517joumX0JaZY08tPzeWDqA7i9ze/5KemYeKqqGiyTljCJRNKekSIsHIoBlBA/pKsOLElhN693eTj9ud8AyIxBhBXVFjF3x1zOGHhGkLjaUbmD+xffz8x+M7GZbDy27DHW7VvHbYfcxqkDTsXtdXPPonuoc9fx1Zav/Pu9vuZ1zhx4JuWOclaVrOLrU77m223f+i1Jm8o38fWWr5l1yiwu+OYC7CY7s2bO4thPjgXglVWvAFBaV8oXm78AYMUFKyiuK+asr86izl3nP9dJn53kf/zcn881eG3Li5Yz5q0x/uOaDWZemPECw3OH+7d5dOmjfLbpMzxeDzuqdvBTwU/+dRvKNkR970wGExcOuZCXV73M8JzhDMsZBsAXJ39Bz9SeGA1G/3aSAwstI1KPwWptg5FIJBJJbMg7VTgUA4oWDKZpMUdVRBG2bEcZK3eJG8CQvDT/8k83fsorq15hZv+ZfLLxEz4/+XMMioH7f7+f77Z/R5Y9C6vRSt+Mvryw4gW+2PwFbq+b+QXB2ZjfbvuWRXsXsaZ0Ddsrt4cdw/vr3/c/Xly4mOVFyxtsc+ynQnTVueu4fu71QesyrZl+AQYi0/DcWecGCbDm4PK6eGzZY3RL6cbumt3+5VsrtvofbyrfxLG9j+WOSXfwxuo3eGL5E2yr3NbgWC8d+RIjc0diNVoZ22UsI3NH+tfpLW6SAxNPeXlbD0EikUiahBRh4VAMDd2Rzmqgc9jNN+wNuEH0ZSnuXnQ3Do+DR5Y+Aojg8QpHBd9t/w6AG+fdGNNwFu5Z2KThP7j4wUYtSiuKV9DJ3omiuiIA7ph0B9f+eC1H9jqS77Z/x3Vzr6PWLQKdPznxE55a/hSnDTiNJHMS/TL6Mfm9yQCkW9P59/h/c/P8m0kyJXHt6Gu5f/H9AJzS7xQsRgvvr3+fP4v/BCDDmsHLR73MqV+cGjSem8fdjNVo5aJhF/HEctF0+dbxt3LPonsA+OnMn4IyGyd3m9yk90Sy/6O3hOV/+CGeyoaWMYlEImlPSBEWDsWI3wSmBeY7GsabaKzeXQnAvTOHYzMb/cvTLGkU1xX7n+sDzPum92VzRaCuVTR6pvZkd/Vu3GrDOCcFhQ9P+JDcpFzKHeWc/dXZDQTYlSOuxGww88aaNzih7wn+2KxPTvqEuxbexUGdD+KwHoex/PzlmAwmrvnhGr+L8M5Jd9I/sz+PH/F40DHnnzmfK7+/kv9M+A99M/oyOGswfx/3d3/AfZfkLtwx6Q5cXhe7q3fz866fAbjtkNvom94XgIM6HUS2PZsxncf4y1CYDQF37tmDzvaLMFlaQtIY7t0BS6tt2NCYs3AlEomkrZAiLByKAUXxtSvyW8JqIm6+enclh/S3Mjh/H6tLqshLyWNLxRaK64rpmty1QTB5t5RufHzix8zZMYebfroJIOx2Gh+d+BEltSV+d+I9k++hqLaIcwefi9PrJM0iXKBZtiwybZnUVtcG7X/N6GsAuHLklQAYFSMHdzmYdGs6Dx76oH87LY7q3in3cufCO/lm6zcc3OXgsGPKtGXywQkf+J9rj6ud1eKco8Q5zQYzTxzxBPvq9wW1CvrpzJ9ItaQGiS6NN455w/+aJJJYqV8fmHxIASaRSDoCUoSFQzEAPnektszrhuVvgaMaJlwFQGFNIdM/mo6z9ny65Czg/G8aWrb+PeHfpFvTOW/Wef5lqqpiNBg5Kv8oBmUNIsOaQbI5mdFvjg47HLvJTvfU7v7n+npcNoJLPZTUlfgfD8gcwMcnftzgeDePuznqy0+1pPLA1Ae4f8r9Tb6ZpVhSWHnhyqBlJoOpQa/GaJat0Z0C78P3p30vg+wlYSn/+GPcxSU4Nqwn6+JL8JSWkvPXv5A+89TGd5ZIJJJ2gLy7hUNRUAixhKle+Pxq8dgnwtbuWwuAJe9N9kWoiNArrVeDZXtr90Zd7x8GCtN7TfcNKTYx5PA4/I9bWqahPVgTuiR3aeshSNope/71b//jylnfAJA6fTqW7gdWnT6JRNJxkSIsHAYj+EWYT4io3qBNqpxV7Kjc0WDXp6c9zdU/XO1/3i2lGzWugCtzfNfxnDPonLCnfXra02TbsxmSNYQtFVvom9E3aP38M+fj8SUMROLhQx/mlVWvsLp0tayVJTmgsPTqhXXw4LYehkQikcSMFGHhUAxoJjC/O1INrht23qzz2FKxJWjZKf1OYWr3qSw6ZxEldSWUOcowGUykWlKxGW04PA6en/68v5ZVKFqBVKCBAAMRh9UYR+YfyeDswRz7ybFShEn2W7z19Q2W2UaMaBfWW4lEIokVKcLCoRgg1B25YwEApQYDN8++pIEAA/wWryRzEj3NPelJTwAMioGvTvmKVEtqRAEWT/KS8zi297FcMOSChJ9LImlNvHV1lL3zLslTGpYoMWZktP6AJBKJpAVIERYOxeCPCfMbwH5+GIB301JZvHdx2N1SLZFbpHRODl9jLBEYDUbun3p/q51PIkk0XocDFIWiRx6l7M03ydgeXLTY2r8fGaed1kajk0gkkuYhRVg4FH1MWGDxFrOJFzLSOKjTQdw35T7+2Kryl3cW8e4VY9mnrghyJ0okkvix4eDxmHJyUOwiG9ixRWQim7t3x5idRe/334+2u0QikbRLpAgLh75tEYEYk2U2K6qi8N9qD129Kh8V1YBqYWS3riRZerTNWCWSAwDV4cC1a5c/8L5+hSiD0uPZZ1Ds4duJSSQSSXtHirBwKApanTC9JWydxUKqx0uf1V9SlTuO79eOoXumnSSLfBslktZA9QXkq04nmM1Y+vWTwfgSiaTDYmjrAbRL9NmROhG21mJhkNOJAjz4UxErCiro3ymlTYYokRwoqLofobuoyP/YlJUlBZhEIunQSBEWDoOxQbFWN7DeYmaQ0wmA19fGKNXWsO2ORCKJD3UrV7Fu8BD/c29NDZjFb86QJN2QEomkYyP9aOHQlahQfTFh28xmHAYDgx1ChI01rGer2oU+uf3bapQSyX5P2XvvNliWecYZGNPTsB80pg1GJJFIJPFDirBwKAZQg2PC1lrF7Huw0wXAycYFnGxcgOvwv7fFCCWSAwJDmKB7Y2YmuddcHWZriUQi6VhId2Q4FAOKGuyOXGuxYPN6yXe5gjY1G+VbKJEkCoPdHmaZLcyWEolE0vGQCiIcipHQwPylNiuDnC5pOpRIWhFDUkMRptikCJNIJPsHUoSFQzFA5U7xWFXYYTKxxmplRk1t245LIjnQMDWc9oRzUUokEklHRIqwcCiKKBXms4ZttIh4sDH1jrYbk0RyAKL6spH1SHekRCLZX5AiLBxak21FuCOLjOJ5Z4+7DQclkRx4qI6GIky6IyUSyf6CFGHhUHxviwKoUGQyYlJVsjzeNh2WRHIgUP3rrzg2bQIClrBe776DtX8/sYG+grJEIpF0YKQIC4dPhGkeySKjkRyPJ/yb5fW04sAkkv2fnZdexpbjTwBAdTowZmSQNHo0Xe64A0NqKrYhQxo5gkQikXQMZLJfOPyWMBUVhSKTkU7uCGLL4wRDwwwuiUTScrwOB4rVCkDS6NEMXPx7G49IIpFI4oe0hIVDETFgis8dWW4wkuWJIsIkEklcUEPq8KlOl1+ESSQSyf6GFGHhCIkJqzAaSPdGiAfzuMIvl0gkTcZTXR30XHU4UCyyP6tEItk/kSIsHKI+BSBigMsN0USYtIRJJPHCG0aEGSzSEiaRSPZPpAgLhxaYr4AHhTqDgfRImZHuMLXDPC54bASs/SqBg5RI9g+q589n07TpeB0OPJWVQeu8Tod0R0okkv2WRkWYoignKIpyYIk1f50wFadJ1CTK0FnC5nuGs8vWXzwJ546sKYHy7fD1jYkeqUTS4dl79924du3CvWcP3qqAJWzfO+9Q+9tClDBV8yUSiWR/IBZxdSawUVGUBxRFGZToAbULdDFhzlzxktN0IsyDgYXdL/E9CeeO1OoYKWHWIXycobWOZO0jyYGK76uvqiqeygr/4sI77gSgdvHithiVRCKRJJxGRZiqqucBo4HNwGuKovymKMoViqKkJnx0bYWuTpjTJ77SddmRSVYzx4/OF0+aExO24Am4PQPqfa6X5W+L5xW7mj1kiaSjU/bOu+y67vq2HoZEIpG0GjG5GVVVrQQ+At4DugKnAMsURbk2gWNrO3SWMJdPhCXrLFW9slOwanEq7nqY/a9gAaVtq0SwhC15VfyvKRb/V7wv/pesj8foJZIOSdlbb4Vd3mfWrFYeiUQikbQOscSEnagoyqfAPMAMHKyq6jHASOD/Eju8NkIJxIR5fYLK7g2IMKPRCEaLeLJ5Lvz2FHx1Q2B/VXNdRhBhmjjTxJoWgxYpA1MiORCI4JK39undygORSCSS1iGWiNdTgUdVVZ2vX6iqaq2iKJcmZlhtjE8kKQq4fcLIpgYEksWsE2H1vhgW/Q3E21ijb02E+Y6piT5VtkCSSCQSieRAIRZ35G2Av1eIoih2RVHyAVRV/SHajoqiHK0oynpFUTYpinJLhG3OUBRljaIoqxVFeSf2obcOHp9Q0lvCbGYTGH0FJB1V4r/JKspVPDUONs1peKA1X8Bzk4W1S7OEafFkfktYY+JNIpFIJBLJ/kIslrAPgYm65x7fsnHRdlIUxQg8DcwACoDFiqJ8oarqGt02/YF/ApNUVS1TFKVTE8efGPwxXeD1NehO0lm6LCajEF0ATl9KvdECZduhZAPMusm3v84d+fGlQnR5HPgtYR5fjTHNEiabgUsORCJ47SUSiWR/JxZLmElVVX8KoO+xJYb9DgY2qaq6xbfPe8BJIdtcDjytqmqZ79hFsQ070QjBpShQUy/qgNl0IkxRlIA7UhNhJmvAohXYMvBQqyemegOB/27NEmYIrJNIDjRkdRaJRHKAEosIK1YU5UTtiaIoJwElMezXDdipe17gW6ZnADBAUZRfFUVZqCjK0TEcN/H4Y7VUymvrsXq9wW+UYtC5I3WWsOgHFf+87oAIC7WEyZgwyQFEyYsvsnbQYFRnwzIvg9etbYMRSSQSSesSizvyKuBtRVGeQph2dgIXxPH8/YHDgO7AfEVRhquqWq7fSFGUK4ArAHr27BmnU0dBDVjCQMUemrUVyRIW6k6sLIAFT8JEXSUPryfgpnSHxoRJS5jkwKH0+RcA8JSXh13f+7NPMabuv+UIJRKJJJZirZtVVZ0ADAEGq6o6UVXVTTEcexfQQ/e8u2+ZngLgC1VVXaqqbgU2IERZ6BheUFV1rKqqY3Nzc2M4dQvRuwVVbxgRZmiYHWm0gDdMC6Pv/h2SOekhYkyYtIRJDiBUXwFktb7ev8ycl0feww8BYBs0CHO3UOO5RCKR7D/E1JRNUZTjgKGATfFZcVRVvaOR3RYD/RVF6Y0QX2cB54Rs8xlwNvCqoig5CPfkllgHnzgCgfkKalBmpH+F5o6sKxf/DabwfSQhuKq+qreE+USYQQbmSw48VHfDbOB+P0ZNuJZIJJL9iliKtT6H6B95LcKEczrQq7H9VFV1A9cAs4G1wAeqqq5WFOUOXYzZbKBUUZQ1wFzgZlVVS5v1SuKJPztSRVG92EMD5hUDGH3Zka4a8d/rjlxi4uUZgcded8MSFUpIYP5Xf4P5D7XsNUg6Jh9dCgufbetRtA6uCJMWiUQiOUCIxRI2UVXVEYqirFBV9XZFUR4Gvonl4KqqzgJmhSz7r+6xCtzo+2s3uDxuzARiwmyhljBFZwnTWPMF9D08/AH3/Bl4rHdHun1uGE2EaSJuySvi/9SbmvcCJB2XVR+Jvwl/aeuRSCQSiSTBxJIdqQVs1CqKkge4EP0j91te/jngEVXCBeajCBeioitJUbEDPr+m8YOrUQLzI7kzJZL9DDVMi6LMc0KjFSQSiWT/JhYR9qWiKBnAg8AyYBvQ7irbxxNFVydMUcNlR2ruw5AYrqo9jR/c64lcouKbm4MbgUskHQx3aSlrBw2m4suvom6nOhz+x6bOnRm8bi1d/vufRA9PIpFI2hVRRZiiKAbgB1VVy1VV/RgRCzZI71LcH1F0D1RU7KGlI5QWlPjWizB3SEwYQMn65h9bImljnFu3ArDvjTeClquqSslzz+PYvBkAb42IpUw79hjyP/ygdQcpkUgk7YSoIkxVVS+i9ZD23KGqakXCR9XGGNBEl4qqKuHdkc3F6w4E4LtqYd/W4Er7jRZ9lUjaL55qUTcvtACrt6KC4sceo/wDIbg0EZY8dSrmTu2jW5lEIpG0NrG4I39QFOVURWmJ+adjob3QHXSKUKKiBage8PgC8H99DJ4YBYWrA+vd9eH2khwIhImT6mh4SkVyc6gIc/uW16/fAAREmCE5uRVHJ5FIJO2LWETYlYiG3Q5FUSoVRalSFKUyweNqM1werz8mTEVBIUyx1pbgdQdKU2gWsW0/B9ZrdcckBx6RSpy0YzwVFWw940yc27YB4C4RYsu5dSt777zLv5223LFuHQXXXU/l7NkAGDuqCJt7D/x4V+PbSSQSSRRiqZifqqqqQVVVi6qqab7naa0xuLagzuXxizC71YSi0rBOWEvweoOLtzYYQFng8ZovIltHSjfD7j/iNy5J2xPte9FOqfrhR+pXrKDkWVHbzF0aaCtb9vbb/scVn3wCiBZFVd99R+lzzwMJtoRtmB3o7Rpvfrof5j+YmGNLArjqYd2sxreTSDoosRRrnRrurzUG1xbUOT3+mLCsVIsQYfF0R3qc4KqLMoDywOMPzofVn4bf7smD4IVD4zcuSdvTAUVYKJ59ZUHPVacTT3UNFZ9/Hnb7hImwwtXwzhnwzT8Sc3xJ6/Ddv+C9s6FgaVuPRCJJCLEUa71Z99gGHAwsBY5IyIjamFqnxx8T5lVUFMAWT3fka8dGX18XfBOjujB+55a0jN1/COF72Y/QfUz8j+/peO7IUDxVlShmM6qvGr6nsjJseyKNhImwigLxv3pvYo4vaR1KRAwhLx0BN6yCjB7Rt5dIOhixuCNP0P3NAIYBZY3t11GpcwbckV7wWcJCS1QkcAC/vxD8XPaTbD9s/E78X58g98h+YAnzVlVjHzOG1GOOBoT7UQvCTz91ZoPtEybCaveJ/5vmtO/ae4tfgsI1bT2K9ov++rd7eduNQyJJELEE5odSAAyO90DaC3UuNwafCPMoPhHWmllr3pCq+fGMR5O0EE19J+j70AFFmOoO/r56qyoxpqaQceppgE+E+cpWpM6YQfdn/BVvMHXqhIFaEfcTLyoKRByl3qL8wQXxO368+fr/4LlJbT2K9ktQskrHzx6WSEKJJSbsSUVRnvD9PQX8jKicv19S6/Twh9oXAK/J2nIRNu1/YAjpMzn1Zug5MXhZUk74/UOr8oeyH7iwOgx+DZYoEdbx2lZ5a2uDnnuqqjGkpmHMyBDPKyr8ljBjcjKpRxxB+imnANB39rcojwyEt0+Lz2CKN8CjQ2HBk8EiLNTF317QrDxyohUZ/W9Cvk+S/ZBYLGFLEDFgS4HfgH+oqnpeQkfVhtQ6PXzoOZQNZ8zHa0tBAcwtuemabGBJCl6mGBuKq9BtNBq78Lhqmj82SRORlrBQ1LrgJBNvZSXGgnkYHSImq+Dqa6j5/Xcg4Hrsctv/6PfDHAx2u9hJX6KlJWjxkxu+hdpS3aAiiNutP8O754iM5aYQr4mP29H4NvHE6xGvd9uvrXvelqD/7PaDOnoSSSixBOZ/BNSrqlANiqIYFUVJUlW1tpH9OiRDuqZx38wRdMrvwjaEO9LclN++YggWTmYbmJOhXtdowGBsKK5M9sDj7H5Qukk89nrF3/pZkDNAiLdOOm+wswZs6bBxDuRPArOduFK0DgwmyOkX3+N2RLR6xYm6GUQSC/Fm+wLIGQjJ2S0+lGYJ8zqdqB4P3tpaDDWFmL+6AMgCCJSjSEkR/61WDN26xfd9VNWAmKuvFLFg/kFGsCa/exY4q8FRCfaM2M/ljpLd3BQ8rSzC6spg/dew/Ve4ZXvrnru5BH12UoRJ9j9iqpgP6O/sdmBOhG07PD2ykjjr4J5kJFlQfTFhxkg//v5HNWwzFOp6DGsJMwQuLrYM3346PZzSJfBY9cCf78D758LT4+CZCcHHctbC3lXw9qnw7S0xvcYm8cx4eCoBmYAdkkRbwlpBhHlc8Oox8ObJcTmct7bO97/WH/tltHhR1IZxXg2C8OOZdPLH26J2F0DxOijXiYxIRXC18zfVIuWM0/zT3cqWT83S2pHc3vrPTlrCJPshsYgwm6qq/oqHvscRfGf7F15F3HaNkX77534A/ykOXmYMI8LMIW+XQeeOTPbFghl0H0WqToR5PbBvS/D+t6UHHjuroc6XCVayKdJLCew3777o2ySa1hjDN/8Q57ktHZa+Hr/jJtoSpndH3pYOlbvjf44aXzHVvSvicjjNElbz03y2niKyHw1mb9B/DcOjfeDXxwML4ul+/fM93aBCREYk0aH9Bl1NEFW7lsLDA5o2tki0tiVMq08Yy/v+yFD49p+JHU8seNqxO/LFI+C149t6FJIOTiwirEZRlIO0J4qijAHiZI9v36ioKCqYmmL5CCfCLCEWAMUYmIXbswLLNPQibP4DULIx8vlctYFjGaJ8nNoFbN69kbdJNNo4Ez2GRc8FHn95HZTFy/XSyjFhieiIUFMk/ivNSYxuiFcXE+baLUSjJVV8zr2PCp6gKEbg+//qdtbdYFsaZxWt3ZfemlK8AWb/Cxa9EPg+NkWExVPUt3ZMmNaXVnvfSzfDoudh31ZY8FTgGvHb01BZAAufad3xhUNvLW1vgfm7lsYvnrEj46oXE+t4ZjkfQMQSE3YD8KGiKLsRd6EuwJmJHFR7QVUUIcIau+cefV/AFWiyE1RGzWSNYAnzXVA0gWbQibCc/sHbr/0i8rlLN4E9UzyuKRHxYwYDVBdBUnbguI21SjLZWh5P5qoTf163yPYMFYXROgW0lKq9kNI5YK3S8+5Z8NffWn6ORPewDxUicRJKQVT7hJEhlp9+dFSvl/qVK8XhkpP9WZDWdHGTt6R4MNk9uOuMmJPdgbdP+47qX29dGaTktmQwkdfpRdiLhwvrsZ6y7dB5aOT968rF5MoSEtupUbkbUrs2/fvR2iJMf5P0uOC146BqD/xwJzirYPhp4nc0+9bw+9dXiO9N6KQykcgSFe2f358XE2uTFSb/ra1H0xBnrbj/NSXusxWJpVjrYmAQ8BfgKmCwqqoHRA8JzRLWMCYs5GI74S8wQBSnJCkreJ3Z3lDcKEbo7ev8lNYtsEwjNa/hYIadBiPPbrj8i2vhx7vF46I18Msj4qbxUP9gq0M0EXZ/PrzaSCX/WHjlaHigtzj3j3c0XJ8oEVa2DR4eGOzq0hPvEgWt4Y6ExIgwzRIWGrvYDBwbN+LatYuu99zDwKVLMGaKyYDREnh/3HXie91tou4z0DJ69a+3pZ9RrCIsVICBaIsT7fwPDxJ/IESKnjVfwCODYdMPsY9Vo9XdkTqL38eXCgEGQoCBqLH2xonB++i/6/f1hCdbOT40KDuynVnCJAKn7/fcXi1hLx4O9/dq61FEJJY6YVcDyaqqrlJVdRWQoijKXxM/tLZHiwlr1BIGAcuCZpXSMFkbzhwNRjjyLrh2GWTmi2WqF25cC//Y1tClqR033HKA4rWBx9t+CcSIrf0ysLyxYNzdYUq//fJo9H1AzI7fO1fEo+35I7B81SeBx6oKn/4FNs4Wz0OTGVqKdgNd+WH49XGw+gABUdRaIiyae7m5VPtEmLHl74lnn/ieWXp0B6Dvt9/Q75HLwm5rTdcJIYfvpq+/wW77WRRVjSVY/bdnhMtMY+lrwb+BBgONIRC9aJ2IJXxogBAbz06G108Q3293ncigrC4KCBeN+Q+I//qSGLHS2oH5bt1Nck2YXp4vTROvd9R5cJCvwO0dWeJ90D6zqj3i/W4t2nNMmESgfS6J9hQ0FUc1vHmKSNRpx8RyJb5cVVX/FU9V1TJFUS4H2kHAQGLxW8Ji+fFrwsKeKXoLvuRrrWmyN3RHKgYhqLL7CpEGYrae5rOAacv0JGXFdqG3Zwayt/RiJ5IlTG+d8rjEzbDvEaIB8pzbAutUVaT995se/GP79XFY9xXkDmx43JoSn6tniMjw/PMdsS4OVpggNHEUqc9m3CxKvte96Xvw3iVE0qY50PuwuIiaBmKhqfWrYkGbtTZTADi2bgXA2rs3nkpxYzakpgJgTE/HmBp8Ie41vZi6EgsG/UzG4bNG6V/v1zeK/5Ouh26NWFtm+wLGD7la/P/y+kZG7Tv3tl8ib1KwODiWMM0LW+cHW5N3LYWaYpG9nNJJJDeU7RDrmvP5+y1hrXTzitUSPfpc4V5d9oaYHG6dDzt/D6z/8noYcxEUr4eitcHXpbzR0O2gBocMy7ZfhGUxnItXo7488Fj1CrFstgUmr+Eo3yFEY+ehwlW8d5X4vPJGxTYuSdPQLJSJsNy3hI2zYfOPged7VkDXEW03ngjEcuUwKoqiqKpQIoqiGIE4mzLaJ15fiQpTRg/Y10hwt16EdR8jnnuckS1hGnoR5j9WGBFmzwzMRqNhzxSzdgi2nEUSYfqA5h9uF9XGL5kNrxwVvN2KD+DTK+DYh+DgywPLdywS//VlNUDMul+eITI7bw7J7oxk0WsumqCoKQ6/Xv9+twTtYlOyAZa8LGL33joVDr0FDo9DJlmoeyoR7irtmO468b6ZmvZT3nKMcFsPXrcWb7VPhKWkBjZw1QIKDDkJ1nxGUo6LpJwQcam5v8JZqGL5jjeHmhIRAxWJ318Mfn7uByKWUG/12blIvL5D/yF+t9+uCFjzmpNYoH1vW+vm5Y7BXWRJgc7DwJYGp70KH10slocGoKsqPH1ww/2TO8GNaxq3PlfsjP55hMPrFiVzAG6LItweGx7Y5smxwv1tz4S/b42PtUZa5ELQ3o92ZgkL/ZyenxL9e9NGxCLCvgXeVxTled/zK4FvEjek9oM/O/Ivv8HiV+C7f0fe2KQTYRC4wZjtYE0L3lZ/gdJEmP6GFO7GaM9q6AoJx4r3hUAAESO26AUYf0XDG96f78GnV8JluliWIp/Zdt1XDY9bsVP8DzXtaoIvNMPMVRsoraGfzUL8RZheYD4SJsBaiZMI07vPyrYFPut4mbtDLRWJCNzWfw/u8gXC/7sovPU1hB2XXBJ8KJ8lzJimE2HOGnEjP/01uD0j/IH8lrAwE4NoVpFwxCp+CldFX1/hs2hds0RYWYxmYdF+epz4rCHgnk/pFLAoau9ncwrtaoK4tdw40SxhF80SFizVG5g0DpsJg0+AR4fBhu+Ct3/3rMDjqX+HcZcJq8NnV8GdEVqwReLyHyGte8PlpRuDhVqkem/R0OIP68pEzFtqF3hkiPi+15TAv/dG3z8cH18W3p3b3nHWwD15cMoLMDKOuXV+S1g7E2HxrEOYQGIRYf8ArkAE5QOsQGRI7vf464TFchPvPEz8r9zlW+BT4SabMN1n9YZPfBYk/fEsoop40AUykiUsFjdeaODxNzcL8323sYFlf7wDn/1FPC5eH1i+6XvxvyqMW0+brWs3Hw3NcqHFGmnoL5ihbsJ4uyP1FqPKgjAb6GZEZduEC3Fc+NilsGycAzt+E5YQPZqYbM7NIRyhQjYRbYzCCp/KmDITaxYEMkxVpxNvlc8Spi/C6qwRxYn1F+QTHg92GTqqhIXJFJKwAjD73zD4xNgu6PMfEha3WNgbIsIUI5z6InwULCzJ6huIxTNZhFtOE2EaluSG4qs5n5UmshUDVO4RWdDjr2z6cWIlmgjL7BU+O9poFiEIf7wVvHzjd9BpqLi2jblQiJoRZ4gJV6xC2mQVgjeS+zk0vjZSbN/W+bB5LvSaCP1nBJZvmRe8XeEqYRWv0V2rXHVNzwpf/WnjPX1joWQT7FgQiL9LNNo1+vv/xlmEtdOYsA6SyNGoCFNV1asoyiKgL3AGkAN8nOiBtQe8WkxYLO6skWeJwPCDrwhebrKKeK5Buhmd/nhaxXynzg0TzhKW2qX5Ae1fXCtmmxqaAINAeyQ94dqyaD+w0BuSVvyzaHXk84dmlMXdEtaIFaKuHPauhNzB8O7ZwkI4dKZ47+v2BQrm6qkuEhYPEN0IQlGUgDCNVwXyBpawBGQbhRMLzWjD4yosxFNdhSElBcWo+z6768XEA+D4x4SwGHNRsAjbuyJQ3T6Uih3C6prRs/FB/HinaMETC/qkEY0hJwMhIiw0GUKzWo+7XMRI2TOg5yHBbZGgee5I/2ehCMvSnj/EdSI9jFUoHkT6nLuPE2IzEiPOaCjCVC+c8XpwOR2DUWSKxwuTBToPh0JRBiWiq/r1E8T/Xx4Jdje9ESLQdy1r6JWoKxMxtLb04Lg+rzfytSG9m4g703DWNK9sx7MTxQRy9PmtI2A00a8lbsWL9ip22uu4QogYjKAoygBFUf6nKMo64ElgB4CqqoerqvpUaw2wLVEVVWRHKiaC/N3hfjC2dLhsDvQIiZPQbkh6F6Q+BsTmuyjoLUzhLGG5A6OLl6k3RxdptRFS8H95pOGy+sqGy7Tx7fgNNvosZq66gHgsWBL53KGWsLjHhEVw26V2Fe9LbQk8N1kUn9QyKSt2wpz/wYN9G87cf31ClNkIFZx6VDWQkh0vi1WolTER2XPhBGMMAdteZ/BYHBs34a2s8gflBx1f+3zHXgznf9rwYJEEmEZTXnfp5ti2C5c5q02GNCtxOIuMtk33sfCfIrhpgxDnodbcZlnCfN8fxaCbqCTwZhyuhIBiENetaBPN/Cnif3InmH6beJwzoGE9w0Rw1tuBxzVFkbeLhfkPwGshpXhqSuDBPvDRRcHLf3lYXBsqw4SAhCbM3NujeePRLPiJsHiHw+9CT9D52pv7Lx7WylYgWkToOuAI4HhVVSerqvok0DFeVRwoqSthXfkGFBWUUNHVlMBM7eKmd0EGWcJ8LYj0P4xwYspkjSyyzvkQDvtndDdfpKD1cNSGmSnNfzDwuMhXDkDvggxXf0kj1BKmjXPObQFB1xIiXVSsqSLb7uz3RczJriWBGeu7Z8OCJ8RjzZqn8f1/fOOOkG2pobkPt8yFnx6Ap8fDj3c17zUUb4DfQuY2iQjMDydYv7wB1oaJA9QPpTQ4M7fym2/wVFdh9DXl9uN1t9zdHM0yF2pxCv3smsp1y+GCz8X/8z9ruF6bPIVmOIdmQzYnJkwfmK991olo4r7+W+GCCve+xnItMxjghpWi4LEWPtFpcHzHGPHcuvd58UuBx1rCxOKXg7d/79ymHV+L51z7pfgdbJojXNfa7zhcxnWohbqlN/vP/tI6wf7RrtEtQQvHaO3iw43R0S1hwExgDzBXUZQXFUWZRrtLf0gcL618CRUwNPe3cdmPMO1/ged64aUXZKHmcQh2R57yApzqu9BEEmHdDhLH124MmvVNT20TblaNlcKw+i7EocIu3HmhYbyYZin55VF4+7TYxxWJaCLMmgoDj4Zuo0UwrXbj88fuARtmC1fTulnBs9xomXpbfgq2XM29W1zQ5z/YPNfU52FK7yXEEhbmmDsWiAbxUahZGBwPV792Da4dOzHlhbixvO7wmXGX/QjT/gsT/go9xkcfY7SLeYMEkJrw28VKVh/xfc7qE7BK69FeS6ilqIElzAUVu4JjLBtDE16umoCFNhGf+btnilIyW+eHWRnjBS6jp3DNaeNMb6b1p6lEstBp7m2ttImGPqlo6s2Bx+MjuEn1WbFLX4VPrgj+LeiFS/F6Edwf7vtZvF4Iqc1zo1uEqgpFUpTe+r7q48T0iQ2lKe25moImSlu7+HBjhPscElH2p4VEFGGqqn6mqupZiGr5cxHtizopivKsoihHttL42hRVIfw1Khb/ffcxMEV3gdDvE2QJC3Ph17sjR54p2olA5FpEWmabdmPoO63hNk2yhDUiwiIF43cZHnh8yguBx9WhMWGW+P4YIt209QK35yHif8WOhtvN/qeIm3vvbHFB1AjN6tRTuDJQqDOUcHF2jRFOuCSkREUUS0to8LqOfa8HeibaR47EuX0Hji1bsA0cFLyh1x3+xtl9DEz5Pzj6Xrj0u+AJihYXqRHNPRpLras+h4Vfrg8DOCTGetPa5xKafBHqUve44NEh4cs2RCJcT9NE3sh2L2/5MbTf0dBTWn6sWIiWFBVNsI67PHA9GnC0sIiHo+D34Odp3aBGd/3Td1J4+mB4dGj4z+jpg2HDt/DmyfD7Cw3Xa/x0v8hK/+Od4OWFUWJq44V+0hjP66/m5m7t4sONEc4SlghLcwuJpW1Rjaqq76iqegLQHViOyJjc71GVFljCoqG/sIS6OSByzFQkS1ho3Jk+20dzsejdNuFEmh79Reb4R+HKkBm0FjOmmerTfUHUXUcGtkntHHisufVu2ijaNane2GZlu5bBbenCzffRpYHlX90olt+WDq8cA1/dEH5/qy5eacJfoX9I7bPTXg1+bLIFCoGCKL8R7WIVqdVNuCDwxgj3mcfLvD//IXjQF7/jcUauS/XcJJh7L7x4hGhyDRTc8DfWjx2Ha88eksaPZ9DKFaQeczS4XOB2Yx0wIPgYXndsMX8puu+H1tNNy4ZzO0QhT+0z1tpyvXMmvH9e48c+71P4b5jPxu5rKdZlBMy4s/HjQKCtmDm01l+IaG5qnI2qhi9zkOj4oNB402hFT8PRewr8p0TEyLUG0WLVnp8SeZ3ZFsi+9bggrasoxaJxy87g7f9vA/SbIX7z+iSpcL/xSJ+RVrbj21vgrQgWfu2aGRqiES2xKV7oRVi82vgUrw8U4f79ebirS9TJXKsSzsUbrySqONKkMs+qqpYBL/j+9msUFGEJSwRBrskwJ4lkaYsUa6PdELSbn0Un7LQssz90Aa69DoHNMfa6UwyBOBAQF/H6ClGkVZvN2TOEhUmf0ZaUHXisWcLsmeJmVlcWXoTVlcHyt2DC1SIORYv7KF4n/sZcJKxTS14J7LNjQeSx6y1hiiLS/zfOFsL3+MeCLSZDThJxIas/EWLMXS9cDz/dF/n4Ghd8IWqiOWtg3n0w6+/Qa5Ko2ZaUBWMvafwY4T7bBU/A9NsDGXtb5vn6jka5+YTjR53g8LjE+xJq5cvqC/s2B17vrqWQ0omqb7/1b2Lq3AnFbMacF+htai6cC/NWipuyq14cP5Y2UVrmKQQsYfYs8R1w18NcXWzdpjkilm/Dt4TFZA+Od4rU7smSDMc9DD0nxJ6NNuN26DIM+oVMXEIFclPLlLjrw4cINMWa4KoTVf7HXyWyf+srof90sa5gqSjXkt0veB+DKTDJOvOtxrsThCPeiTXRiCbCotXnMycFPAea9cNkFbF/hWuEB+KIfwdiv1I7i84eWpkejXDxsbGw6XsR57n2C1HfUTGI91qbDO8Kab+sT4Za+ZGo9h/vuDu9CHNUCpHS0qzM0Jhed52YQLnqxG+5/wxY+CyMOqf1G2iHs3q1VhJEE4hTU739kxbFhEUj1BLR+9BAQ++o+0X4wWjL9UHExz0i4pxCXT0gZvfJnRrPNrJnCuuR3qybnCt+wK/4PNK2dFHyAaDTkMB2euFWWyoq6hvN4sLocYcPEv3qRiGCsvqIVP1Qt+jrxwcedxsj2lBEMy/rLWEg3ufu42DidTDkxOCYAYNRdALYvkAUt517D/z8cORj6+lzqPjT+O5fog+i1o+z+8Eim8xVK8ZUXyE+M0uKeE9UNXL82fZfA6JLS7n/116xjyWMFTUaHpe4AdvCiLBwN9bv/wsEBJfBCBSuxpwU+FEYVr4KO3UCpOfE2ERYsq4uWaglrLpQ3Cg1di8L39tUY9BxsOqjxs+pemHoyY1vp8dsD1/HKbQ1j/7i7vUGhKDHJT5bgzGQhAPhM5BDj9MYc26HRc+KpJNPfHXvbt0txKbWNi0UTdQYzKIQa3sn1B05dKa4RujJ7A1lW4OXmaziGpHSRSQtaWT1EX8Ak/9PxMkddKF43nsq/PGu+G5akoWrMpZYvW5jRdJPKJ9cHtkqHtqBQP+5f+yz+se7unto/KQmxFoijvSTKY3CVfCtz1l20dfCu7BrKZz2csNtE0m431JNibjWhd4b2pB21uypfREUExYkgFo4ewid3V34BUy9qfH9GpttazdSsx3GXQpX/hQ+5sxkgyvmNX6+f2wTZny9ezMpM7jVUXKumLWBsCxpla/1NxwI3PwMZiGcnDpLmGY2Ltkg/r93jnBBhavcr3HsgyK1Phqhr91oEvsMOdE3Ft/nkNlb/O81EW5aL2KXwiVMxMLEa4RVTS8anpskqtPf30sEEj/QG+7Ph6/+Jtb/eFfD2BSNcK7Dpw6GRwY1XN4YrjpxYQr32voc3mBRqDVfWf0uPDsR46dn+5cZzSEbuWqbYQnzfVc06+m6r4VYvPR7GHFWw31DyZ8Ufnlo8HivCNs1h9QuMPyMwHN9oLX+ZvfFdeLzvi+k7lmkgqZNEWFrvxD/9Yk89+SJBIFI9D8y+H97J/RamTcKbg0pG6GfwGrfJbdDPL5pvfhdhz22AS78MhBz22863LwR/roALvteCDjNWumIIJpBWNBC6TK8aWEJmpss1v6ezSG0BM5bp4prUksyM0PH2/OQwKRcvz5S6EYi0QtnzQ3/9Di4N0F1+JqJFGFRCLKEBX1RW2gei+UmFY5GXR4+caiPXwln4TDbm1YlWt/SxpYR/COzpIgYnOv+EOf6yy9w7TLhhvtLoMI6uYMC4yndBBt0na80q5jeOhAp6F0/jtxB0fvuxTLbuXZZeEHakir4xz0KZ7wJV4UpJKrvRbj8TXhpBvz8UORj7dssqrrrb9oVO8TzpgbXuuoC7shQZtwBZ79H0YpUqgpEjKHqDp5sGIwq5I3GaA2c12AOGUPFzqZbwjTXXhdf1wktsSF3UMOq6QCDjg9+PvhEuOKnhttd9bNwP/1lgfiMT3i88XE1Bf3vQi98HDor78oPwi+PdFOPJsKqi0RspGY11SzFoTfC0EQYPSc9DX9dCKe+FHmb9kTod8mcFGwBHn2e+FyvmAeXzxUTKIhPD9I0naCN1gUgXFzveF+DmWGniWvM5XNh4rXB2/SaHHisWfT1YuXTq8LXdmsOHleg7ZZGwWLx/8OLYMfC5h03NKwkp39IIVvfd74tqunrY5tDvQbRWhC2MlKERUBREhgT1txeho0Vw9N+yI0JLLM9fK9ALfMJ4ExdDJm+9IQ9M9BHEoTZPjlbtGXS1mf3FY/1M0TN8qG9dn09rZ2/i0DVUPdo15HCvRUOW7oIvs2OUjBywDGR12lk9w1vjj/sFuFGDEf/o8TN7Iw3RGxZKMnZwtrWZZiIF9PTd5qoAt55OPQ9wvf+6axCoa9n7j0iYzNcoO/Wn2DVJyLLrmRjYHl1caCWm37ysOM3EeMSTpyaLDiTR1C6JpWCX7Kg7zTq9gULeMWoQv5kDDrrlyHUElZbGlvMkH4b7Uantf4q3yG+c9bUYBGWP0VYGU9+JvhY9ixhIQnFnilcT52HQt5o8X2JJ/rfkL7kyb7NgVIV+mQV7XdTXyFKGYBIfNETLRnjp/uF2/XP90SJFK00gP6zh4bNyDXSe4r3oNPgpruy24rQa2Wo4Ol/lLjB540WLmJtghHNchUrGT1EDcCqwoYiTB9uYTDBzJfgxCcDy4aeIgTiEf8W15huB4mM4HGXB7YZNjPwWBPfehH257sw757G6xXGQrS+w2s+g1eO8sX5vitiT111IjRDj8cN20ImlqFhJek9gzPxt2pu17YQYboJTej3ZsGTtBekCIuAqqrB2ZGJdEfGPKhGRJhWnypUhIXWyDHZw9f0OuSawOPBOmuDfryhMQCxWtQ0oREuvfutmfDwwOAiiD3Gi6zMS74RzYVD0S62+ZMbrgMYeCzk9Au/LhYOuTp8tXd7Fpz7gbjADjlJVIWPRp9DRYNjEO6O8z8R1sK//CKOf8FncM3iwPb9fIHVQ30XaO09CeeufPNk+OhieHwEPKXLVntpGjwzQQgw/UX9wwuFlSTUTTtMtGWqWSAusOaePeH8T9gxN7hli8GowpCTg34KStcRDccV6/f7YF+fxBGni/89J/hWqOL7oiiBC+mUm+Cir4TwDXV1RwrETzR6K41ehL12XKBURV1ZIHu43CfCXjs+kHjQ85Dg4PholjBNUK/7Ct44MbA81JL657vh9++IVR5DP1vteqNZkUITD7TvUL8ZtBjtmvXWzMZF2IjTRexgl+Ei5MKSLCZq2uQUxMTjON1npe84oLkjQxMBfn1cZCu3FC38Y9INkbd540TRgP2Nk+DNU+DVY4JLZ8y7V3QcKNAlFTh94QfpPYV3IiMkBGCJLw4smsciUbijiDBoNzXDZGB+BBweByb9RSv0wt8SmmsJs/gsGEnZwuJw0IUi20tDyxALtXQc5bOmaJYmsy38jTKcdSyU5BARFqlAayhag2hnbfTtLvtBBPjrLSX5k0Qw+qLnRashCMTBHPNA4IcOIgC+ZEPs44pGuH5wzWnNMeQk4V6N5KbTf7e0i5VmnWtKLMW9PcRNvdxXf+r2jMB3Ro92QUrKhhvX+cflLhYzWGNaGmqYC5Ry7N0NSxNcPtdngVVE7JOrNvaK+cfcL7IPTTYhyExWcRzUwPdFe89yB8Z2zNZE/zsOJ57mPySyZoecJFzI75wuSqHsXRHYxppGkDqKGhPmE2HxsIx0VLTv7vmfCGEUOinsNBj+VRgfq6d2DSpeB9+EVGXK6Blw++qvVZfPo9FwlaQcEWuWoSsTsfpTUcdNX2BWo7JAXAe++pvIPOwyXFjMjw0TsjHrZl8CUDoUr4XTXoHHRwXqpIXrhanhrhcu0wVPCas5iP6Wf98qwku0ZALtdX90ibiv2NKF2x81QkFgxITqx7tEMevOw+AvMfZ8bQn6CX84Y4GzOnzMdCsjRVgEHB4HSXpL2MizRTr43pUtP3gsM/eLZjV0GQw/TdSw8bhF9omiBF8AtPiBUBFmMIgg/Ud8Kc/hZgUgjnXB58HlJULRbo5NRRNv0eqD5U8RVoFw8QNmuwiGDkVfwPbEJ32lJr6CgTG4Ihsj3DiaEyvWZRic/Fzk0hKKAud8IGo2LX9TLAvNak3pIi5+o8+DEWeKFitlW4Vo08bkqBQlOPToax5pGC0iZq3ryKCgbneJCEL21tU1aFMEYEgOI+iMpsBn0GmwyIKKNeZRUQIXR+2mabKJyYRWR2zS9eI7NyzEHXvpHBHTonf3XfVr0zpDtJTGLH5aaRC9FeCjEMupLT3Ywh1LbTh9OECT6IimsBC074vJGj4zD+Lndp56s+g32+dwXzkMXabWof8Q2Y91+4K/75EKauu57HthYdJP8jxOMXkMLeLa53DhEv39RSHUADb/KP5Ub0PXf2ih2L0rRSb0D7eL5/p4UEtqw+tDn8Og01Dxest3iEzUz/4qLHpa/a9vbxGJHVpha3Ny4HX3OUwIQEeI5XDDt4ESM4WrRHJXoktW6GuChZtQSxHWvnF6nKiAookwg1HUe9Iy2lpCLJawcBlfBiOMuywQ3B1aEVhzXelN5RppeYGyFJqVKK27mGVp+3Qd1fgPI9QS1ljA5fGPiToxmqCMJsLOeCP68SJZIyddD3v+DJQSGN3E/nFNobkVl0edHX39gJBCsiar+J6oHiG8QNRQ6zZGZIMNmyliL1K6RK5lNuFqWPh0w+VGSyBDVIenRAgvb1UVrt2BNiqW3r1xbt2KYvPdAA+6kIzNq/Dmjg4+QFbfpomwcGjWXK2MgCVJfOdD6TFO/OnRAvtbi5jdrlcEbqB68g4SNwf979hRKRJUzHbxPpZvFyVl3I5AgU8tDidcaYZotEVwdNxJRM2gCCRlQY8JwqLirhd1Cpe+KtZZU0Xnh2cmwPDTm3ZcrUyGPlFDY8tcIdrzRovJVtdRYtncuxtuu/hFYXWOFhKiL/WinduWIYTZSU+KoHw96T0DIRGqKrbb/qv40yYT5TuEOA2HwQiTr4cf7gh4bMKxdT70PTyxpSL0E5pwhodw738bIEVYBOo99aiKToTFk+bGhPnxXUxDRZgmEKxhRBgELCbaj/avv8F9Ph/+rVHS2vXoK53rxxKJsRcHx01FSsG+YZW46EVDy6jTSkpozLgj+n7xJDQGJd5ocT8GY8BCMuw0cTNe/hak+no1HqHL7pl6E9wZ4maYdH0UERbeXej2Wb88VVW49gqXV+/PPqXowYdwbt2KweZzV5/4BF0barjA9yoWa0AktAv38NMa37atCY1zyRkoJgpa/N7o8+Gkp8TjrqOCSxac+5EoZAnBv+Mf7hB//abD2EtFK61R5wqLht6NmT9FxMjdFjIxGXaaiBkLbTK9vxDOvZ5IzDYRQuGqF99ve5awftnSREzXfxtp8RaNSCET2f3h8h/F431bGq4r3SjKo6z8QGS56mvfbf8NXj068PzbEDeqPRNu0bXLWvgs7FwkkoQ2/wjpuvINitIwLlb7vn3/38CyqpC+l5rgsaQEi7BR5waKhn9wvvj/76LYwmCaQ7TsSAjvJWgDpAiLgNPjTJwIa25MmH9/38U/Un2XiBcq7Qbv+9ib8+XXB5NC02fXobVqNKLFKmjkHSTcdokWQnquXyFM+as+FvFWpzyX2PNpN2R9XFXvqeIz7zREFJsNRS+qhp0mMujqykUV8ItmiaDxT3RZWRHaX2nuSLWuDk+lcCcYUlIwJAlxpbobiYcLbZ/VHC78UpRiyBvd+LZtTejrtKYKa+6uJeJm12NCYN0Fn4kb17I3xHN91me4AOFNcwLZontXNAyDCLWc9pokrBVGs5jQVO+F5yIkrXRULp0jepC2Jia7yBYE8f2+9DuRjayV3GkJRpMon/LJFcJFp6HVXYSGnoej7xOT7O4Hi8mtPqMdRDeUUefBH2+FP2eo1ey8j4VlKzMfSjc3njV77TJRoiha+zDN9WfPDMSnQvDr0nj5yIDnRlFEQe1t88Vk/+TnWjah099rwlnCvrxeLB93eSA5qA2QIiyEvTV7WVa4jAW7F9BbSVAURUstYdr+4RqUQmQT7wVfiFY6mlsvUi/KaDRwVzbxHYrkjowly9JgaHjzSTSZvQLWp4HHNr3XXlPRAv8NJjj6fmEZ0j7vHjE0hz7pafFeTrxOPM+fFFy3p8/hAQuMDufOnbh27MCUm4u7uBiPT5AZrFYMSeIC5q1rpJBkaCP55tB5aPiLdXskdDJlSRbFjdPCVKK3Z4qMvXAiLNLveIuvjEW4ONTQGLnTXhUWtGn/FTF0YWM3O7g7MtT93Bror0vmJDEJDZ2ItoTOQxteh/XFZfVejSEni2xwLeYtUhHaYx8Q19mKncIiWlMSKFERKkasqYHfW7hM51Cy+4q/tG5ictf3iIbu2GGnibpjU/4PntR1lsgZEPjffZzoDawPndm7UgT/Kwbxm8juL87Ve6qI/yvZKM7pcQlLsd4A4PWKmDPt/mKyBRcVD7q/+GL7tN/VhL82/roTiBRhIawuXc0/fhYmXBUwK2HeopbGVrQ0XVcLRtZ896FEckd2HRH8Q2vK67ClByxvmflQtq3pxwAYeZZIu+6ItEZMjd8SZoIJV8W+n9Y6xWwLuMA0TLoL0AWfhd29eu48ADLOOpOSJ5/yZ0oqdjsp06dT8fkXWAc0cvPRLnQtdrd3EEJfZ7jgXz369P1YRNieP8MvT+ksxJ6e1M5wchjXs579IiaslQkSYXGuM6ehhYlo/VuHnBwyhiSR9HLG67Edz5IMp78aeL5xDrx9qm9dnOrDTfsvfHqlsMyFZi5bkgK1/DoNCRT37uK794w+L5CtqeeXR2HObaI80IoPRI00EO21znwruAzPRV8Hlyda91XAxRkOfeP6sRcH+g/bM2HA0eH3aSWkCAthQtcJfHHyF+yp2UPu7u9wL/2k8Z2aSktvUp2HBnrEhSNS9mNLuGlT4PHVi2Hlh/D5X2ny7HrabXDoLXBP10Y3PSDxi7Amfkcu+TZy+QztRqLVqwpD/bp1GLOzsQ0SbhZNhBmsVtJmzCBl6RIMyY2IDM0SFklU7G80WYTpShLos1+jvV95B4kWWIf/S1g3VU/T3b3HPwZf3dC0fSQC/Xsdj7I34dB+t1NvEoIj1JPx9y0tc/HrxX+87g0jzxKegcayC6/4SbRsAzFR+OeuyL+TidcLAZrRU1jRakpEUdVlrzeMfXzzlGBh5a4XSUoXfil+I89OCs461iYg2f1FZuuSV4Q176pfEieuY0SKsBCSzcn0Tu9N7/TeFNl+pzQRBd1aGhMG0S/4iZjx6vvTmSyBOKSmnstgEDOl018XYlI/u5EEbshNfV+N5siV6q0pcNIzIhspAo7167ENHIghRdwA3MUlYDSimMUxGxVgELC4taTlU0ci9MbYmAhLyoJjHhRiVV+mJlSE9Zsu3DWWFJHp++d7Im4lXHzMpd83XtbC32xcWsKajL7MQVNavTUFLaHKkhw+lKSl59WHUMTSzSJWYinvYLKI0jFaMeNIXhoQvwl95xV7pmi+bs8IeE/6HA5jLoSdixvu3+8IyNW5PIvX6sbhE1r2DFHq6ITHhYhsLBmsFZAiLBoGJTj4vSWNTgG/L7ols5poHHpL+FT4aOQOErOvppLvq3k1vgkuMz36jJ72jva5t/jzj+VcmgiLs0svTNkOVVVRXS4MFguuggLsI0dgTNNEWDEGaxMTNzShfqCIsEHHiR50A44RvVBjsTKMv6LhstBOGEfeDZ10gd8TQjpe6IkWJ3jEf0ScTHZ/EXc07b+Rt5WEJ6j1TYJEmCb0zDFMdJpDorIPY6XLsOaXj0nrKrLf+x4BX/8fnP6aEFJDT4m+X+7AYBHWa6IQcof6skXHXNS88SQA2bYoCoqixLe1gea+SFTMzOH/hGvCtLeJxtWLgssdxEpaV7itIrZg8cZICVOE9UBFuyG3QpuP4scfZ/2IkXhra/HW1mJITsaQGhBhir2JNx0tIP9AEWFZfcRvQGuV01yRrgnvrqPE/3BNy5vD1JvgsjnC8vyf4o418Wkv6EWYKVGWMN9vPlEiDxITotKa9DkMrl0ae4HX0MLemflwW3nYpKS2JqGWMEVRjgYeB4zAS6qqhq0qqSjKqcBHwDhVVZckckxNwncjVFVVCLIWB+QbAXf8rRwdmb8ubJiG3d7QPvdWCcz33chbQYSVv/8BAJ7KSmERS0rCmCLcBarT2XRLmGbhbU5rp46MZmlorvjUPvOZL4rimKmhtfgOcK5ZmtiintEIckcmODA/kSLs+hWt202irQmdyNjb3u0YiYSJMEVRjMDTwAygAFisKMoXqqquCdkuFbgeWJSosTQbg1YUVRU34Ja6owxG8NB2DYfbI50Gt/UI2hfNDcxvzqk8Qix5a0Vat2K3Y0gJxGwotibedPwi7ACxhGm09HVrn7nZHohpkQTIacW6gKHoC34mamKkjwlLFBHLluynNBBhGW0yjFhIpBo4GNikquoWVVWdwHvASWG2uxO4H2h/JZ41y0e8XJJ+C5gMkJVEwB8T1gpC3SfCPBW+wqxJSSgmk78umGJrqiXM9/0+4ESYVrevmRZArc5SO75RHLAMPDbwOFHfa39MWAItYQcaWoiARjwTEuJMIq/03QB9p9kC3zI/iqIcBPRQVfXrBI6j2SiaxSpeAdlpefE5jqR1aZPA/MSLMNU3ufBWVgJgsAvxZUgTWU8GW1Njwg5QS5jWFNkaQ7ZYOKb9D27Z2XYuN0lkxl0mEi+gecWtY8EfE9bB47baE11Hwj+2tfUoYqLNsiMVRTEAjwAXxbDtFcAVAD17Rq51FH+ExUpV1RDbVTMtWed/KvpzyRmvJBLe1gvMb2AJS/aJMJ8lzNBkS9gBGhM29BRRkXzsJc3b32CILd1f0vooCsx8Hpa/HcgIjzetERN2IGLPhMvnQk1xW48kKom80u8CdFXi6O5bppEKDAPmKYqyDZgAfKEoSoPCUaqqvqCq6lhVVcfm5raiXzvelrD0bnBQlKq+kvZJqwbmN7NOWHNO5RdhmiVM3AQMvlgwxSpjwmLCYISJ1yY2pkfSdtjS4ZC/Ju43edTdwsqWqOzLA5luB7V+q7smkkgRthjoryhKb0VRLMBZwBfaSlVVK1RVzVFVNV9V1XxgIXBi+8qO9P1PRMFWiSQciaoTFg5NhFUGYsIAf2mKJseEaWnhoW1MJBJJZMZdKkqIyIStA5KEuSNVVXUrinINMBtRouIVVVVXK4pyB7BEVdUvoh+h7Yl7TJhE0hitGZjvQ4sJ08SX3yIWS5V8PXmj4KJZotq7RCKRSBoloTFhqqrOAmaFLAtbtllV1cMSOZbm4YsJ82oiTIqxA5JJN4iG5aNbwZWcYBHmravDtXcv1t69/cs85ZolTIgug124IY1NFWEA+ZNaPkiJRCI5QJD2z2j4zcNSfB3QpOTCWW+3TkJFgkVYwbXXseWYY/2ZkQDusn1AIDBfiwUzJEfp8yaRSCSSFiNFWDRkTJiktUlwsdaaX34Rp3EHguddO3ai2GwYMzJ8YxCTjia7IyUSiUTSJKQIi0LEmLDWyJKTHJi0UkyY6gy0Y3Hu2IE5L0+05iKQNSlFmEQikSQWKcKiosWESUuYpJU4+Erxv+vIxJ7HreuJ5/VizssLeg5ShEkkEkmiabNirR2CUEtYqu9GlZnfJsORHAAMOBJuq0j4aVSXK+i5uWvXwDpfsVXFkqAK4RKJRCIBpAiLjr6BN8DAY+C8j6HP4W03JokkDqhOZ9DznKuuDDzxCEuYYpSGcolEIkkkUoRFQQlt4K0o0G962w1IIokT3traoOfmboG2rqrHF7SfoOQAiUQikQjkVDcavuBoVRZrlexneKqqI65LmSx65Fny81tpNBKJRHJgIi1h0VBC3JESyX6Ct7oq4rrM888j7ZijMbVmn1aJRCI5AJEiLBqhMWESSQfFVViEY+NG/3NPVWQRpiiKFGASiUTSCkgRFoUGMWESSQdl29ln4d69x//cG8UdKZFIJJLWQcaERUORDbwl+wd6AQbgqapso5FIJBKJREOKsGhoFcSlCJPsZ0hLmEQikbQ90h0ZDRkTJtlP8VYLEWbt34+ca69t49FIJBLJgYkUYVGQMWGS/RWPLzsy74EHsA0e3MajkUhaF5fLRUFBAfX19W09FMl+hM1mo3v37pjN5pj3kSIsGpEaeEskHQ1FCfoeeyuFCFOstrYakUTSZhQUFJCamkp+fn5gsi2RtABVVSktLaWgoIDevXvHvJ+MCYuGVqzVK0WYpINjDK5+r1nCDHYpwiQHHvX19WRnZ0sBJokbiqKQnZ3dZOuqFGHR0H6fqnRHSjoGqqriratrsFwxBP/UPeXlYrlNijDJgYkUYJJ405zvlBRhUVCkO1LSwSh+5FHWjz6I6p9/CV4RYglzbtoMgMFub62hSSQSiSQEKcKioZWokIH5kg5C3fLlADh3bA9arhgbNuNOGj8eg7SESSSSOPPaa69xzTXXxO14xx57LOU+631bjiMRyMD8aPiLtbbtMCSSWFFdLvG/3hG8IowISz/55FYYkUQiaUvcbjcmU8e+1c+aNauth5AwpCUsGjImTNLB8Lqc4r8jODg0NCYMwJST3Spjkkgk4Tn55JMZM2YMQ4cO5YUXXgDg22+/5aCDDmLkyJFMmzYNgOrqai6++GKGDx/OiBEj+PjjjwFISUnxH+ujjz7ioosuAuCiiy7iqquuYvz48fz973/n999/55BDDmH06NFMnDiR9evXA+DxeLjpppsYNmwYI0aM4Mknn+THH3/kZN0E7fvvv+eUU06J+BrCjVfPl19+yfjx4xk9ejTTp0+nsLAQgJ9++olRo0YxatQoRo8eTVVVFXv27GHq1KmMGjWKYcOG8fPPPwOQn59PSUkJAG+88QYjRoxg5MiRnH/++VHP0RHo2PI4wciYMElHw1tTAzS0hIVzqZtyclplTBJJe+b2L1ezZnd823gNyUvjfycMbXS7V155haysLOrq6hg3bhwnnXQSl19+OfPnz6d3797s27cPgDvvvJP09HRWrlwJQFlZWaPHLigoYMGCBRiNRiorK/n5558xmUzMmTOHW2+9lY8//pgXXniBbdu28ccff2Aymdi3bx+ZmZn89a9/pbi4mNzcXF599VUuueSSsOcoLi4OO149kydPZuHChSiKwksvvcQDDzzAww8/zEMPPcTTTz/NpEmTqK6uxmaz8cILL3DUUUfxr3/9C4/HQ21tbdCxVq9ezV133cWCBQvIycnxny/SOToCUoRFQ8aESToYWjsib30gQ7J6/ny8FRUkT5pE8sRDKHrwIQCM2dISJpG0JU888QSffvopADt37uSFF15g6tSp/jpTWVlZAMyZM4f33nvPv19mZmajxz799NMx+sIQKioquPDCC9m4cSOKouDyhS3MmTOHq666yu+u1M53/vnn89Zbb3HxxRfz22+/8cYbb4Q9x8KFC8OOV09BQQFnnnkme/bswel0+redNGkSN954I+eeey4zZ86ke/fujBs3jksuuQSXy8XJJ5/MqFGjgo71448/cvrpp5Pjm0Bq54t0jo6AFGHRkDFhkg6Eqqp4qkT9L80SVr9+AzuvuBIA+8iRZF96Kd66ekqeegpTmAumRHKgEYvFKhHMmzePOXPm8Ntvv5GUlMRhhx3GqFGjWLduXczH0JdECK1PlZyc7H/8n//8h8MPP5xPP/2Ubdu2cdhhh0U97sUXX8wJJ5yAzWbj9NNPb1FM2bXXXsuNN97IiSeeyLx587jtttsAuOWWWzjuuOOYNWsWkyZNYvbs2UydOpX58+fz9ddfc9FFF3HjjTdywQUXNPscHQEZExYNGRMm6UCoDgdogfm+mLCq777zr9dqguVeczWD1q5B6eDBuhJJR6aiooLMzEySkpJYt24dCxcupL6+nvnz57N161YAv7ttxowZPP300/59NXdk586dWbt2LV6v129Ri3Subt26ASJjUGPGjBk8//zzuN3uoPPl5eWRl5fHXXfdxcUXXxzxuBMmTAg73kjnfv311/3LN2/ezPDhw/nHP/7BuHHjWLduHdu3b6dz585cfvnlXHbZZSxbtizoWEcccQQffvghpaWlQeeLdI6OgBRhUZAxYZKOhKcyENfi9VnCnDt3+JdZevbwP5aFKiWStuXoo4/G7XYzePBgbrnlFiZMmEBubi4vvPACM2fOZOTIkZx55pkA/Pvf/6asrIxhw4YxcuRI5s6dC8B9993H8ccfz8SJE+natWvEc/3973/nn//8J6NHj/YLLoDLLruMnj17+gPd33nnHf+6c889lx49ejA4Sm/ZSOPVc9ttt3H66aczZswYvxsR4LHHHvMnBJjNZo455hjmzZvHyJEjGT16NO+//z7XX3990LGGDh3Kv/71Lw499FBGjhzJjTfeGPUcHQFF7WACY+zYseqSJUta5VzVP//MzsuvIP+9d7GH+KYlkvZG6csv++O9kg+dSs/nn2fHJZdSs2ABAH1mzcLap+PESkgkiWLt2rVRxYUErrnmGkaPHs2ll17a1kPpUIT7bimKslRV1bHhtpf+iKhogfkdS6hKDjxchYVCgBkM2EeM8MeEuX1mewBLr55tNTyJRNKBGDNmDMnJyR0mw7AjI0VYNAw+l42MCZO0c9y+Gjqdb7mF6p9+wlstsiTdpaWkHX88nW78W9iq+RKJRBLK0qVLGywbP348Dkdw6Zs333yT4cOHt9aw9kukCIuCdtNSPZ42HolE0hBVVan88kssvXr5Y8CsAwZQs2gR3tJSVI8Hz759mLt3w5yX18ajlUgkHZlFixa19RD2S2RgfhT82WO6QEaJpL3gWLuW3X//B9vOPAtPZQUAhuRkDFYral0djo0bwevF0r17G49UIpFIJOGQIiwKmghTpQiTtBPq129g7aDB1K1ajbs0kA5ePW8eIESYYrfhra+n4ssvwWQiJUwrEYlEIpG0PVKERcNkBqQIk7Qfquf+CEDV99/jKS/3L3esFQUeDcnJGJKS8VZXU/nV16RMmYIphuraEolEIml9pAiLgmL2iTCnq41HIpH40ErKKASJMOcOUQ/MkJyMITkJb00N7sJCUmfMaINBSiQSiSQWpAiLgmKW7khJ+0Kr66cYDHgqAnFg3upqUBQMSXYMunYltiGyFpJE0tFJSUlp6yG0GbfddhsPPfRQ3I43ceLEdjEODSnCohCICZOWMEk7wV+zTsFTXo4hNRVTly4AGJKSUAyGIBFm6dOnDQYpkUj2R9z7gUFiga94dXtBirAoyOxISVujejxU//yL3wKmb6FV+fXXGNPTMWVnA/jFl1E3azZYLK03WIlEEhO33HJLUC/I2267jbvuuotp06Zx0EEHMXz4cD7//POYjlVdXR1xvzfeeMPfkuj8888HoLCwkFNOOYWRI0cycuRIFixYwLZt2xg2bJh/v4ceesjfBPuwww7jhhtuYOzYsTz++ON8+eWXjB8/ntGjRzN9+nQKCwv947j44osZPnw4I0aM4OOPP+aVV17hhhtu8B/3xRdf5G9/+1vE1xJuvHpefPFFxo0bx8iRIzn11FOpra0F4MMPP/S3dJo6dSoAq1ev5uCDD2bUqFGMGDGCjRs3AsFWxfvvv5/hw4czcuRIbrnllqjnSBSyTlg0ZHakpI3Z9+qrFD30MN2fe5bUww5D9YqadfXr1uEpK8OYkYHJ1yvNkJYq/vvEmGK1ts2gJZKOxDe3wN6V8T1ml+FwzH0RV5955pnccMMNXH311QB88MEHzJ49m+uuu460tDRKSkqYMGECJ554YqN9Xm02G59++mmD/dasWcNdd93FggULyMnJ8Te7vu666zj00EP59NNP8Xg8VFdX+xuCR8LpdKK1CywrK2PhwoUoisJLL73EAw88wMMPP8ydd95Jeno6K1eu9G9nNpu5++67efDBBzGbzbz66qs8//zzYc+xevXqsOPVM3PmTC6//HJA9NN8+eWXufbaa7njjjuYPXs23bp1o9wXK/vcc89x/fXXc+655+J0OvGE1Pv85ptv+Pzzz1m0aBFJSUn+80U6R6KQIiwK/sB8lxRhkrbBsXkLAB5f+yF/O6LiYgC6/Off/t6Q5i6iga8mwgw2W6uOVSKRxMbo0aMpKipi9+7dFBcXk5mZSZcuXfjb3/7G/PnzMRgM7Nq1i8LCQrr4wg0ioaoqt956a4P9fvzxR04//XR/Q+usrKz/b+/e46qs0oaP/y5gD6AoIioiajCTBiMICIqHJk9RNK9hNoOMWZNUNk1jpj7WlDnJm9qnaWzsYONojQpl42OYM449bz0eUJvyEIykpuYpTDwkIpKoCMJ6/9g3O0AQNdgb4fp+Pn7c97pP19439+ZirXWvBcD69etJT08HwN3dHV9f33qTsKoTc+fl5ZGcnMzx48cpLS0lJMQ+H+3atWtZtmyZYzs/66nsYcOGsXr1asLCwigrK6tzhP264q1q165dTJ8+nTNnzlBcXMydd94JwKBBgxg3bhyjR4/m3nvvBWDAgAHMnj2bvLw87r33Xnr06FHtWGvXriUlJYVWrVpVO19d52gsmoRdgY4TplzOqvnCmr2h4oK9arzE+mvTrU0bPKzR8Ctrvhw1Yd7ezoxUqRvTFWqsGlNSUhIZGRmcOHGC5ORkli5dSn5+PtnZ2dhsNoKDgykpKan3ONe7X1UeHh5UVHw/PV/N/VtX6Wf6xBNPMGXKFBITE9mwYYOj2bIujzzyCC+++CKhoaGkpKRcU1w1jRs3jn/84x9ERkayZMkSNljjI/71r39l69atfPjhh8TExJCdnc19991HXFwcH374IT//+c9ZsGABw4YNu+5zNBbtE3YF39eEacd85Rrmkj0Jq5xCq6JG/wQ3Ly88Kv9itPqLVdaAuWlzpFJNVnJyMsuWLSMjI4OkpCSKioro1KkTNpuNzMxMDh8+fFXHqWu/YcOG8f7771Ng1aJXNrcNHz6c+fPnA1BeXk5RUREBAQGcPHmSgoICLl68yOrVq694vqCgIADS0tIc5fHx8dX6uVXWrsXFxXHkyBHee+89xowZU+dx64q3qrNnzxIYGEhZWRlLly51lB88eJC4uDheeOEFOnbsyJEjRzh06BA//vGPmThxIiNHjmTHjh3VjhUfH8/ixYsdfb4qz1fXORqLJmFXoE9HKlerWQtrLlyotizerbAF2acl8o6OAuy1YwCtb7218QNUSl2XXr16cfbsWYKCgggMDGTs2LFkZWURERFBeno6oaGhV3Wcuvbr1asXzz33HIMHDyYyMpIpU6YA8Nprr5GZmUlERAQxMTHs3r0bm83G888/T79+/YiPj7/iuVNTU0lKSiImJsbRdAj2/lOFhYWODvKZmZmOdaNHj2bQoEGOJsq6Po/a4q1q5syZxMXFMWjQoGoxPvXUU0RERBAeHs7AgQOJjIxk+fLlhIeHExUVxa5du/j1r39d7VgJCQkkJiYSGxtLVFSUY/iJus7RWMRUedrqRhAbG2sqOwg2NmMMe8N+SofHf0vHiROdck6lqjoyYQLFa9fReeYL+CUl8c1DD3Hus82O9T0+/Tce/v6U7NmD5y23IG72v6tK9u3DMyTEUZurlPrenj17CAvTMfScZcSIEUyePJnhLWAKtdp+tkQk2xgTW9v2WhN2BSICNpt2zFdOY0pLObdtGwAXD31N2dFjABSvW893a9ZwPueLattXNj16hYU5EjAAr549NQFTSrnUmTNn6NmzJ97e3i0iAbse2jG/HuLhoR3zldOcfPU1Ti9aRPCKDHJ/8UtHefGGDY5JuqvSzvdKtQw7d+68bOwsT09Ptm7d6qKI6teuXTv27dtXraygoKDWhGzdunX4W2MetiSahNVDkzDlTBetL6zKISlq03PrFvbF9QeoVvullGq+IiIiyMnJcXUYP5i/v3+zeB8NpVG/wUUkQUS+EpEDIvJMLeuniMhuEdkhIutE5KbGjOd62JMw7ZivnMTNPjCjqfK4eE3uvr7OikYppVQjarSaMBFxB94E4oE84HMRWWWM2V1ls+1ArDHmvIj8FngZSL78aK4jNpsOUaGcRsT+d1FF8bnL1vndf//3U2kppZS64TXmN3o/4IAx5hCAiCwDRgKOJMwYk1ll+y3A/Y0Yz3URDw/QjvnKWazxwMqOH7tsVefpzzk7GqWUUo2oMZsjg4AjVZbzrLK6PAz8v0aM5/rYtE+YciKrObLs2OVJmFJKtURLlizhWDP9TmwSbRsicj8QCwyuY/2jwKMA3bt3d2JkIB42TcKUU5R8tc8xJ2R9SVjQ3D9fNnq+UkrVdOnSJTxu8G4MS5YsITw8nC7WFG3NSWPWhB0FulVZ7mqVVSMitwPPAYnGmIu1HcgYs9AYE2uMie3YsWOjBFsXfTpSOUNFSQlfjxxJyRf2qTUu1UjCbN26VVtue9ddtPvFL5wWn1Kq4d1zzz3ExMTQq1cvFi5cCMBHH31Enz59iIyMdAzlUFxcTEpKChEREfTu3ZsVK1YA4OPj4zhWRkYG48aNA+zzHz722GPExcXx9NNPs23bNgYMGEB0dDQDBw7kq6++AuzTFk2dOpXw8HB69+7NG2+8wfr167nnnnscx12zZg2jRo2q8z0sXryYnj170q9fP8aPH8+ECRMcMWRkZDi2q4y1uLiY4cOH06dPHyIiIvjnP/8JQG5uLmFhYYwfP55evXpxxx13cOHCBTIyMsjKymLs2LFERUVx4cIFgoODOXXqFABZWVkMGTIEsI/m/+CDD/Kzn/2Mm266iQ8++ICnn36aiIgIEhISKGuC/bsbMz3+HOghIiHYk69fAfdV3UBEooEFQIIx5mQjxnLd9OlI1VgOjhhB6YGDdHpq6mVJ1sX9BxyvA6ZPx+9XTep5FaWajT9u+yN7T+9t0GOGtg/l9/1+X+92ixYton379ly4cIG+ffsycuRIxo8fz6ZNmwgJCXHMZzhz5kx8fX3ZuXMn8P28jFeSl5fHZ599hru7O9999x2ffPIJHh4erF27lmnTprFixQoWLlxIbm4uOTk5eHh4cPr0afz8/Hj88cfJz8+nY8eOLF68mIceeqjWcxw/fpwZM2aQnZ2Nr68vQ4cOJTo6+opxeXl5sXLlStq2bcupU6fo378/iYmJAOzfv5+///3vvPXWW4wePZoVK1Zw//33M2/ePObMmUNsbK2Dzldz8OBBMjMz2b17NwMGDGDFihW8/PLLjBo1ig8//LBagtkUNFoSZoy5JCITgI8Bd2CRMeZLEXkByDLGrAL+BPgA74sIwDfGmMTGiul62DvmaxKmGlbF+fOUHjgIwMk/zcGjc+c6t3Xz9tKnIpVqhl5//XVWrlwJwJEjR1i4cCG33XYbISEhALRv3x6AtWvXsmzZMsd+V5qDsVJSUhLu1oM+RUVFPPjgg+zfvx8RcdQIrV27lscee8zRXFl5vgceeIB3332XlJQUNm/eTHp6eq3n2Lp1K0OGDKGyhSo5OfmywVlrMsYwbdo0Nm3ahJubG0ePHuXbb78FICQkhKioKABiYmLIzc2t933WdNddd2Gz2YiIiKC8vJyEhATAPs7a9RyvsTXqN7sx5n+A/6lR9nyV17c35vkbgnh5UXGx1NVhqGbm4oED1ZYvnTgBQKt+/fDo2JGSr/YS8NRT5D05ida3/swVISrVIlxNjVVj2LBhA2vXrmXz5s20atWKIUOGEBUVxd69V18rZ1VeAFBSUlJtXevWrR2v//CHPzB06FBWrlxJbm6uo/muLikpKdx99914eXmRlJR0XX3KPDw8qLDGO6yoqKC01P57dOnSpeTn55OdnY3NZiM4ONgRu6enp2N/d3d3Lly4UO+xa77vymO4ublhs9kcn5GbmxuXmmDXIh1uux5ubXyoOHvW1WGoZqSipITc0bU3L96UnkbQK3P4yerV+AweTGjOdmwBnZwcoVKqsRUVFeHn50erVq3Yu3cvW7ZsoaSkhE2bNvH1118DOJoj4+PjefPNNx37VjZHBgQEsGfPHioqKhw1anWdKyjIPjjBkiVLHOXx8fEsWLDAkZxUnq9Lly506dKFWbNmkZKSUudx4+Li2LhxIwUFBZSVlfH+++871gUHB5OdnQ3AqlWrHLVvRUVFdOrUCZvNRmZmJocPH673s2rTpg1nq/wernrsyv5xNypNwurh3qYt5ZqEqQZyPDWVw/eNdXUYSikXS0hI4NKlS4SFhfHMM8/Qv39/OnbsyMKFC7n33nuJjIwkOdn+x9r06dMpLCwkPDycyMhIMjPtQ2y+9NJLjBgxgoEDBxIYGFjnuZ5++mmeffZZoqOjq9UGPfLII3Tv3p3evXsTGRnJe++951g3duxYunXrRlhYWJ3HDQwMJDU1lQEDBjBo0KBq244fP56NGzcSGRnJ5s2bHTVzY8eOJSsri4iICNLT0wkNDa33s6p80KCyY/6MGTN48skniY2NdTS53qjEGOPqGK5JbGysycrKctr5Trz4IkUfrOSWrM+ddk7VPJz//HPEuxU/uqk7ZceOYwvszL5+cdhu6o7YbLj7tKH8zBlKrX4K3RYuwOe221wbtFItwJ49e66YXCiYMGEC0dHRPPzww1e9z5IlS8jKymLevHmNGFnTVtvPlohkG2NqfapAe/vWw71NWyqKizHl5cgNnnEr5yk7eZLDD/waAM9bbuHiV18RbFXVd5o8mbZWZ9GL+/dz6G77syiagCmlmoKYmBhat27NK6+84upQmj1Nwurh1sY+tknFuXO4t23r4mhUU1V+9iwHhgyl4tw5ui9eVG1suYvWmDy5SUkA2KoMOOjeoYNzA1VKqXpU9reqKi4ujosXqw/l+c477xAREeFYHjdunGOsMnV1NAmrh3sbe+JV/t1ZTcJUnS7uP0DFOfuk23m/m4D/bx8DoFVcHOe3bq22bbUkzNfXeUEqpdR12lrje0w1DO2YX4/KmrDywtMujkQ1Zebi949JV5w/z/ltn+MRGEi3+X/BdtP3U215hobi7u/vWBY3Nzx73EzHSU86NV6llFKupzVh9fCwfmGeeGEmIe8vd3E0qqkqLyqqtnzuk0/wGTIEt1atuPnjj6+474//9a/GDE0ppVQTpTVh9fCOisLN1xdTUvugcUpVlJZydNJkALov+hs/Cg4G7B3ylVJKqbpoElYPcXenTfztlJ8pqn9j1eJc2LmL89u+H77EOyaGjpMm0apvX9reeYcLI1NKKdXUaXPkVfBo147yoiKMMdWmiVAt27ktW/hmXAresTGOMjdPT9om3EnbhDtdGJlSSqkbgdaEXQU3X19MaSmmjnmsVMtUsnsPABeyLn+cWymlGoqPj4+rQ2g2Xn31Vc6fP+/qMBw0CbsK7u3aAZD/2uuc27bNtcEolzNlZZxeupRTCxZUK+867w0XRaSUUo2vKU6Afa2aWhKmzZFXwb2tfSyn02lpnE5L45b/ZOPWqpWLo1Kukv+Xv1Aw/6/VyloPHECb2293UURKqet14sUXubhnb4Me0zMslM7TptW5/plnnqFbt2787ne/AyA1NRUPDw8yMzMpLCykrKyMWbNmMXLkyHrPVVxczMiRI2vdLz09nTlz5iAi9O7dm3feeYdvv/2Wxx57jEOHDgEwf/58unTpwogRI9i1axcAc+bMobi4mNTUVIYMGUJUVBT//ve/GTNmDD179mTWrFmUlpbi7+/P0qVLCQgIoLi4mCeeeIKsrCxEhBkzZlBUVMSOHTt49dVXAXjrrbfYvXs3c+fOrfW9zJ49m7S0NDp16kS3bt2IiYlh6tSpDBkyhDlz5hAbG8upU6eIjY0lNzeX3NxcHnjgAc5ZYzTOmzePgQMHsmHDBlJTU+nQoQO7du0iJiaGd999lzfeeINjx44xdOhQOnToQGZmJj4+PhQXFwOQkZHB6tWrWbJkCePGjcPb25vt27dz8uRJFi1aRHp6Ops3byYuLq7aROg/hCZhV8HNp3W15cPjUghZ/t8uika50oWduy5LwAC6L1rkgmiUUjei5ORkJk2a5EjCli9fzscff8zEiRNp27Ytp06don///iQmJtbbD9nLy4uVK1dett/u3buZNWsWn332GR06dOD0aftYlxMnTmTw4MGsXLmS8vJyiouLKSwsvOI5SktLqZyzubCwkC1btiAivP3227z88su88sorzJw5E19fX3bu3OnYzmazMXv2bP70pz9hs9lYvHgxC2q0IFTKzs5m2bJl5OTkcOnSJfr06UNMTEyt21bq1KkTa9aswcvLi/379zNmzBhHnNu3b+fLL7+kS5cuDBo0iE8//ZSJEyfy5z//mczMTDpcxWwlhYWFbN68mVWrVpGYmMinn37K22+/Td++fcnJySEqKqreY9RHk7Cr0HrgQFoPGsS5Tz8F7NPQmPJyijMzKViyBLfWres5gmouyr45Um355vXrqGhCVdtKqWtzpRqrxhIdHc3Jkyc5duwY+fn5+Pn50blzZyZPnsymTZtwc3Pj6NGjfPvtt3Tu3PmKxzLGMG3atMv2W79+PUlJSY5ko3379gCsX7+e9PR0ANzd3fH19a03CUtOTna8zsvLIzk5mePHj1NaWkpISAgAa9euZdmyZY7t/Pz8ABg2bBirV68mLCyMsrKyatMcVfXJJ58watQoWlmtTImJiVeMCaCsrIwJEyaQk5ODu7s7+/btc6zr168fXbt2BSAqKorc3FxuvfXWeo9Z1d13342IEBERQUBAgCP2Xr16kZubq0mYs4gIQa/M4fgfnscrPJz8uXM5s2IFJ56f4djGKzzchREqZ3Fr3ZqOkyfj3t6Piu++qzYFkVJKXa2kpCQyMjI4ceIEycnJLF26lPz8fLKzs7HZbAQHB1NSUlLvca53v6o8PDyoqKhwLNfcv3WVioYnnniCKVOmkJiY6Gj2u5JHHnmEF198kdDQUFJSUq4prtriqxrb3LlzCQgI4IsvvqCiogIvLy/HOk9PT8drd3f3OvuzVa1prPm+K4/h5uZW7Xhubm4N1j9Ok7Cr5N6uHV3feJ2LBw+SP3dutQQs4A/TaT92rAujU0opdSNJTk5m/PjxnDp1io0bN7J8+XI6deqEzWYjMzOTw4cPX9VxioqKat1v2LBhjBo1iilTpuDv78/p06dp3749w4cPZ/78+UyaNMnRHBkQEMDJkycpKCjAx8eH1atXk5CQUOf5goKCAEhLS3OUx8fH8+abbzr6fxUWFuLn50dcXBxHjhzhP//5Dzt27Kjzfdx2222MGzeOZ599lkuXLvGvf/2L3/zmNwAEBweTnZ1Nv379yMjIqBZL165dcXNzIy0tjfLy8no/rzZt2nD27FlHDWFAQAB79uzhlltuYeXKlbRp06beYzQkfTryGnn+5Cf85OOPCF6RQciqf3Lzpo343Xefq8NSSil1A+nVqxdnz54lKCiIwMBAxo4dS1ZWFhEREaSnpxMaGnpVx6lrv169evHcc88xePBgIiMjmTJlCgCvvfYamZmZREREEBMTw+7du7HZbDz//PP069eP+Pj4K547NTWVpKQkYmJiqvWrmj59OoWFhYSHhxMZGUlmZqZj3ejRoxk0aJCjibI2ffr0ITk5mcjISO666y769u3rWDd16lTmz59PdHQ0p06dcpQ//vjjpKWlERkZyd69e6vV2NXl0UcfJSEhgaFDhwLw0ksvMWLECAYOHEhgYGC9+zc0McY4/aQ/RGxsrKnseKeUUkpdqz179hAWFubqMFqMESNGMHnyZIYPH37V+6SmpuLj48PUqVMbMbKGV9vPlohkG2Nia9tea8KUUkop1eDOnDlDz5498fb2vqYErCXRPmFKKaVUE7dz504eeOCBamWenp5s3brVRRHVr127dtWeWAQoKCioNSFbt24d/v7+juX6Ovw3F5qEKaWUUk1cREQEOTk5rg7jB/P3928W76OhaHOkUkqpFudG6w+tmr7r+ZnSJEwppVSL4uXlRUFBgSZiqsEYYygoKKg2VtnV0OZIpZRSLUrXrl3Jy8sjPz/f1aGoZsTLy8sxSv/V0iRMKaVUi2Kz2RzT7SjlStocqZRSSinlApqEKaWUUkq5gCZhSimllFIucMNNWyQi+cDVzWx6/ToAp+rdSjmbXpemSa9L06PXpGnS69L0OOOa3GSM6VjbihsuCXMGEcmqa54n5Tp6XZomvS5Nj16TpkmvS9Pj6muizZFKKaWUUi6gSZhSSimllAtoEla7ha4OQNVKr0vTpNel6dFr0jTpdWl6XHpNtE+YUkoppZQLaE2YUkoppZQLaBJWg4gkiMhXInJARJ5xdTwthYh0E5FMEdktIl+KyJNWeXsRWSMi+63//axyEZHXreu0Q0T6uPYdNG8i4i4i20VktbUcIiJbrc//v0XkR1a5p7V8wFof7NLAmykRaSciGSKyV0T2iMgAvVdcT0QmW99fu0Tk7yLipfeK84nIIhE5KSK7qpRd8/0hIg9a2+8XkQcbI1ZNwqoQEXfgTeAu4KfAGBH5qWujajEuAf9ljPkp0B/4nfXZPwOsM8b0ANZZy2C/Rj2sf48C850fcovyJLCnyvIfgbnGmJuBQuBhq/xhoNAqn2ttpxrea8BHxphQIBL7tdF7xYVEJAiYCMQaY8IBd+BX6L3iCkuAhBpl13R/iEh7YAYQB/QDZlQmbg1Jk7Dq+gEHjDGHjDGlwDJgpItjahGMMceNMf+xXp/F/kslCPvnn2ZtlgbcY70eCaQbuy1AOxEJdG7ULYOIdAX+D/C2tSzAMCDD2qTmdam8XhnAcGt71UBExBe4DfgbgDGm1BhzBr1XmgIPwFtEPIBWwHH0XnE6Y8wm4HSN4mu9P+4E1hhjThtjCoE1XJ7Y/WCahFUXBBypspxnlSknsqrlo4GtQIAx5ri16gQQYL3Wa+U8rwJPAxXWsj9wxhhzyVqu+tk7rou1vsjaXjWcECAfWGw1Eb8tIq3Re8WljDFHgTnAN9iTryIgG71XmoprvT+cct9oEqaaFBHxAVYAk4wx31VdZ+yP8urjvE4kIiOAk8aYbFfHohw8gD7AfGNMNHCO75tWAL1XXMFqqhqJPUnuArSmEWpO1A/XlO4PTcKqOwp0q7Lc1SpTTiAiNuwJ2FJjzAdW8beVTSfW/yetcr1WzjEISBSRXOzN88Ow90dqZzW5QPXP3nFdrPW+QIEzA24B8oA8Y8xWazkDe1Km94pr3Q58bYzJN8aUAR9gv3/0XmkarvX+cMp9o0lYdZ8DPaynWX6EvVPlKhfH1CJYfSH+Buwxxvy5yqpVQOVTKQ8C/6xS/mvryZb+QFGVqmbVQIwxzxpjuhpjgrHfD+uNMWOBTOCX1mY1r0vl9fqltX2T+IuzuTDGnACOiMgtVtFwYDd6r7jaN0B/EWllfZ9VXhe9V5qGa70/PgbuEBE/q5bzDqusQelgrTWIyM+x94FxBxYZY2a7NqKWQURuBT4BdvJ936Np2PuFLQe6A4eB0caY09aX3Dzs1f3ngRRjTJbTA29BRGQIMNUYM0JEfoy9Zqw9sB243xhzUUS8gHew9+k7DfzKGHPIRSE3WyIShf1BiR8Bh4AU7H9U673iQiLyf4Fk7E97bwcewd6PSO8VJxKRvwNDgA7At9ifcvwH13h/iMhD2H8PAcw2xixu8Fg1CVNKKaWUcj5tjlRKKaWUcgFNwpRSSimlXECTMKWUUkopF9AkTCmllFLKBTQJU0oppZRyAU3ClFLNioiUi0hOlX/P1L/XVR87WER2NdTxlFItm0f9myil1A3lgjEmytVBKKVUfbQmTCnVIohIroi8LCI7RWSbiNxslQeLyHoR2SEi60Sku1UeICIrReQL699A61DuIvKWiHwpIv8rIt4ue1NKqRuaJmFKqebGu0ZzZHKVdUXGmAjsI2S/apW9AaQZY3oDS4HXrfLXgY3GmEjsczN+aZX3AN40xvQCzgC/aNR3o5RqtnTEfKVUsyIixcYYn1rKc4FhxphD1mTxJ4wx/iJyCgg0xpRZ5ceNMR1EJB/oaoy5WOUYwcAaY0wPa/n3gM0YM8sJb00p1cxoTZhSqiUxdby+FhervC5H+9Yqpa6TJmFKqZYkucr/m63XnwG/sl6PxT6RPMA64LcAIuIuIr7OClIp1TLoX3BKqebGW0Ryqix/ZIypHKbCT0R2YK/NGmOVPQEsFpGngHwgxSp/ElgoIg9jr/H6LXC8sYNXSrUc2idMKdUiWH3CYo0xp1wdi1JKgTZHKqWUUkq5hNaEKaWUUkq5gNaEKaWUUkq5gCZhSimllFIuoEmYUkoppZQLaBKmlFJKKeUCmoQppZRSSrmAJmFKKaWUUi7w/wHvnB5cNJf+XAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 720x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
+    "#docs_infra: no_execute\n",
     "plt.figure(figsize=(10,5))\n",
     "plt.plot(classical_history.history['accuracy'], label='accuracy_classical')\n",
     "plt.plot(classical_history.history['val_accuracy'], label='val_accuracy_classical')\n",
@@ -878,7 +1102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Despite my best efforts the quantum_data tutorial flakes around 1 in every 8 runs. The version that is live happened to be one such flake. I ran locally and saved outputs and flagged the docs infra to not run the flaky cells.