### PR TITLE
Removes use of old qubits

### DIFF
--- a/docs/tutorials/hello_many_worlds.ipynb
+++ b/docs/tutorials/hello_many_worlds.ipynb
@@ -920,11 +920,11 @@
         "        full_circuit,\n",
         "        {s:v for (s,v) in zip(control_params, params_to_prepare_output[index])}\n",
         "    ).final_state_vector\n",
-        "    expectation = z0.expectation_from_state_vector(state, {qubit: 0}).real\n",
+        "    expt = cirq.Z(qubit).expectation_from_state_vector(state, {qubit: 0}).real\n",
         "    print(f'For a desired output (expectation) of {desired_values[index]} with'\n",
         "          f' noisy preparation, the controller\\nnetwork found the following '\n",
         "          f'values for theta: {params_to_prepare_output[index]}\\nWhich gives an'\n",
-        "          f' actual expectation of: {expectation}\\n')\n",
+        "          f' actual expectation of: {expt}\\n')\n",
         "\n",
         "\n",
         "check_error(commands, expected_outputs)"


### PR DESCRIPTION
In part 2 of the hello many worlds tutorial we used some paulisum operations that were defined on qubits defined in part 1. This changes things so that the paulisums defined in part 2 use qubits from part 2. Fixes #467