### PR TITLE
Custom gate_approx_eq

### DIFF
--- a/tensorflow_quantum/core/ops/tfq_utility_ops_test.py
+++ b/tensorflow_quantum/core/ops/tfq_utility_ops_test.py
@@ -302,8 +302,8 @@ class ResolveParametersOpTest(tf.test.TestCase, parameterized.TestCase):
                                  expected_resolved_circuits):
             for test_m, exp_m in zip(test_c, exp_c):
                 for test_o, exp_o in zip(test_m, exp_m):
-                    self.assertTrue(
-                        util.gate_approx_eq(test_o.gate, exp_o.gate))
+                    self.assertTrue(util.gate_approx_eq(test_o.gate,
+                                                        exp_o.gate))
 
 
 if __name__ == '__main__':

--- a/tensorflow_quantum/core/ops/tfq_utility_ops_test.py
+++ b/tensorflow_quantum/core/ops/tfq_utility_ops_test.py
@@ -133,27 +133,6 @@ class AppendCircuitOpTest(tf.test.TestCase, parameterized.TestCase):
 class ResolveParametersOpTest(tf.test.TestCase, parameterized.TestCase):
     """Test the in-graph parameter resolving op."""
 
-    def _compare_gate_parameters(self, tg_value, eg_value):
-        """TODO(zaqqwerty): Remove this function and the gate-specific tests
-        below once https://github.com/quantumlib/Cirq/issues/3192 is resolved"""
-        rounding_digits = 3
-        if isinstance(tg_value, int):
-            self.assertAlmostEqual(tg_value, eg_value)
-        elif isinstance(tg_value, float):
-            self.assertAlmostEqual(tg_value, eg_value, places=rounding_digits)
-        else:
-            test_value = 1
-            exp_value = 1
-            for v in tg_value.args:
-                if not isinstance(v, sympy.Symbol):
-                    test_value *= sympy.N(v)
-            for v in eg_value.args:
-                if not isinstance(v, sympy.Symbol):
-                    exp_value *= sympy.N(v)
-            self.assertAlmostEqual(test_value,
-                                   exp_value,
-                                   delta=0.1**rounding_digits)
-
     def test_resolve_parameters_input_checking(self):
         """Check that the resolve parameters op has correct input checking."""
         n_qubits = 5
@@ -323,45 +302,8 @@ class ResolveParametersOpTest(tf.test.TestCase, parameterized.TestCase):
                                  expected_resolved_circuits):
             for test_m, exp_m in zip(test_c, exp_c):
                 for test_o, exp_o in zip(test_m, exp_m):
-                    tg = test_o
-                    eg = exp_o
-                    if isinstance(tg, cirq.ControlledOperation):
-                        self.assertEqual(tg.controls, eg.controls)
-                        self.assertEqual(tg.control_values, eg.control_values)
-                        # Pull out controlled gate for tests later on.
-                        tg = tg.sub_operation
-                        eg = eg.sub_operation
-
-                    tg = tg.gate
-                    eg = eg.gate
-
-                    self.assertEqual(type(tg), type(eg))
-                    # TODO(zaqqwerty): simplify parsing when cirq build parser
-                    # see core/serialize/serializer.py
-                    if isinstance(tg, cirq.IdentityGate):
-                        # all identity gates are the same
-                        continue
-                    elif isinstance(tg, cirq.EigenGate):
-                        self._compare_gate_parameters(tg._global_shift,
-                                                      eg._global_shift)
-                        self._compare_gate_parameters(tg._exponent,
-                                                      eg._exponent)
-                    elif isinstance(tg, cirq.FSimGate):
-                        self._compare_gate_parameters(tg.theta, eg.theta)
-                        self._compare_gate_parameters(tg.phi, eg.phi)
-                    elif isinstance(
-                            tg, (cirq.PhasedXPowGate, cirq.PhasedISwapPowGate)):
-                        self._compare_gate_parameters(tg._global_shift,
-                                                      eg._global_shift)
-                        self._compare_gate_parameters(tg._exponent,
-                                                      eg._exponent)
-                        self._compare_gate_parameters(tg._phase_exponent,
-                                                      eg._phase_exponent)
-                    else:
-                        self.assertTrue(False,
-                                        msg="Some gate in the randomizer "
-                                        "is not being checked: "
-                                        "{}".format(type(tg)))
+                    self.assertTrue(
+                        util.is_gate_approx_eq(test_o.gate, exp_o.gate))
 
 
 if __name__ == '__main__':

--- a/tensorflow_quantum/core/ops/tfq_utility_ops_test.py
+++ b/tensorflow_quantum/core/ops/tfq_utility_ops_test.py
@@ -303,7 +303,7 @@ class ResolveParametersOpTest(tf.test.TestCase, parameterized.TestCase):
             for test_m, exp_m in zip(test_c, exp_c):
                 for test_o, exp_o in zip(test_m, exp_m):
                     self.assertTrue(
-                        util.is_gate_approx_eq(test_o.gate, exp_o.gate))
+                        util.gate_approx_eq(test_o.gate, exp_o.gate))
 
 
 if __name__ == '__main__':

--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -457,7 +457,8 @@ def gate_approx_eq(gate_true, gate_deser, atol=1e-5):
         raise TypeError(f"`gate_true` not a cirq gate, got {type(gate_true)}")
     if not isinstance(gate_deser, cirq.Gate):
         raise TypeError(f"`gate_deser` not a cirq gate, got {type(gate_deser)}")
-    if isinstance(gate_true, cirq.ControlledGate) != isinstance(gate_deser, cirq.ControlledGate):
+    if isinstance(gate_true, cirq.ControlledGate) != isinstance(
+            gate_deser, cirq.ControlledGate):
         raise TypeError("Both gates must be ControlledGates, or neither.")
     if isinstance(gate_true, cirq.ControlledGate):
         if gate_true.control_qid_shape != gate_deser.control_qid_shape:
@@ -467,11 +468,9 @@ def gate_approx_eq(gate_true, gate_deser, atol=1e-5):
         return gate_approx_eq(gate_true.sub_gate, gate_deser.sub_gate)
     supported_gates = serializer.SERIALIZER.supported_gate_types()
     if not any([isinstance(gate_true, g) for g in supported_gates]):
-        raise ValueError(
-            f"`gate_true` not a valid TFQ gate, got {gate_true}")
+        raise ValueError(f"`gate_true` not a valid TFQ gate, got {gate_true}")
     if not any([isinstance(gate_deser, g) for g in supported_gates]):
-        raise ValueError(
-            f"`gate_deser` not a valid TFQ gate, got {gate_deser}")
+        raise ValueError(f"`gate_deser` not a valid TFQ gate, got {gate_deser}")
     if not isinstance(gate_true, type(gate_deser)):
         return False
     if isinstance(gate_true, type(cirq.I)) and isinstance(

--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 # ==============================================================================
 """A collection of helper functions that are useful several places in tfq."""
-import random
+
 import itertools
+import numbers
+import random
 
 import numpy as np
 import sympy

--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -453,17 +453,25 @@ def gate_approx_eq(gate_true, gate_deser, atol=1e-5):
         bool which says if the two gates are approximately equal in the way
             described above.
     """
-    if not isinstance(gate_true, cirq.ops.raw_types.Gate):
+    if not isinstance(gate_true, cirq.Gate):
         raise TypeError(f"`gate_true` not a cirq gate, got {type(gate_true)}")
-    if not isinstance(gate_deser, cirq.ops.raw_types.Gate):
+    if not isinstance(gate_deser, cirq.Gate):
         raise TypeError(f"`gate_deser` not a cirq gate, got {type(gate_deser)}")
+    if isinstance(gate_true, cirq.ControlledGate) != isinstance(gate_deser, cirq.ControlledGate):
+        raise TypeError("Both gates must be ControlledGates, or neither.")
+    if isinstance(gate_true, cirq.ControlledGate):
+        if gate_true.control_qid_shape != gate_deser.control_qid_shape:
+            return False
+        if gate_true.control_values != gate_deser.control_values:
+            return False
+        return gate_approx_eq(gate_true.sub_gate, gate_deser.sub_gate)
     supported_gates = serializer.SERIALIZER.supported_gate_types()
     if not any([isinstance(gate_true, g) for g in supported_gates]):
         raise ValueError(
-            f"`gate_true` is not a valid TFQ gate, got {gate_true}")
+            f"`gate_true` not a valid TFQ gate, got {gate_true}")
     if not any([isinstance(gate_deser, g) for g in supported_gates]):
         raise ValueError(
-            f"`gate_deser` is not a valid TFQ gate, got {gate_deser}")
+            f"`gate_deser` not a valid TFQ gate, got {gate_deser}")
     if not isinstance(gate_true, type(gate_deser)):
         return False
     if isinstance(gate_true, type(cirq.I)) and isinstance(

--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -453,9 +453,9 @@ def gate_approx_eq(gate_true, gate_deser, atol=1e-5):
         bool which says if the two gates are approximately equal in the way
             described above.
     """
-    if not isinstance(gate_true, cirq.Gate):
+    if not isinstance(gate_true, cirq.ops.raw_types.Gate):
         raise TypeError(f"`gate_true` not a cirq gate, got {type(gate_true)}")
-    if not isinstance(gate_deser, cirq.Gate):
+    if not isinstance(gate_deser, cirq.ops.raw_types.Gate):
         raise TypeError(f"`gate_deser` not a cirq gate, got {type(gate_deser)}")
     supported_gates = serializer.SERIALIZER.supported_gate_types()
     if not any([isinstance(gate_true, g) for g in supported_gates]):

--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -402,6 +402,94 @@ def _symbols_in_op(op):
         "tfq.util.get_supported_gates().")
 
 
+def _expression_approx_eq(exp_1, exp_2, atol):
+    """Compare possibly symbolic expressions for approximate equality.
+
+    Coefficient based approximate equality.  If no symbol is present in
+    `exp_1` or `exp_2`, then return true if the expressions are approximately
+    equal.  If the expressions contain symbols, return true if the two symbols
+    are the same and their coefficients are approximately equal.
+
+    Args:
+      exp_1: An argument to a cirq Gate, either a `sympy.Basic` or a number.
+      exp_1: An argument to a cirq Gate, either a `sympy.Basic` or a number.
+      atol: Float determining how close the coefficients must be for truth.
+
+    Returns:
+      bool which says whether the coefficients of `exp_1` and `exp_2` are
+        approximately equal.
+    """
+    if not isinstance(atol, numbers.Real):
+        raise TypeError("atol must be a real number.")
+    s_1 = serializer._symbol_extractor(exp_1)
+    s_2 = serializer._symbol_extractor(exp_2)
+    v_1 = serializer._scalar_extractor(exp_1)
+    v_2 = serializer._scalar_extractor(exp_2)
+    v_eq = cirq.approx_eq(v_1, v_2, atol=atol)
+    if isinstance(s_1, numbers.Real) and isinstance(s_2, numbers.Real):
+        return cirq.approx_eq(s_1, s_2, atol=atol) and v_eq
+    if isinstance(s_1, sympy.Symbol) and isinstance(s_2, sympy.Symbol):
+        return str(s_1) == str(s_2) and v_eq
+    return False
+
+
+def gate_approx_eq(gate_true, gate_deser, atol=1e-5):
+    """Compares gates in the allowed TFQ gate set.
+
+    Gates in TFQ support symbols, numbers or a single product of a real number
+    and a symbol as their parameters. This function behaves like
+    `cirq.approx_eq` specialized for these kinds of gates so that TFQ can
+    support approximate equality in gates containing symbols.
+
+    Args:
+        gate_true: `cirq.Gate` which is in the TFQ gate set.  These are gates
+          which are instances of those found in `tfq.util.get_supported_gates()`
+        gate_deser: `cirq.Gate` which is in the TFQ gate set.  These are gates
+          which are instances of those found in `tfq.util.get_supported_gates()`
+
+    Returns:
+        bool which says if the two gates are approximately equal in the way
+            described above.
+    """
+    if not isinstance(gate_true, cirq.Gate):
+        raise TypeError(f"`gate_true` not a cirq gate, got {type(gate_true)}")
+    if not isinstance(gate_deser, cirq.Gate):
+        raise TypeError(f"`gate_deser` not a cirq gate, got {type(gate_deser)}")
+    supported_gates = serializer.SERIALIZER.supported_gate_types()
+    if not any([isinstance(gate_true, g) for g in supported_gates]):
+        raise ValueError(
+            f"`gate_true` is not a valid TFQ gate, got {gate_true}")
+    if not any([isinstance(gate_deser, g) for g in supported_gates]):
+        raise ValueError(
+            f"`gate_deser` is not a valid TFQ gate, got {gate_deser}")
+    if not isinstance(gate_true, type(gate_deser)):
+        return False
+    if isinstance(gate_true, type(cirq.I)) and isinstance(
+            gate_deser, type(cirq.I)):
+        # all identity gates are the same
+        return True
+    if isinstance(gate_true, cirq.EigenGate):
+        a = _expression_approx_eq(gate_true._global_shift,
+                                  gate_deser._global_shift, atol)
+        b = _expression_approx_eq(gate_true._exponent, gate_deser._exponent,
+                                  atol)
+        return a and b
+    if isinstance(gate_true, cirq.FSimGate):
+        a = _expression_approx_eq(gate_true.theta, gate_deser.theta, atol)
+        b = _expression_approx_eq(gate_true.phi, gate_deser.phi, atol)
+        return a and b
+    if isinstance(gate_true, (cirq.PhasedXPowGate, cirq.PhasedISwapPowGate)):
+        a = _expression_approx_eq(gate_true._global_shift,
+                                  gate_deser._global_shift, atol)
+        b = _expression_approx_eq(gate_true._exponent, gate_deser._exponent,
+                                  atol)
+        c = _expression_approx_eq(gate_true._phase_exponent,
+                                  gate_deser._phase_exponent, atol)
+        return a and b and c
+    raise ValueError(
+        f"Some valid TFQ gate type is not yet accounted for, got {gate_true}")
+
+
 def get_circuit_symbols(circuit):
     """Returns a list of the sympy.Symbols that are present in `circuit`.
 

--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -459,7 +459,7 @@ def gate_approx_eq(gate_true, gate_deser, atol=1e-5):
         raise TypeError(f"`gate_deser` not a cirq gate, got {type(gate_deser)}")
     if isinstance(gate_true, cirq.ControlledGate) != isinstance(
             gate_deser, cirq.ControlledGate):
-        raise TypeError("Both gates must be ControlledGates, or neither.")
+        return False
     if isinstance(gate_true, cirq.ControlledGate):
         if gate_true.control_qid_shape != gate_deser.control_qid_shape:
             return False

--- a/tensorflow_quantum/python/util_test.py
+++ b/tensorflow_quantum/python/util_test.py
@@ -274,17 +274,18 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
 
         # Unsupported gates
         with self.assertRaisesRegex(
-                ValueError,
-                expected_regex="`gate_true` not a valid TFQ gate"):
+                ValueError, expected_regex="`gate_true` not a valid TFQ gate"):
             _ = util.gate_approx_eq(
-                cirq.PhasedXZGate(x_exponent=1, z_exponent=1, axis_phase_exponent=1),
-                cirq.I)
+                cirq.PhasedXZGate(x_exponent=1,
+                                  z_exponent=1,
+                                  axis_phase_exponent=1), cirq.I)
         with self.assertRaisesRegex(
-                ValueError,
-                expected_regex="`gate_deser` not a valid TFQ gate"):
+                ValueError, expected_regex="`gate_deser` not a valid TFQ gate"):
             _ = util.gate_approx_eq(
                 cirq.I,
-                cirq.PhasedXZGate(x_exponent=1, z_exponent=1, axis_phase_exponent=1))
+                cirq.PhasedXZGate(x_exponent=1,
+                                  z_exponent=1,
+                                  axis_phase_exponent=1))
 
         # Not a child class
         self.assertFalse(util.gate_approx_eq(cirq.X, cirq.Y))
@@ -316,22 +317,25 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
 
         # Controlled gates
         with self.assertRaisesRegex(
-                TypeError,
-                expected_regex="Both gates must be ControlledGates"):
-          _ = util.gate_approx_eq(
-              cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]), cirq.X)
-        self.assertFalse(util.gate_approx_eq(
-            cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
-            cirq.ops.ControlledGate(cirq.X, 2, [1, 1], [2, 2])))
-        self.assertFalse(util.gate_approx_eq(
-            cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
-            cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 1])))
-        self.assertFalse(util.gate_approx_eq(
-            cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
-            cirq.ops.ControlledGate(cirq.Y, 2, [1, 0], [2, 2])))
-        self.assertTrue(util.gate_approx_eq(
-            cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
-            cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2])))
+                TypeError, expected_regex="Both gates must be ControlledGates"):
+            _ = util.gate_approx_eq(
+                cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]), cirq.X)
+        self.assertFalse(
+            util.gate_approx_eq(
+                cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
+                cirq.ops.ControlledGate(cirq.X, 2, [1, 1], [2, 2])))
+        self.assertFalse(
+            util.gate_approx_eq(
+                cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
+                cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 1])))
+        self.assertFalse(
+            util.gate_approx_eq(
+                cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
+                cirq.ops.ControlledGate(cirq.Y, 2, [1, 0], [2, 2])))
+        self.assertTrue(
+            util.gate_approx_eq(
+                cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
+                cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2])))
 
     def test_get_circuit_symbols(self):
         """Test that symbols can be extracted from circuits.

--- a/tensorflow_quantum/python/util_test.py
+++ b/tensorflow_quantum/python/util_test.py
@@ -351,22 +351,19 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
                 ValueError, expected_regex="`gate_true` not a valid TFQ gate"):
             _ = util.gate_approx_eq(
                 cirq.ops.ControlledGate(
-                        cirq.PhasedXZGate(x_exponent=1,
-                                          z_exponent=1,
-                                          axis_phase_exponent=1),
-                        2, [1, 0], [2, 2]),
-                cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]))
+                    cirq.PhasedXZGate(x_exponent=1,
+                                      z_exponent=1,
+                                      axis_phase_exponent=1), 2, [1, 0],
+                    [2, 2]), cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]))
         with self.assertRaisesRegex(
                 ValueError, expected_regex="`gate_deser` not a valid TFQ gate"):
             _ = util.gate_approx_eq(
                 cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
                 cirq.ops.ControlledGate(
-                        cirq.PhasedXZGate(x_exponent=1,
-                                          z_exponent=1,
-                                          axis_phase_exponent=1),
-                        2, [1, 0], [2, 2]))
-
-
+                    cirq.PhasedXZGate(x_exponent=1,
+                                      z_exponent=1,
+                                      axis_phase_exponent=1), 2, [1, 0],
+                    [2, 2]))
 
     def test_get_circuit_symbols(self):
         """Test that symbols can be extracted from circuits.

--- a/tensorflow_quantum/python/util_test.py
+++ b/tensorflow_quantum/python/util_test.py
@@ -181,6 +181,135 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
         with self.assertRaisesRegex(ValueError, expected_regex='not iterable'):
             list(util.kwargs_cartesian_product(a=[1, 2], b=-1))
 
+    def test_expression_approx_eq(self):
+        """Test that coefficients and symbols are compared correctly."""
+        # integers
+        a = 1
+        b = 1
+        c = 2
+        atol = 0.1
+        self.assertTrue(util._expression_approx_eq(a, b, atol))
+        self.assertFalse(util._expression_approx_eq(a, c, atol))
+        self.assertTrue(util._expression_approx_eq(a, c, 2.0))
+
+        # reals
+        a = 1.1234
+        b = 1.1231
+        c = 1.1220
+        atol = 5e-4
+        self.assertTrue(util._expression_approx_eq(a, b, atol))
+        self.assertFalse(util._expression_approx_eq(a, c, atol))
+        self.assertTrue(util._expression_approx_eq(a, c, 0.01))
+
+        # symbols
+        a = sympy.Symbol("s")
+        b = sympy.Symbol("s")
+        c = sympy.Symbol("s_wrong")
+        self.assertTrue(util._expression_approx_eq(a, b, atol))
+        self.assertFalse(util._expression_approx_eq(a, c, atol))
+
+        # number * symbol
+        a = 3.5 * sympy.Symbol("s")
+        b = 3.501 * sympy.Symbol("s")
+        c = 3.5 * sympy.Symbol("s_wrong")
+        atol = 1e-2
+        self.assertTrue(util._expression_approx_eq(a, b, atol))
+        self.assertFalse(util._expression_approx_eq(a, c, atol))
+        c = 3.6 * sympy.Symbol("s")
+        self.assertFalse(util._expression_approx_eq(a, c, atol))
+
+        # symbol * number
+        a = sympy.Symbol("s") * -1.7
+        b = sympy.Symbol("s") * -1.701
+        c = sympy.Symbol("s_wrong") * -1.7
+        atol = 1e-2
+        self.assertTrue(util._expression_approx_eq(a, b, atol))
+        self.assertFalse(util._expression_approx_eq(a, c, atol))
+        c = sympy.Symbol("s") * -1.8
+        self.assertFalse(util._expression_approx_eq(a, c, atol))
+
+        # other not equal
+        atol = 1e-3
+        self.assertFalse(util._expression_approx_eq(1, sympy.Symbol("s"), atol))
+        self.assertFalse(util._expression_approx_eq(sympy.Symbol("s"), 1, atol))
+
+        # too complicated
+        a = sympy.Symbol("s_1") * sympy.Symbol("s_2")
+        b = 1.0 * a
+        with self.assertRaisesRegex(ValueError, expected_regex='not supported'):
+            util._expression_approx_eq(a, a, 1e-3)
+        with self.assertRaisesRegex(ValueError, expected_regex='not supported'):
+            util._expression_approx_eq(a, b, 1e-3)
+
+        # junk
+        with self.assertRaisesRegex(TypeError, expected_regex='Invalid input'):
+            util._expression_approx_eq('junk', 'junk', 1e-3)
+        with self.assertRaisesRegex(TypeError,
+                                    expected_regex='atol must be a real'):
+            util._expression_approx_eq(1, 1, 'junk')
+
+    def test_gate_approx_eq(self):
+        """Check valid TFQ gates for approximate equality."""
+        atol = 1e-2
+        exps_true = [
+            3, 2.54, -1.7 * sympy.Symbol("s_1"),
+            sympy.Symbol("s_2") * 4.3
+        ]
+        exps_eq = [
+            3, 2.542, -1.705 * sympy.Symbol("s_1"),
+            sympy.Symbol("s_2") * 4.305
+        ]
+        exps_not_eq = [
+            4, 2.57, -1.5 * sympy.Symbol("s_1"),
+            sympy.Symbol("s_2") * 4.4
+        ]
+
+        # junk
+        with self.assertRaisesRegex(TypeError,
+                                    expected_regex='`gate_true` not a cirq'):
+            util.gate_approx_eq("junk", cirq.I)
+        with self.assertRaisesRegex(TypeError,
+                                    expected_regex='`gate_deser` not a cirq'):
+            util.gate_approx_eq(cirq.I, "junk")
+
+        # Unsupported gates
+        with self.assertRaisesRegex(
+                ValueError,
+                expected_regex='`gate_true` is not a valid TFQ gate'):
+            util.gate_approx_eq(cirq.PhasedXZGate, cirq.I)
+        with self.assertRaisesRegex(
+                ValueError,
+                expected_regex='`gate_deser` is not a valid TFQ gate'):
+            util.gate_approx_eq(cirq.I, cirq.PhasedXZGate)
+
+        # Not a child class
+        self.assertFalse(util.gate_approx_eq(cirq.X, cirq.Y))
+
+        # Identity gate
+        self.assertTrue(util.gate_approx_eq(cirq.I, cirq.I))
+
+        # Parameterized gates
+        for e_true, e_eq, e_not_eq in zip(exps_true, exps_eq, exps_not_eq):
+            for g in serializer.EIGEN_GATES_DICT:
+                g_true = g(exponent=e_true, global_shift=e_eq)
+                g_eq = g(exponent=e_eq, global_shift=e_true)
+                g_not_eq = g(exponent=e_not_eq, global_shift=e_not_eq)
+                self.assertTrue(util.gate_approx_eq(g_true, g_eq, atol=atol))
+                self.assertFalse(
+                    util.gate_approx_eq(g_true, g_not_eq, atol=atol))
+            for g in serializer.PHASED_EIGEN_GATES_DICT:
+                g_true = g(exponent=e_true, phase_exponent=-1.0 * e_true)
+                g_eq = g(exponent=e_eq, phase_exponent=-1.0 * e_eq)
+                g_not_eq = g(exponent=e_not_eq, phase_exponent=-1.0 * e_not_eq)
+                self.assertTrue(util.gate_approx_eq(g_true, g_eq, atol=atol))
+                self.assertFalse(
+                    util.gate_approx_eq(g_true, g_not_eq, atol=atol))
+            g_true = cirq.FSimGate(theta=e_true, phi=e_eq)
+            g_eq = cirq.FSimGate(theta=e_eq, phi=e_true)
+            g_not_eq = cirq.FSimGate(theta=e_not_eq, phi=e_not_eq)
+            self.assertTrue(util.gate_approx_eq(g_true, g_eq, atol=atol))
+            self.assertFalse(util.gate_approx_eq(g_true, g_not_eq, atol=atol))
+
     def test_get_circuit_symbols(self):
         """Test that symbols can be extracted from circuits.
         This test will error out if get_supported_gates gets updated with new

--- a/tensorflow_quantum/python/util_test.py
+++ b/tensorflow_quantum/python/util_test.py
@@ -274,13 +274,17 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
 
         # Unsupported gates
         with self.assertRaisesRegex(
-                TypeError,
+                ValueError,
                 expected_regex="`gate_true` not a valid TFQ gate"):
-            _ = util.gate_approx_eq(cirq.PhasedXZGate, cirq.I)
+            _ = util.gate_approx_eq(
+                cirq.PhasedXZGate(x_exponent=1, z_exponent=1, axis_phase_exponent=1),
+                cirq.I)
         with self.assertRaisesRegex(
-                TypeError,
+                ValueError,
                 expected_regex="`gate_deser` not a valid TFQ gate"):
-            _ = util.gate_approx_eq(cirq.I, cirq.PhasedXZGate)
+            _ = util.gate_approx_eq(
+                cirq.I,
+                cirq.PhasedXZGate(x_exponent=1, z_exponent=1, axis_phase_exponent=1))
 
         # Not a child class
         self.assertFalse(util.gate_approx_eq(cirq.X, cirq.Y))
@@ -309,6 +313,25 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
             g_not_eq = cirq.FSimGate(theta=e_not_eq, phi=e_not_eq)
             self.assertTrue(util.gate_approx_eq(g_true, g_eq, atol=atol))
             self.assertFalse(util.gate_approx_eq(g_true, g_not_eq, atol=atol))
+
+        # Controlled gates
+        with self.assertRaisesRegex(
+                TypeError,
+                expected_regex="Both gates must be ControlledGates"):
+          _ = util.gate_approx_eq(
+              cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]), cirq.X)
+        self.assertFalse(util.gate_approx_eq(
+            cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
+            cirq.ops.ControlledGate(cirq.X, 2, [1, 1], [2, 2])))
+        self.assertFalse(util.gate_approx_eq(
+            cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
+            cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 1])))
+        self.assertFalse(util.gate_approx_eq(
+            cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
+            cirq.ops.ControlledGate(cirq.Y, 2, [1, 0], [2, 2])))
+        self.assertTrue(util.gate_approx_eq(
+            cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
+            cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2])))
 
     def test_get_circuit_symbols(self):
         """Test that symbols can be extracted from circuits.

--- a/tensorflow_quantum/python/util_test.py
+++ b/tensorflow_quantum/python/util_test.py
@@ -346,6 +346,27 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
                 cirq.PhasedXZGate(x_exponent=1,
                                   z_exponent=1,
                                   axis_phase_exponent=1))
+        # Unsupported gates inside a controlled gate
+        with self.assertRaisesRegex(
+                ValueError, expected_regex="`gate_true` not a valid TFQ gate"):
+            _ = util.gate_approx_eq(
+                cirq.ops.ControlledGate(
+                        cirq.PhasedXZGate(x_exponent=1,
+                                          z_exponent=1,
+                                          axis_phase_exponent=1),
+                        2, [1, 0], [2, 2]),
+                cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]))
+        with self.assertRaisesRegex(
+                ValueError, expected_regex="`gate_deser` not a valid TFQ gate"):
+            _ = util.gate_approx_eq(
+                cirq.ops.ControlledGate(cirq.X, 2, [1, 0], [2, 2]),
+                cirq.ops.ControlledGate(
+                        cirq.PhasedXZGate(x_exponent=1,
+                                          z_exponent=1,
+                                          axis_phase_exponent=1),
+                        2, [1, 0], [2, 2]))
+
+
 
     def test_get_circuit_symbols(self):
         """Test that symbols can be extracted from circuits.

--- a/tensorflow_quantum/python/util_test.py
+++ b/tensorflow_quantum/python/util_test.py
@@ -237,16 +237,16 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
         a = sympy.Symbol("s_1") * sympy.Symbol("s_2")
         b = 1.0 * a
         with self.assertRaisesRegex(ValueError, expected_regex='not supported'):
-            util._expression_approx_eq(a, a, 1e-3)
+            _ = util._expression_approx_eq(a, a, 1e-3)
         with self.assertRaisesRegex(ValueError, expected_regex='not supported'):
-            util._expression_approx_eq(a, b, 1e-3)
+            _ = util._expression_approx_eq(a, b, 1e-3)
 
         # junk
         with self.assertRaisesRegex(TypeError, expected_regex='Invalid input'):
-            util._expression_approx_eq('junk', 'junk', 1e-3)
+            _ = util._expression_approx_eq('junk', 'junk', 1e-3)
         with self.assertRaisesRegex(TypeError,
                                     expected_regex='atol must be a real'):
-            util._expression_approx_eq(1, 1, 'junk')
+            _ = util._expression_approx_eq(1, 1, 'junk')
 
     def test_gate_approx_eq(self):
         """Check valid TFQ gates for approximate equality."""
@@ -266,21 +266,21 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
 
         # junk
         with self.assertRaisesRegex(TypeError,
-                                    expected_regex='`gate_true` not a cirq'):
-            util.gate_approx_eq("junk", cirq.I)
+                                    expected_regex="`gate_true` not a cirq"):
+            _ = util.gate_approx_eq("junk", cirq.I)
         with self.assertRaisesRegex(TypeError,
-                                    expected_regex='`gate_deser` not a cirq'):
-            util.gate_approx_eq(cirq.I, "junk")
+                                    expected_regex="`gate_deser` not a cirq"):
+            _ = util.gate_approx_eq(cirq.I, "junk")
 
         # Unsupported gates
         with self.assertRaisesRegex(
-                ValueError,
-                expected_regex='`gate_true` is not a valid TFQ gate'):
-            util.gate_approx_eq(cirq.PhasedXZGate, cirq.I)
+                TypeError,
+                expected_regex="`gate_true` not a valid TFQ gate"):
+            _ = util.gate_approx_eq(cirq.PhasedXZGate, cirq.I)
         with self.assertRaisesRegex(
-                ValueError,
-                expected_regex='`gate_deser` is not a valid TFQ gate'):
-            util.gate_approx_eq(cirq.I, cirq.PhasedXZGate)
+                TypeError,
+                expected_regex="`gate_deser` not a valid TFQ gate"):
+            _ = util.gate_approx_eq(cirq.I, cirq.PhasedXZGate)
 
         # Not a child class
         self.assertFalse(util.gate_approx_eq(cirq.X, cirq.Y))


### PR DESCRIPTION
Add functions to approximately compare parameterized gates in the TFQ gate set.

Supersedes #462 .  In this PR, full support for ControlledGates is added.