### PR TITLE
Adds support for CCZ and CCX/TOF gates.

### DIFF
--- a/tensorflow_quantum/core/ops/circuit_execution_ops_test.py
+++ b/tensorflow_quantum/core/ops/circuit_execution_ops_test.py
@@ -185,7 +185,10 @@ class ExecutionOpsConsistentyTest(tf.test.TestCase, parameterized.TestCase):
             for qubit in qubits:
                 c += cirq.Circuit(cirq.Y(qubit)**0.125)
 
-            if gate_ref[gate] == 2:
+            if gate_ref[gate] == 3:
+                op_qubits = np.random.choice(qubits, size=3, replace=False)
+                c += cirq.Circuit(gate(*op_qubits))
+            elif gate_ref[gate] == 2:
                 op_qubits = np.random.choice(qubits, size=2, replace=False)
                 c += cirq.Circuit(gate(*op_qubits))
             elif gate_ref[gate] == 1:

--- a/tensorflow_quantum/core/serialize/serializer.py
+++ b/tensorflow_quantum/core/serialize/serializer.py
@@ -464,7 +464,9 @@ EIGEN_GATES_DICT = {
     cirq.ZZPowGate: "ZZP",
     cirq.HPowGate: "HP",
     cirq.CZPowGate: "CZP",
+    cirq.CCZPowGate: "CCZP",
     cirq.CNotPowGate: "CNP",
+    cirq.CCXPowGate: "CCXP",
     cirq.SwapPowGate: "SP",
     cirq.ISwapPowGate: "ISP",
 }

--- a/tensorflow_quantum/core/serialize/serializer_test.py
+++ b/tensorflow_quantum/core/serialize/serializer_test.py
@@ -140,6 +140,7 @@ def _make_controlled_circuit(circuit, control_qubits, control_values):
 def _get_circuit_proto_pairs():
     q0 = cirq.GridQubit(0, 0)
     q1 = cirq.GridQubit(0, 1)
+    q2 = cirq.GridQubit(0, 2)
 
     pairs = [
         # HPOW and aliases.
@@ -290,6 +291,26 @@ def _get_circuit_proto_pairs():
                            ['exponent', 'exponent_scalar', 'global_shift'],
                            [1.0, 1.0, 0.0], ['0_0', '0_1'])),
 
+        # CCZPow and aliases
+        (cirq.Circuit(cirq.CCZPowGate(exponent=0.3)(q0, q1, q2)),
+         _build_gate_proto("CCZP",
+                           ['exponent', 'exponent_scalar', 'global_shift'],
+                           [0.3, 1.0, 0.0], ['0_0', '0_1', '0_2'])),
+        (cirq.Circuit(
+            cirq.CCZPowGate(exponent=sympy.Symbol('alpha'))(q0, q1, q2)),
+         _build_gate_proto("CCZP",
+                           ['exponent', 'exponent_scalar', 'global_shift'],
+                           ['alpha', 1.0, 0.0], ['0_0', '0_1', '0_2'])),
+        (cirq.Circuit(
+            cirq.CCZPowGate(exponent=3.1 * sympy.Symbol('alpha'))(q0, q1, q2)),
+         _build_gate_proto("CCZP",
+                           ['exponent', 'exponent_scalar', 'global_shift'],
+                           ['alpha', 3.1, 0.0], ['0_0', '0_1', '0_2'])),
+        (cirq.Circuit(cirq.CCZ(q0, q1, q2)),
+         _build_gate_proto("CCZP",
+                           ['exponent', 'exponent_scalar', 'global_shift'],
+                           [1.0, 1.0, 0.0], ['0_0', '0_1', '0_2'])),
+
         # CNOTPow and aliases
         (cirq.Circuit(cirq.CNotPowGate(exponent=0.3)(q0, q1)),
          _build_gate_proto("CNP",
@@ -308,6 +329,26 @@ def _get_circuit_proto_pairs():
          _build_gate_proto("CNP",
                            ['exponent', 'exponent_scalar', 'global_shift'],
                            [1.0, 1.0, 0.0], ['0_0', '0_1'])),
+
+        # CCXPow and aliases
+        (cirq.Circuit(cirq.CCXPowGate(exponent=0.3)(q0, q1, q2)),
+         _build_gate_proto("CCXP",
+                           ['exponent', 'exponent_scalar', 'global_shift'],
+                           [0.3, 1.0, 0.0], ['0_0', '0_1', '0_2'])),
+        (cirq.Circuit(
+            cirq.CCXPowGate(exponent=sympy.Symbol('alpha'))(q0, q1, q2)),
+         _build_gate_proto("CCXP",
+                           ['exponent', 'exponent_scalar', 'global_shift'],
+                           ['alpha', 1.0, 0.0], ['0_0', '0_1', '0_2'])),
+        (cirq.Circuit(
+            cirq.CCXPowGate(exponent=3.1 * sympy.Symbol('alpha'))(q0, q1, q2)),
+         _build_gate_proto("CCXP",
+                           ['exponent', 'exponent_scalar', 'global_shift'],
+                           ['alpha', 3.1, 0.0], ['0_0', '0_1', '0_2'])),
+        (cirq.Circuit(cirq.TOFFOLI(q0, q1, q2)),
+         _build_gate_proto("CCXP",
+                           ['exponent', 'exponent_scalar', 'global_shift'],
+                           [1.0, 1.0, 0.0], ['0_0', '0_1', '0_2'])),
 
         # SWAPPow and aliases
         (cirq.Circuit(cirq.SwapPowGate(exponent=0.3)(q0, q1)),

--- a/tensorflow_quantum/core/src/adj_util.h
+++ b/tensorflow_quantum/core/src/adj_util.h
@@ -65,6 +65,14 @@ void PopulateGradientTwoEigen(
     const std::string& symbol, unsigned int location, unsigned int qid,
     unsigned int qid2, float exp, float exp_s, float gs, GradientOfGate* grad);
 
+void PopulateGradientThreeEigen(
+    const std::function<qsim::Cirq::GateCirq<float>(unsigned int, unsigned int,
+                                                    unsigned int, unsigned int,
+                                                    float, float)>& create_f,
+    const std::string& symbol, unsigned int location, unsigned int qid,
+    unsigned int qid2, unsigned int qid3, float exp, float exp_s, float gs,
+    GradientOfGate* grad);
+
 // Note: all methods below expect gate qubit indices to have been swapped so
 // qid < qid2.
 void PopulateGradientPhasedXPhasedExponent(const std::string& symbol,
@@ -112,6 +120,14 @@ void Matrix2Diff(Array2& source, Array2& dest) {
 template <typename Array2>
 void Matrix4Diff(Array2& source, Array2& dest) {
   for (unsigned i = 0; i < 32; i++) {
+    dest[i] -= source[i];
+  }
+}
+
+// does matrix elementiwse subtraction dest -= source.
+template <typename Array2>
+void Matrix8Diff(Array2& source, Array2& dest) {
+  for (unsigned i = 0; i < 128; i++) {
     dest[i] -= source[i];
   }
 }

--- a/tensorflow_quantum/core/src/circuit_parser_qsim.h
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim.h
@@ -61,6 +61,11 @@ struct GateMetaData {
   std::function<qsim::Cirq::GateCirq<float>(unsigned int, unsigned int,
                                             unsigned int, float, float)>
       create_f2;
+
+  // set only if gate is Three qubit Eigen gate.
+  std::function<qsim::Cirq::GateCirq<float>(
+      unsigned int, unsigned int, unsigned int, unsigned int, float, float)>
+      create_f3;
 };
 
 // parse a serialized Cirq program into a qsim representation.


### PR DESCRIPTION
This PR adds serialization and C++ implementation support for three qubit eigen gates. A lot of this code is copy pasted from the two qubit cases with tweaks to work for the three qubit cases. Currently tests will fail on our unitary op since the latest qsim (https://github.com/quantumlib/qsim/blob/278b217f94bca179ac5fafd85498ee28bbd3e236/lib/unitary_calculator_basic.h#L52) unitary calculator doesn't support three qubit gates. This is being worked on by @sergeisakov so we should be able to merge very soon once we can upgrade our qsim dependency. Fixes #480 