### PR TITLE
Removed DM from gradient_test.py

### DIFF
--- a/tensorflow_quantum/python/differentiators/gradient_test.py
+++ b/tensorflow_quantum/python/differentiators/gradient_test.py
@@ -36,8 +36,8 @@ ANALYTIC_DIFFS = [
 ]
 
 SAMPLED_DIFFS = [
-    linear_combination.ForwardDifference(grid_spacing=0.1),
-    linear_combination.CentralDifference(grid_spacing=0.1),
+    linear_combination.ForwardDifference(grid_spacing=0.05),
+    linear_combination.CentralDifference(grid_spacing=0.05),
     parameter_shift.ParameterShift(),
 ]
 
@@ -45,16 +45,12 @@ SAMPLED_DIFFS_TOLS = [0.5, 0.5, 0.2]
 
 ANALYTIC_OPS = [
     circuit_execution_ops.get_expectation_op(cirq.sim.Simulator()),  # WF
-    circuit_execution_ops.get_expectation_op(
-        cirq.DensityMatrixSimulator()),  # DM
     circuit_execution_ops.get_expectation_op()  # C++
 ]
 
 SAMPLED_OPS = [
     circuit_execution_ops.get_sampled_expectation_op(
         cirq.sim.Simulator()),  # WF
-    circuit_execution_ops.get_sampled_expectation_op(
-        cirq.DensityMatrixSimulator()),  # DM
     circuit_execution_ops.get_sampled_expectation_op()  # C++
 ]
 


### PR DESCRIPTION
With our fast C++ noisy ops coming up and our no longer having a very large need for pure python backends, I figured we might as well remove the `cirq.DensityMatrix` instances from our gradient tests.