### PR TITLE
Update build from source instructions.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -84,7 +84,7 @@ As noted in the TensorFlow
 guide, the <a href="https://bazel.build/" class="external">Bazel</a>
 build system will be required.
 
-To ensure compatibility with TensorFlow 2.3.1, we use `bazel` version 3.1.0. To remove any existing version of Bazel:
+Our latest source builds use TensorFlow 2.4.1. To ensure compatibility we use `bazel` version 3.1.0. To remove any existing version of Bazel:
 
 <!-- common_typos_disable -->
 <pre class="devsite-click-to-copy">
@@ -122,7 +122,7 @@ Finally, confirm installation of the correct `bazel` version:
 ### 4. Build TensorFlow from source
 
 Here we adapt instructions from the TensorFlow [build from source](https://www.tensorflow.org/install/source)
-guide, see the link for further details. TensorFlow Quantum is compatible with TensorFlow version&nbsp;2.3.
+guide, see the link for further details. TensorFlow Quantum is compatible with TensorFlow version&nbsp;2.4.
 
 Download the
 <a href="https://github.com/tensorflow/tensorflow" class="external">TensorFlow source code</a>:
@@ -131,7 +131,7 @@ Download the
 <pre class="devsite-click-to-copy">
   <code class="devsite-terminal">git clone https://github.com/tensorflow/tensorflow.git</code>
   <code class="devsite-terminal">cd tensorflow</code>
-  <code class="devsite-terminal">git checkout v2.3.1</code>
+  <code class="devsite-terminal">git checkout v2.4.1</code>
 </pre>
 
 Be sure the virtual environment you created in step 2 is activated. Then, install the TensorFlow dependencies:
@@ -141,7 +141,7 @@ Be sure the virtual environment you created in step 2 is activated. Then, instal
   <code class="devsite-terminal">pip install -U pip six numpy wheel setuptools mock 'future>=0.17.1'</code>
   <code class="devsite-terminal">pip install -U keras_applications --no-deps</code>
   <code class="devsite-terminal">pip install -U keras_preprocessing --no-deps</code>
-  <code class="devsite-terminal">pip install numpy==1.18.0</code>
+  <code class="devsite-terminal">pip install numpy==1.19.5</code>
 </pre>
 <!-- common_typos_enable -->
 


### PR DESCRIPTION
Updates the build from source instructions for TFQ in light of #482 . When we can an official release we will still have to remember to update the rest.

cc @balopat 