### PR TITLE
Updated mnist.ipynb Typo in section header

### DIFF
--- a/docs/tutorials/mnist.ipynb
+++ b/docs/tutorials/mnist.ipynb
@@ -448,7 +448,7 @@
         "id": "SlJ5NVaPojhT"
       },
       "source": [
-        "### 1.3 Encode the data as quantum circuits\n",
+        "### 1.4 Encode the data as quantum circuits\n",
         "\n",
         "To process images using a quantum computer, <a href=\"https://arxiv.org/pdf/1802.06002.pdf\" class=\"external\">Farhi et al.</a> proposed representing each pixel with a qubit, with the state depending on the value of the pixel. The first step is to convert to a binary encoding."
       ]


### PR DESCRIPTION
I assume 1.4 comes after 1.3 numerically and **not** 1.3 again. 😀