### PR TITLE
Add symbol_names empty check to diffs

### DIFF
--- a/tensorflow_quantum/python/differentiators/differentiator.py
+++ b/tensorflow_quantum/python/differentiators/differentiator.py
@@ -37,7 +37,7 @@ def catch_empty_inputs(func):
         empty_args = tf.equal(tf.size(programs), 0)
         empty_vals = tf.equal(tf.size(symbol_values), 0)
         empty_symbols = tf.equal(tf.size(symbol_names), 0)
-        
+
         ret_zero = tf.logical_or(empty_args, empty_vals)
         ret_zero = tf.logical_or(ret_zero, empty_symbols)
         return tf.cond(ret_zero, lambda: tf.zeros_like(symbol_values),

--- a/tensorflow_quantum/python/differentiators/differentiator.py
+++ b/tensorflow_quantum/python/differentiators/differentiator.py
@@ -30,13 +30,16 @@ def catch_empty_inputs(func):
 
     @functools.wraps(func)
     def new_diff(*args, **kwargs):
-        # args[1] is programs. args[3] is symbol_values
+        # args[1]=programs. args[2]=symbol_names. args[3]=symbol_values
         programs = args[1]
+        symbol_names = args[2]
         symbol_values = args[3]
         empty_args = tf.equal(tf.size(programs), 0)
         empty_vals = tf.equal(tf.size(symbol_values), 0)
-
+        empty_symbols = tf.equal(tf.size(symbol_names), 0)
+        
         ret_zero = tf.logical_or(empty_args, empty_vals)
+        ret_zero = tf.logical_or(ret_zero, empty_symbols)
         return tf.cond(ret_zero, lambda: tf.zeros_like(symbol_values),
                        lambda: func(*args, **kwargs))
 


### PR DESCRIPTION
Adds an empty check to the `tf.cond` that checks if the `symbol_names` tensor is empty to avoid accidentally computing lots of circuit info, only to not use any of it.