### PR TITLE
Add nightly consistency checks for Cirq

### DIFF
--- a/.github/workflows/cirq_compatibility.yaml
+++ b/.github/workflows/cirq_compatibility.yaml
@@ -1,8 +1,6 @@
 name: Cirq Compatibility
 
-on:
-  schedule:
-    - cron: '0 0 * * *'
+on: [push]
 
 jobs:
   consistency:

--- a/.github/workflows/cirq_compatibility.yaml
+++ b/.github/workflows/cirq_compatibility.yaml
@@ -17,6 +17,6 @@ jobs:
       - name: Configure CI TF
         run: echo "Y\n" | ./configure.sh
       - name: Install Cirq nightly
-        run: pip install -U cirq --pre --no-deps
+        run: pip install -U cirq --pre
       - name: Nightly tests
         run: ./scripts/test_all.sh

--- a/.github/workflows/cirq_compatibility.yaml
+++ b/.github/workflows/cirq_compatibility.yaml
@@ -17,6 +17,6 @@ jobs:
       - name: Configure CI TF
         run: echo "Y\n" | ./configure.sh
       - name: Install Cirq nightly
-        run: pip install -U cirq --pre
-      - name: Full Library Test
+        run: pip install -U cirq --pre --no-deps
+      - name: Nightly tests
         run: ./scripts/test_all.sh

--- a/.github/workflows/cirq_compatibility.yaml
+++ b/.github/workflows/cirq_compatibility.yaml
@@ -1,0 +1,20 @@
+name: Cirq Compatibility
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  consistency:
+    name: Nightly Compatibility
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+          architecture: 'x64'
+      - name: Install Cirq nightly
+        run: pip install --upgrade pip setuptools; pip install -r requirements.txt; pip install -U cirq --pre
+      - name: Run tests
+        run: ./scripts/test_all.sh

--- a/.github/workflows/cirq_compatibility.yaml
+++ b/.github/workflows/cirq_compatibility.yaml
@@ -12,7 +12,11 @@ jobs:
         with:
           python-version: '3.7'
           architecture: 'x64'
+      - name: Install Bazel on CI
+        run: ./scripts/ci_install.sh
+      - name: Configure CI TF
+        run: echo "Y\n" | ./configure.sh
       - name: Install Cirq nightly
-        run: pip install --upgrade pip setuptools; pip install -r requirements.txt; pip install -U cirq --pre
-      - name: Run tests
+        run: pip install -U cirq --pre
+      - name: Full Library Test
         run: ./scripts/test_all.sh

--- a/.github/workflows/cirq_compatibility.yaml
+++ b/.github/workflows/cirq_compatibility.yaml
@@ -1,6 +1,8 @@
 name: Cirq Compatibility
 
-on: [push]
+on:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   consistency:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pylint==2.4.4
 yapf==0.28.0
 tensorflow==2.4.1
 google-api-python-client==1.8.0
+# Needed for compatibility with cirq program protos.
+googleapis-common-protos==1.52.0

--- a/tensorflow_quantum/core/serialize/serializer_test.py
+++ b/tensorflow_quantum/core/serialize/serializer_test.py
@@ -540,7 +540,7 @@ class SerializerTest(tf.test.TestCase, parameterized.TestCase):
         """Ensure we error on unsupported gates."""
         q0 = cirq.GridQubit(0, 0)
         q1 = cirq.GridQubit(0, 1)
-        unsupported_circuit = cirq.Circuit(cirq.QFT(q0, q1))
+        unsupported_circuit = cirq.Circuit(cirq.qft(q0, q1))
 
         with self.assertRaises(ValueError):
             serializer.serialize_circuit(unsupported_circuit)
@@ -701,7 +701,7 @@ class SerializerTest(tf.test.TestCase, parameterized.TestCase):
         q0 = cirq.GridQubit(0, 0)
         c = cirq.Circuit(gate(q0))
 
-        c = c._resolve_parameters_(cirq.ParamResolver({"alpha": 0.1234567}))
+        c = cirq.resolve_parameters(c, cirq.ParamResolver({"alpha": 0.1234567}))
         before = c.unitary()
         c2 = serializer.deserialize_circuit(serializer.serialize_circuit(c))
         after = c2.unitary()


### PR DESCRIPTION
Now we test against Cirq master and should be able to flag breakages as they happen.
Related: https://github.com/quantumlib/Cirq/issues/3828