### PR TITLE
Add support for cirq.DepolarizingChannel in serialize_circuit.

### DIFF
--- a/scripts/import_test.py
+++ b/scripts/import_test.py
@@ -42,6 +42,7 @@ def test_imports():
     _ = tfq.get_quantum_concurrent_op_mode
     _ = tfq.from_tensor
     _ = tfq.set_quantum_concurrent_op_mode
+    _ = tfq.util.get_supported_channels
     _ = tfq.util.get_supported_gates
     _ = tfq.util.exponential
 

--- a/tensorflow_quantum/core/serialize/serializer.py
+++ b/tensorflow_quantum/core/serialize/serializer.py
@@ -154,6 +154,32 @@ def _optional_control_promote(gate, qubits_message, values_message):
     return DelayedAssignmentGate(gate, qbs, vals)
 
 
+def _depolarize_channel_serializer():
+    args = [
+        # cirq channels can't contain symbols.
+        cirq.google.SerializingArg(serialized_name="p",
+                                   serialized_type=float,
+                                   op_getter=lambda x: x.gate.p)
+    ]
+    return cirq.google.GateOpSerializer(gate_type=cirq.DepolarizingChannel,
+                                        serialized_gate_id="DP",
+                                        args=args,
+                                        can_serialize_predicate=_CONSTANT_TRUE)
+
+
+def _depolarize_channel_deserializer():
+    """Make standard deserializer for fsim gate."""
+
+    args = [
+        cirq.google.DeserializingArg(serialized_name="p",
+                                     constructor_arg_name="p")
+    ]
+    return cirq.google.GateOpDeserializer(
+        serialized_gate_id="DP",
+        gate_constructor=cirq.DepolarizingChannel,
+        args=args)
+
+
 def _eigen_gate_serializer(gate_type, serialized_id):
     """Make standard serializer for eigen gates."""
 
@@ -455,7 +481,7 @@ SERIALIZERS = [
 ] + [
     _phased_eigen_gate_serializer(g, g_name)
     for g, g_name in PHASED_EIGEN_GATES_DICT.items()
-]
+] + [_depolarize_channel_serializer()]
 
 DESERIALIZERS = [
     _eigen_gate_deserializer(g, g_name)
@@ -467,7 +493,7 @@ DESERIALIZERS = [
 ] + [
     _phased_eigen_gate_deserializer(g, g_name)
     for g, g_name in PHASED_EIGEN_GATES_DICT.items()
-]
+] + [_depolarize_channel_deserializer()]
 
 SERIALIZER = cirq.google.SerializableGateSet(gate_set_name="tfq_gate_set",
                                              serializers=SERIALIZERS,

--- a/tensorflow_quantum/core/serialize/serializer.py
+++ b/tensorflow_quantum/core/serialize/serializer.py
@@ -155,6 +155,8 @@ def _optional_control_promote(gate, qubits_message, values_message):
 
 
 def _depolarize_channel_serializer():
+    """Make standard serializer for depolarization channel."""
+
     args = [
         # cirq channels can't contain symbols.
         cirq.google.SerializingArg(serialized_name="p",
@@ -168,7 +170,7 @@ def _depolarize_channel_serializer():
 
 
 def _depolarize_channel_deserializer():
-    """Make standard deserializer for fsim gate."""
+    """Make standard deserializer for depolarization channel."""
 
     args = [
         cirq.google.DeserializingArg(serialized_name="p",

--- a/tensorflow_quantum/core/serialize/serializer_test.py
+++ b/tensorflow_quantum/core/serialize/serializer_test.py
@@ -30,7 +30,7 @@ def _build_circuit_ops_proto(gate_id, arg_names, arg_vals, qubit_ids):
     program_proto.language.gate_set = 'tfq_gate_set'
 
     circuit_proto = program_proto.circuit
-    circuit_proto.scheduling_strategy = circuit_proto.MOMENT_BY_MOMENT  #'1'.
+    circuit_proto.scheduling_strategy = circuit_proto.MOMENT_BY_MOMENT
     circuit_proto.moments.add(operations=[program_pb2.Operation(
         gate = program_pb2.Gate(id=gate_id),
         args = {arg_names[i]: (program_pb2.Arg(symbol=arg_vals[i]) \

--- a/tensorflow_quantum/python/__init__.py
+++ b/tensorflow_quantum/python/__init__.py
@@ -15,6 +15,7 @@
 """Module definitions for tensorflow_quantum.python.util.*"""
 from tensorflow_quantum.python.util import (
     # Utility functions.
+    get_supported_channels,
     get_supported_gates,
     exponential,
 )

--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -24,6 +24,8 @@ import cirq
 from tensorflow_quantum.core.proto import pauli_sum_pb2
 from tensorflow_quantum.core.serialize import serializer
 
+_SUPPORTED_CHANNELS = [cirq.DepolarizingChannel]
+
 
 def get_supported_gates():
     """A helper to get the gates supported by tfq.
@@ -35,7 +37,9 @@ def get_supported_gates():
     `controlled_by` function for multi qubit control are also
     supported.
     """
-    supported_gates = serializer.SERIALIZER.supported_gate_types()
+    supported_ops = serializer.SERIALIZER.supported_gate_types()
+    supported_gates = filter(lambda x: x not in _SUPPORTED_CHANNELS,
+                             supported_ops)
     gate_arity_mapping_dict = dict()
     for gate in supported_gates:
         if gate is cirq.IdentityGate:

--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -24,6 +24,7 @@ import cirq
 from tensorflow_quantum.core.proto import pauli_sum_pb2
 from tensorflow_quantum.core.serialize import serializer
 
+# Can't use set() since channels don't give proper support.
 _SUPPORTED_CHANNELS = [cirq.DepolarizingChannel]
 
 
@@ -56,6 +57,23 @@ def get_supported_gates():
             g_num_qubits = gate().num_qubits()
         gate_arity_mapping_dict[g] = g_num_qubits
     return gate_arity_mapping_dict
+
+
+def get_supported_channels():
+    """Get the channels that are supported in TFQ.
+
+    Returns a dictionary mapping from supported channel types
+    to number of qubits.
+    """
+    supported_ops = serializer.SERIALIZER.supported_gate_types()
+    supported_channels = filter(lambda x: x in _SUPPORTED_CHANNELS,
+                                supported_ops)
+    channel_arity_mapping_dict = dict()
+    for chan in supported_channels:
+        # For now all channels are single qubit.
+        if chan == cirq.DepolarizingChannel:
+            channel_arity_mapping_dict[chan(0.01)] = 1
+    return channel_arity_mapping_dict
 
 
 def _apply_random_control(gate, all_qubits):

--- a/tensorflow_quantum/python/util_test.py
+++ b/tensorflow_quantum/python/util_test.py
@@ -64,7 +64,15 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(
             len(mapping_1.keys()),
             len(serializer.SERIALIZER.supported_gate_types()) -
-            len(util._SUPPORTED_CHANNELS))
+            len(util.get_supported_channels()))
+
+    def test_get_supported_channels(self):
+        """Confirm one of every channel is returned."""
+        mapping_1 = util.get_supported_channels()
+        self.assertEqual(
+            len(mapping_1.keys()),
+            len(serializer.SERIALIZER.supported_gate_types()) -
+            len(util.get_supported_gates()))
 
     @parameterized.parameters(_items_to_tensorize())
     def test_convert_to_tensor(self, item):

--- a/tensorflow_quantum/python/util_test.py
+++ b/tensorflow_quantum/python/util_test.py
@@ -61,8 +61,10 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
     def test_get_supported_gates(self):
         """Confirm one of every gate is returned."""
         mapping_1 = util.get_supported_gates()
-        self.assertEqual(len(mapping_1.keys()),
-                         len(serializer.SERIALIZER.supported_gate_types()))
+        self.assertEqual(
+            len(mapping_1.keys()),
+            len(serializer.SERIALIZER.supported_gate_types()) -
+            len(util._SUPPORTED_CHANNELS))
 
     @parameterized.parameters(_items_to_tensorize())
     def test_convert_to_tensor(self, item):


### PR DESCRIPTION
Adds serialization support for the depolarizing channel. First step in getting #250 finished. Once we have serialization support in place, hopefully we can upgrade our qsim dependancy and have https://github.com/quantumlib/qsim/issues/288 resolved so we can immediately start plumbing the support for channels.

CC: @balopat , @95-martin-orion 