### PR TITLE
Fix the tensorflow package naming in configure.sh

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -52,7 +52,7 @@ function is_ppc64le() {
 # Check if we are building GPU or CPU ops, default CPU
 while [[ "$TF_NEED_CUDA" == "" ]]; do
   read -p "Do you want to build ops again TensorFlow CPU pip package?"\
-" Y or enter for CPU (tensorflow), N for GPU (tensorflow-gpu). [Y/n] " INPUT
+" Y or enter for CPU (tensorflow-cpu), N for GPU (tensorflow). [Y/n] " INPUT
   case $INPUT in
     [Yy]* ) echo "Build with CPU pip package."; TF_NEED_CUDA=0;;
     [Nn]* ) echo "Build with GPU pip package."; TF_NEED_CUDA=1;;
@@ -76,39 +76,39 @@ done
 if [[ "$TF_NEED_CUDA" == "0" ]]; then
 
   # Check if it's installed
-  if [[ $(pip show tensorflow) == *tensorflow* ]] || [[ $(pip show tf-nightly) == *tf-nightly* ]] ; then
+  if [[ $(pip show tensorflow-cpu) == *tensorflow-cpu* ]] || [[ $(pip show tf-nightly-cpu) == *tf-nightly-cpu* ]] ; then
     echo 'Using installed tensorflow'
   else
     # Uninstall GPU version if it is installed.
-    if [[ $(pip show tensorflow-gpu) == *tensorflow-gpu* ]]; then
+    if [[ $(pip show tensorflow) == *tensorflow* ]]; then
       echo 'Already have gpu version of tensorflow installed. Uninstalling......\n'
-      pip uninstall tensorflow-gpu
-    elif [[ $(pip show tf-nightly-gpu) == *tf-nightly-gpu* ]]; then
+      pip uninstall tensorflow
+    elif [[ $(pip show tf-nightly) == *tf-nightly* ]]; then
       echo 'Already have gpu version of tensorflow installed. Uninstalling......\n'
-      pip uninstall tf-nightly-gpu
+      pip uninstall tf-nightly
     fi
     # Install CPU version
-    echo 'Installing tensorflow......\n'
-    pip install tensorflow
+    echo 'Installing tensorflow-cpu......\n'
+    pip install tensorflow-cpu
   fi
 
 else
 
   # Check if it's installed
-   if [[ $(pip show tensorflow-gpu) == *tensorflow-gpu* ]] || [[ $(pip show tf-nightly-gpu) == *tf-nightly-gpu* ]]; then
-    echo 'Using installed tensorflow-gpu'
+   if [[ $(pip show tensorflow) == *tensorflow* ]] || [[ $(pip show tf-nightly) == *tf-nightly* ]]; then
+    echo 'Using installed tensorflow'
   else
     # Uninstall CPU version if it is installed.
-    if [[ $(pip show tensorflow) == *tensorflow* ]]; then
+    if [[ $(pip show tensorflow-cpu) == *tensorflow-cpu* ]]; then
       echo 'Already have tensorflow non-gpu installed. Uninstalling......\n'
       pip uninstall tensorflow
-    elif [[ $(pip show tf-nightly) == *tf-nightly* ]]; then
+    elif [[ $(pip show tf-nightly-cpu) == *tf-nightly-cpu* ]]; then
       echo 'Already have tensorflow non-gpu installed. Uninstalling......\n'
       pip uninstall tf-nightly
     fi
-    # Install CPU version
-    echo 'Installing tensorflow-gpu .....\n'
-    pip install tensorflow-gpu
+    # Install GPU version
+    echo 'Installing tensorflow .....\n'
+    pip install tensorflow
   fi
 fi
 


### PR DESCRIPTION
related to this issue and PR: 
https://github.com/tensorflow/custom-op/issues/74
https://github.com/tensorflow/custom-op/pull/79/files

It can affect this issue, even if cpu only custom ops are compiled:
https://github.com/tensorflow/tensorflow/issues/43022

```
2020-09-07 15:46:38.915193: W tensorflow/stream_executor/platform/default/dso_loader.cc:59] Could not load dynamic library 'cudart64_101.dll'; dlerror: cudart64_101.dll not found
2020-09-07 15:46:38.915211: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
2020-09-07 15:46:40.468711: W tensorflow/stream_executor/platform/default/dso_loader.cc:59] Could not load dynamic library 'cudart64_101.dll'; dlerror: cudart64_101.dll not found
2020-09-07 15:46:40.468729: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.

...

ERROR: C:/users/patrik.veges/_bazel_patrik.veges/gdil2b47/external/local_config_tf/BUILD:3:11 Executing genrule @local_config_tf//:tf_header_include failed (Exit 35584)
```