### PR TITLE
Add tfq.noise.sampled_expectation.

### DIFF
--- a/release/BUILD
+++ b/release/BUILD
@@ -42,6 +42,7 @@ sh_binary(
         "//tensorflow_quantum/core/ops/math_ops:inner_product_op_py",
         "//tensorflow_quantum/core/ops/noise:noisy_samples_op_py",
         "//tensorflow_quantum/core/ops/noise:noisy_expectation_op_py",
+        "//tensorflow_quantum/core/ops/noise:noisy_sampled_expectation_op_py",
         "//tensorflow_quantum/core/serialize:serializer",
         "//tensorflow_quantum/datasets:cluster_state",
         "//tensorflow_quantum/datasets:spin_system",

--- a/scripts/import_test.py
+++ b/scripts/import_test.py
@@ -39,6 +39,7 @@ def test_imports():
 
     # Noisy simulation ops.
     _ = tfq.noise.expectation
+    _ = tfq.noise.sampled_expectation
     _ = tfq.noise.samples
 
     # Util functions.

--- a/tensorflow_quantum/core/ops/noise/BUILD
+++ b/tensorflow_quantum/core/ops/noise/BUILD
@@ -16,6 +16,7 @@ cc_binary(
     name = "_tfq_noise_ops.so",
     srcs = [
         "tfq_noisy_expectation.cc",
+        "tfq_noisy_sampled_expectation.cc",
         "tfq_noisy_samples.cc"
     ],
     copts = select({
@@ -86,6 +87,26 @@ py_test(
     python_version = "PY3",
     deps = [
         ":noisy_expectation_op_py",
+        "//tensorflow_quantum/core/ops:batch_util",
+        "//tensorflow_quantum/python:util",
+    ],
+)
+
+py_library(
+    name = "noisy_sampled_expectation_op_py",
+    srcs = ["noisy_sampled_expectation_op.py"],
+    data = [":_tfq_noise_ops.so"],
+    deps = [
+        "//tensorflow_quantum/core/ops:load_module",
+    ],
+)
+
+py_test(
+    name = "noisy_sampled_expectation_op_test",
+    srcs = ["noisy_sampled_expectation_op_test.py"],
+    python_version = "PY3",
+    deps = [
+        ":noisy_sampled_expectation_op_py",
         "//tensorflow_quantum/core/ops:batch_util",
         "//tensorflow_quantum/python:util",
     ],

--- a/tensorflow_quantum/core/ops/noise/__init__.py
+++ b/tensorflow_quantum/core/ops/noise/__init__.py
@@ -15,4 +15,6 @@
 """Module for tfq.core.ops.noise.*"""
 
 from tensorflow_quantum.core.ops.noise.noisy_expectation_op import expectation
+from tensorflow_quantum.core.ops.noise.noisy_sampled_expectation_op import \
+sampled_expectation
 from tensorflow_quantum.core.ops.noise.noisy_samples_op import samples

--- a/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op.py
@@ -1,0 +1,64 @@
+# Copyright 2020 The TensorFlow Quantum Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Module for high performance noisy circuit sampled epxectation ops."""
+import os
+import tensorflow as tf
+from tensorflow_quantum.core.ops.load_module import load_module
+
+NOISY_OP_MODULE = load_module(os.path.join("noise", "_tfq_noise_ops.so"))
+
+
+def sampled_expectation(programs, symbol_names, symbol_values, pauli_sums,
+                        num_samples):
+    """Estimate (via sampling) expectation values using monte-carlo simulation.
+
+    Simulate the final state of `programs` given `symbol_values` are placed
+    inside of the symbols with the name in `symbol_names` in each circuit.
+    Channels in this simulation will be "tossed" to a certain realization
+    during simulation. This simulation is repeated `num_samples` times and
+    bitstring based expectation calculations with the given `pauli_sums` are
+    calculated after each run. Once all the runs are finished, these quantities
+    are averaged together.
+
+    Args:
+        programs: `tf.Tensor` of strings with shape [batch_size] containing
+            the string representations of the circuits to be executed.
+        symbol_names: `tf.Tensor` of strings with shape [n_params], which
+            is used to specify the order in which the values in
+            `symbol_values` should be placed inside of the circuits in
+            `programs`.
+        symbol_values: `tf.Tensor` of real numbers with shape
+            [batch_size, n_params] specifying parameter values to resolve
+            into the circuits specificed by programs, following the ordering
+            dictated by `symbol_names`.
+        pauli_sums: `tf.Tensor` of strings with shape [batch_size, n_ops]
+            containing the string representation of the operators that will
+            be used on all of the circuits in the expectation calculations.
+        num_samples: `tf.Tensor` with `num_samples[i][j]` is equal to the
+            number of times `programs[i]` will be simulated to estimate
+            `pauli_sums[i][j]`. Therefore, `num_samples` must have the same
+            shape as `pauli_sums`. Note: internally this quantity can get
+            rounded up to the nearest multiple of the number of available
+            threads to TensorFlow. For best performance ensure that the
+            quantities in `num_samples` are a multiple of the number of
+            available threads.
+    Returns:
+        `tf.Tensor` with shape [batch_size, n_ops] that holds the
+            expectation value for each circuit with each op applied to it
+            (after resolving the corresponding parameters in).
+    """
+    return NOISY_OP_MODULE.tfq_noisy_sampled_expectation(
+        programs, symbol_names, tf.cast(symbol_values, tf.float32), pauli_sums,
+        tf.cast(num_samples, dtype=tf.int32))

--- a/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op.py
@@ -32,6 +32,39 @@ def sampled_expectation(programs, symbol_names, symbol_values, pauli_sums,
     calculated after each run. Once all the runs are finished, these quantities
     are averaged together.
 
+
+    >>> # Prepare some inputs.
+    >>> qubit = cirq.GridQubit(0, 0)
+    >>> my_symbol = sympy.Symbol('alpha')
+    >>> my_circuit_tensor = tfq.convert_to_tensor([
+    ...     cirq.Circuit(
+    ...         cirq.H(qubit) ** my_symbol,
+    ...         cirq.depolarize(0.01)(qubit)
+    ...     )
+    ... ])
+    >>> my_values = np.array([[0.123]])
+    >>> my_paulis = tfq.convert_to_tensor([[
+    ...     3.5 * cirq.X(qubit) - 2.2 * cirq.Y(qubit)
+    ... ]])
+    >>> my_num_samples = np.array([[100]])
+    >>> # This op can now be run with:
+    >>> output = tfq.noise.sampled_expectation(
+    ...     my_circuit_tensor, ['alpha'], my_values, my_paulis, my_num_samples)
+    >>> output
+    tf.Tensor([[0.71530885]], shape=(1, 1), dtype=float32)
+
+
+    In order to make the op differentiable, a `tfq.differentiator` object is
+    needed. see `tfq.differentiators` for more details. Below is a simple
+    example of how to make the from the above code block differentiable:
+
+
+    >>> diff = tfq.differentiators.ForwardDifference()
+    >>> my_differentiable_op = diff.generate_differentiable_op(
+    ...     sampled_op=tfq.noise.sampled_expectation
+    ... )
+
+
     Args:
         programs: `tf.Tensor` of strings with shape [batch_size] containing
             the string representations of the circuits to be executed.

--- a/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op.py
@@ -22,7 +22,7 @@ NOISY_OP_MODULE = load_module(os.path.join("noise", "_tfq_noise_ops.so"))
 
 def sampled_expectation(programs, symbol_names, symbol_values, pauli_sums,
                         num_samples):
-    """Estimate (via sampling) expectation values using monte-carlo simulation.
+    """Estimates (via sampling) expectation values using monte-carlo simulation.
 
     Simulate the final state of `programs` given `symbol_values` are placed
     inside of the symbols with the name in `symbol_names` in each circuit.

--- a/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op_test.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op_test.py
@@ -262,7 +262,7 @@ class NoisyExpectationCalculationTest(tf.test.TestCase, parameterized.TestCase):
         cirq_exps = batch_util.batch_calculate_expectation(
             circuit_batch, resolver_batch, batch_pauli_sums,
             cirq.DensityMatrixSimulator() if noisy else cirq.Simulator())
-        tol = 0.35 if noisy else 0.25
+        tol = 0.35
         self.assertAllClose(cirq_exps, op_exps, atol=tol, rtol=tol)
 
     @parameterized.parameters([{

--- a/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op_test.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op_test.py
@@ -252,7 +252,7 @@ class NoisyExpectationCalculationTest(tf.test.TestCase, parameterized.TestCase):
         pauli_sums1 = util.random_pauli_sums(qubits, 3, batch_size)
         pauli_sums2 = util.random_pauli_sums(qubits, 3, batch_size)
         batch_pauli_sums = [[x, y] for x, y in zip(pauli_sums1, pauli_sums2)]
-        num_samples = [[20000] * 2] * batch_size
+        num_samples = [[10000] * 2] * batch_size
 
         op_exps = noisy_sampled_expectation_op.sampled_expectation(
             util.convert_to_tensor(circuit_batch),
@@ -262,7 +262,7 @@ class NoisyExpectationCalculationTest(tf.test.TestCase, parameterized.TestCase):
         cirq_exps = batch_util.batch_calculate_expectation(
             circuit_batch, resolver_batch, batch_pauli_sums,
             cirq.DensityMatrixSimulator() if noisy else cirq.Simulator())
-        tol = 0.35
+        tol = 0.5
         self.assertAllClose(cirq_exps, op_exps, atol=tol, rtol=tol)
 
     @parameterized.parameters([{
@@ -290,7 +290,7 @@ class NoisyExpectationCalculationTest(tf.test.TestCase, parameterized.TestCase):
         pauli_sums1 = util.random_pauli_sums(qubits, 3, batch_size)
         pauli_sums2 = util.random_pauli_sums(qubits, 3, batch_size)
         batch_pauli_sums = [[x, y] for x, y in zip(pauli_sums1, pauli_sums2)]
-        num_samples = [[50000] * 2] * batch_size
+        num_samples = [[20000] * 2] * batch_size
 
         op_exps = noisy_sampled_expectation_op.sampled_expectation(
             util.convert_to_tensor(circuit_batch),
@@ -301,7 +301,7 @@ class NoisyExpectationCalculationTest(tf.test.TestCase, parameterized.TestCase):
             circuit_batch, resolver_batch, batch_pauli_sums,
             cirq.DensityMatrixSimulator())
 
-        self.assertAllClose(cirq_exps, op_exps, atol=0.25, rtol=0.25)
+        self.assertAllClose(cirq_exps, op_exps, atol=0.35, rtol=0.35)
 
     def test_correctness_empty(self):
         """Test the expectation for empty circuits."""

--- a/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op_test.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op_test.py
@@ -1,0 +1,337 @@
+# Copyright 2020 The TensorFlow Quantum Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests that specifically target noisy expectation calculation."""
+import numpy as np
+from absl.testing import parameterized
+import tensorflow as tf
+import cirq
+
+from tensorflow_quantum.core.ops import batch_util
+from tensorflow_quantum.core.ops.noise import noisy_sampled_expectation_op
+from tensorflow_quantum.python import util
+
+
+class NoisyExpectationCalculationTest(tf.test.TestCase, parameterized.TestCase):
+    """Tests tfq.noise.expectation."""
+
+    def test_noisy_expectation_inputs(self):
+        """Make sure noisy expectation op fails gracefully on bad inputs."""
+        n_qubits = 5
+        batch_size = 5
+        symbol_names = ['alpha']
+        qubits = cirq.GridQubit.rect(1, n_qubits)
+        circuit_batch, resolver_batch = \
+            util.random_symbol_circuit_resolver_batch(
+                qubits, symbol_names, batch_size, include_channels=True)
+
+        symbol_values_array = np.array(
+            [[resolver[symbol]
+              for symbol in symbol_names]
+             for resolver in resolver_batch])
+
+        pauli_sums = util.random_pauli_sums(qubits, 3, batch_size)
+        num_samples = [[10]] * batch_size
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'programs must be rank 1'):
+            # Circuit tensor has too many dimensions.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor([circuit_batch]), symbol_names,
+                symbol_values_array,
+                util.convert_to_tensor([[x] for x in pauli_sums]), num_samples)
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'symbol_names must be rank 1.'):
+            # symbol_names tensor has too many dimensions.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), np.array([symbol_names]),
+                symbol_values_array,
+                util.convert_to_tensor([[x] for x in pauli_sums]), num_samples)
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'symbol_values must be rank 2.'):
+            # symbol_values_array tensor has too many dimensions.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                np.array([symbol_values_array]),
+                util.convert_to_tensor([[x] for x in pauli_sums]), num_samples)
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'symbol_values must be rank 2.'):
+            # symbol_values_array tensor has too few dimensions.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                symbol_values_array[0],
+                util.convert_to_tensor([[x] for x in pauli_sums]), num_samples)
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'pauli_sums must be rank 2.'):
+            # pauli_sums tensor has too few dimensions.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch),
+                symbol_names, symbol_values_array,
+                util.convert_to_tensor(list(pauli_sums)), num_samples)
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'pauli_sums must be rank 2.'):
+            # pauli_sums tensor has too many dimensions.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                symbol_values_array,
+                [util.convert_to_tensor([[x] for x in pauli_sums])],
+                num_samples)
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'num_samples must be rank 2'):
+            # num_samples tensor has the wrong shape.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                symbol_values_array,
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                [num_samples])
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'num_samples must be rank 2'):
+            # num_samples tensor has the wrong shape.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                symbol_values_array,
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                num_samples[0])
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'Unparseable proto'):
+            # circuit tensor has the right type but invalid values.
+            noisy_sampled_expectation_op.sampled_expectation(
+                ['junk'] * batch_size, symbol_names, symbol_values_array,
+                util.convert_to_tensor([[x] for x in pauli_sums]), num_samples)
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'Could not find symbol in parameter map'):
+            # symbol_names tensor has the right type but invalid values.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), ['junk'],
+                symbol_values_array,
+                util.convert_to_tensor([[x] for x in pauli_sums]), num_samples)
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'qubits not found in circuit'):
+            # pauli_sums tensor has the right type but invalid values.
+            new_qubits = [cirq.GridQubit(5, 5), cirq.GridQubit(9, 9)]
+            new_pauli_sums = util.random_pauli_sums(new_qubits, 2, batch_size)
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                symbol_values_array,
+                util.convert_to_tensor([[x] for x in new_pauli_sums]),
+                num_samples)
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'Unparseable proto'):
+            # pauli_sums tensor has the right type but invalid values 2.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                symbol_values_array, [['junk']] * batch_size, num_samples)
+
+        with self.assertRaisesRegex(TypeError, 'Cannot convert'):
+            # circuits tensor has the wrong type.
+            noisy_sampled_expectation_op.sampled_expectation(
+                [1.0] * batch_size, symbol_names, symbol_values_array,
+                util.convert_to_tensor([[x] for x in pauli_sums]), num_samples)
+
+        with self.assertRaisesRegex(TypeError, 'Cannot convert'):
+            # symbol_names tensor has the wrong type.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), [0.1234],
+                symbol_values_array,
+                util.convert_to_tensor([[x] for x in pauli_sums]), num_samples)
+
+        with self.assertRaisesRegex(tf.errors.UnimplementedError, ''):
+            # symbol_values tensor has the wrong type.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                [['junk']] * batch_size,
+                util.convert_to_tensor([[x] for x in pauli_sums]), num_samples)
+
+        with self.assertRaisesRegex(TypeError, 'Cannot convert'):
+            # pauli_sums tensor has the wrong type.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                symbol_values_array, [[1.0]] * batch_size, num_samples)
+
+        with self.assertRaisesRegex(TypeError, 'missing'):
+            # we are missing an argument.
+            # pylint: disable=no-value-for-parameter
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                symbol_values_array, num_samples)
+            # pylint: enable=no-value-for-parameter
+
+        with self.assertRaisesRegex(TypeError, 'positional arguments'):
+            # pylint: disable=too-many-function-args
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                symbol_values_array,
+                util.convert_to_tensor([[x] for x in pauli_sums]), [],
+                num_samples)
+            # pylint: enable=too-many-function-args
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    expected_regex='do not match'):
+            # wrong op size.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor([cirq.Circuit()]), symbol_names,
+                symbol_values_array.astype(np.float64),
+                util.convert_to_tensor([[x] for x in pauli_sums]), num_samples)
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    'greater than 0'):
+            # pylint: disable=too-many-function-args
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                symbol_values_array,
+                util.convert_to_tensor([[x] for x in pauli_sums]),
+                [[-1]] * batch_size)
+            # pylint: enable=too-many-function-args
+
+        with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
+                                    expected_regex='do not match'):
+            # wrong symbol_values size.
+            noisy_sampled_expectation_op.sampled_expectation(
+                util.convert_to_tensor(circuit_batch), symbol_names,
+                symbol_values_array[:int(batch_size * 0.5)],
+                util.convert_to_tensor([[x] for x in pauli_sums]), num_samples)
+
+    @parameterized.parameters([
+        {
+            'n_qubits': 13,
+            'batch_size': 1,
+            'noisy': False
+        },  # ComputeLarge.
+        {
+            'n_qubits': 6,
+            'batch_size': 25,
+            'noisy': False
+        },  # ComputeSmall.
+        {
+            'n_qubits': 6,
+            'batch_size': 10,
+            'noisy': True
+        },  # ComputeSmall.
+        {
+            'n_qubits': 8,
+            'batch_size': 1,
+            'noisy': True
+        }  # ComputeLarge.
+    ])
+    def test_simulate_consistency(self, batch_size, n_qubits, noisy):
+        """Test consistency with batch_util.py simulation."""
+        symbol_names = ['alpha', 'beta']
+        qubits = cirq.GridQubit.rect(1, n_qubits)
+
+        circuit_batch, resolver_batch = \
+            util.random_symbol_circuit_resolver_batch(
+                qubits, symbol_names, batch_size, include_channels=noisy)
+
+        symbol_values_array = np.array(
+            [[resolver[symbol]
+              for symbol in symbol_names]
+             for resolver in resolver_batch])
+
+        pauli_sums1 = util.random_pauli_sums(qubits, 3, batch_size)
+        pauli_sums2 = util.random_pauli_sums(qubits, 3, batch_size)
+        batch_pauli_sums = [[x, y] for x, y in zip(pauli_sums1, pauli_sums2)]
+        num_samples = [[20000] * 2] * batch_size
+
+        op_exps = noisy_sampled_expectation_op.sampled_expectation(
+            util.convert_to_tensor(circuit_batch),
+            symbol_names, symbol_values_array,
+            util.convert_to_tensor(batch_pauli_sums), num_samples)
+
+        cirq_exps = batch_util.batch_calculate_expectation(
+            circuit_batch, resolver_batch, batch_pauli_sums,
+            cirq.DensityMatrixSimulator() if noisy else cirq.Simulator())
+        tol = 0.35 if noisy else 0.25
+        self.assertAllClose(cirq_exps, op_exps, atol=tol, rtol=tol)
+
+    @parameterized.parameters([{
+        'channel': x
+    } for x in util.get_supported_channels()])
+    def test_single_channel(self, channel):
+        """Individually test adding just a single channel type to circuits."""
+        symbol_names = []
+        batch_size = 5
+        n_qubits = 6
+        qubits = cirq.GridQubit.rect(1, n_qubits)
+
+        circuit_batch, resolver_batch = \
+            util.random_circuit_resolver_batch(
+                qubits, batch_size, include_channels=False)
+
+        for i in range(batch_size):
+            circuit_batch[i] = circuit_batch[i] + channel.on_each(*qubits)
+
+        symbol_values_array = np.array(
+            [[resolver[symbol]
+              for symbol in symbol_names]
+             for resolver in resolver_batch])
+
+        pauli_sums1 = util.random_pauli_sums(qubits, 3, batch_size)
+        pauli_sums2 = util.random_pauli_sums(qubits, 3, batch_size)
+        batch_pauli_sums = [[x, y] for x, y in zip(pauli_sums1, pauli_sums2)]
+        num_samples = [[50000] * 2] * batch_size
+
+        op_exps = noisy_sampled_expectation_op.sampled_expectation(
+            util.convert_to_tensor(circuit_batch),
+            symbol_names, symbol_values_array,
+            util.convert_to_tensor(batch_pauli_sums), num_samples)
+
+        cirq_exps = batch_util.batch_calculate_expectation(
+            circuit_batch, resolver_batch, batch_pauli_sums,
+            cirq.DensityMatrixSimulator())
+
+        self.assertAllClose(cirq_exps, op_exps, atol=0.25, rtol=0.25)
+
+    def test_correctness_empty(self):
+        """Test the expectation for empty circuits."""
+        empty_circuit = util.convert_to_tensor([cirq.Circuit()])
+        empty_symbols = tf.convert_to_tensor([], dtype=tf.dtypes.string)
+        empty_values = tf.convert_to_tensor([[]])
+        empty_paulis = tf.convert_to_tensor([[]], dtype=tf.dtypes.string)
+        empty_n_samples = tf.convert_to_tensor([[]], dtype=tf.int32)
+
+        out = noisy_sampled_expectation_op.sampled_expectation(
+            empty_circuit, empty_symbols, empty_values, empty_paulis,
+            empty_n_samples)
+
+        expected = np.array([[]], dtype=np.complex64)
+        self.assertAllClose(out, expected)
+
+    def test_correctness_no_circuit(self):
+        """Test the correctness with the empty tensor."""
+        empty_circuit = tf.raw_ops.Empty(shape=(0,), dtype=tf.string)
+        empty_symbols = tf.raw_ops.Empty(shape=(0,), dtype=tf.string)
+        empty_values = tf.raw_ops.Empty(shape=(0, 0), dtype=tf.float32)
+        empty_paulis = tf.raw_ops.Empty(shape=(0, 0), dtype=tf.string)
+        empty_n_samples = tf.raw_ops.Empty(shape=(0, 0), dtype=tf.int32)
+
+        out = noisy_sampled_expectation_op.sampled_expectation(
+            empty_circuit, empty_symbols, empty_values, empty_paulis,
+            empty_n_samples)
+
+        self.assertShapeEqual(np.zeros((0, 0)), out)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/tensorflow_quantum/core/ops/noise/tfq_noisy_sampled_expectation.cc
+++ b/tensorflow_quantum/core/ops/noise/tfq_noisy_sampled_expectation.cc
@@ -134,7 +134,7 @@ class TfqNoisySampledExpectationOp : public tensorflow::OpKernel {
     // e2s4 = 4 CPU, 16GB -> Can safely do 25 since Memory = 8GB
     // ...
     if (max_num_qubits >= 26) {
-      // If the number of qubits is lager than 24, we switch to an
+      // If the number of qubits is lager than 25, we switch to an
       // alternate parallelization scheme with runtime:
       // O(n_circuits * max_j(num_samples[i])) with parallelization being
       // multiple threads per wavefunction.

--- a/tensorflow_quantum/core/ops/noise/tfq_noisy_sampled_expectation.cc
+++ b/tensorflow_quantum/core/ops/noise/tfq_noisy_sampled_expectation.cc
@@ -1,0 +1,403 @@
+/* Copyright 2020 The TensorFlow Quantum Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <memory>
+#include <vector>
+
+#include "../qsim/lib/channel.h"
+#include "../qsim/lib/channels_cirq.h"
+#include "../qsim/lib/circuit.h"
+#include "../qsim/lib/circuit_noisy.h"
+#include "../qsim/lib/fuser_mqubit.h"
+#include "../qsim/lib/gate_appl.h"
+#include "../qsim/lib/gates_cirq.h"
+#include "../qsim/lib/io.h"
+#include "../qsim/lib/qtrajectory.h"
+#include "../qsim/lib/seqfor.h"
+#include "../qsim/lib/simmux.h"
+#include "cirq/google/api/v2/program.pb.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/lib/core/error_codes.pb.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/lib/core/threadpool.h"
+#include "tensorflow/core/platform/mutex.h"
+#include "tensorflow_quantum/core/ops/parse_context.h"
+#include "tensorflow_quantum/core/proto/pauli_sum.pb.h"
+#include "tensorflow_quantum/core/src/util_qsim.h"
+
+namespace tfq {
+
+using ::cirq::google::api::v2::Program;
+using ::tensorflow::Status;
+using ::tfq::proto::PauliSum;
+
+typedef qsim::Cirq::GateCirq<float> QsimGate;
+typedef qsim::Circuit<QsimGate> QsimCircuit;
+typedef qsim::NoisyCircuit<QsimGate> NoisyQsimCircuit;
+
+class TfqNoisySampledExpectationOp : public tensorflow::OpKernel {
+ public:
+  explicit TfqNoisySampledExpectationOp(
+      tensorflow::OpKernelConstruction* context)
+      : OpKernel(context) {}
+
+  void Compute(tensorflow::OpKernelContext* context) override {
+    // TODO (mbbrough): add more dimension checks for other inputs here.
+    const int num_inputs = context->num_inputs();
+    OP_REQUIRES(context, num_inputs == 5,
+                tensorflow::errors::InvalidArgument(absl::StrCat(
+                    "Expected 5 inputs, got ", num_inputs, " inputs.")));
+
+    // Create the output Tensor.
+    const int output_dim_batch_size = context->input(0).dim_size(0);
+    const int output_dim_op_size = context->input(3).dim_size(1);
+    tensorflow::TensorShape output_shape;
+    output_shape.AddDim(output_dim_batch_size);
+    output_shape.AddDim(output_dim_op_size);
+
+    tensorflow::Tensor* output = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));
+    auto output_tensor = output->matrix<float>();
+
+    std::vector<Program> programs;
+    std::vector<int> num_qubits;
+    std::vector<std::vector<PauliSum>> pauli_sums;
+    OP_REQUIRES_OK(context, GetProgramsAndNumQubits(context, &programs,
+                                                    &num_qubits, &pauli_sums));
+
+    std::vector<SymbolMap> maps;
+    OP_REQUIRES_OK(context, GetSymbolMaps(context, &maps));
+
+    OP_REQUIRES(context, programs.size() == maps.size(),
+                tensorflow::errors::InvalidArgument(absl::StrCat(
+                    "Number of circuits and symbol_values do not match. Got ",
+                    programs.size(), " circuits and ", maps.size(),
+                    " symbol values.")));
+
+    std::vector<std::vector<int>> num_samples;
+    OP_REQUIRES_OK(context, GetNumSamples(context, &num_samples));
+
+    OP_REQUIRES(context, num_samples.size() == pauli_sums.size(),
+                tensorflow::errors::InvalidArgument(absl::StrCat(
+                    "Dimension 0 of num_samples and pauli_sums do not match.",
+                    "Got ", num_samples.size(), " lists of sample sizes and ",
+                    pauli_sums.size(), " lists of pauli sums.")));
+
+    OP_REQUIRES(
+        context, context->input(4).dim_size(1) == context->input(3).dim_size(1),
+        tensorflow::errors::InvalidArgument(absl::StrCat(
+            "Dimension 1 of num_samples and pauli_sums do not match.", "Got ",
+            context->input(4).dim_size(1), " lists of sample sizes and ",
+            context->input(3).dim_size(1), " lists of pauli sums.")));
+
+    // Construct qsim circuits.
+    std::vector<NoisyQsimCircuit> qsim_circuits(programs.size(),
+                                                NoisyQsimCircuit());
+
+    Status parse_status = Status::OK();
+    auto p_lock = tensorflow::mutex();
+    auto construct_f = [&](int start, int end) {
+      for (int i = start; i < end; i++) {
+        Status local = NoisyQsimCircuitFromProgram(
+            programs[i], maps[i], num_qubits[i], false, &qsim_circuits[i]);
+        NESTED_FN_STATUS_SYNC(parse_status, local, p_lock);
+      }
+    };
+
+    const int num_cycles = 1000;
+    context->device()->tensorflow_cpu_worker_threads()->workers->ParallelFor(
+        programs.size(), num_cycles, construct_f);
+    OP_REQUIRES_OK(context, parse_status);
+
+    int max_num_qubits = 0;
+    for (const int num : num_qubits) {
+      max_num_qubits = std::max(max_num_qubits, num);
+    }
+
+    // Cross reference with standard google cloud compute instances
+    // Memory ~= 2 * num_threads * (2 * 64 * 2 ** num_qubits in circuits)
+    // e2s2 = 2 CPU, 8GB -> Can safely do 25 since Memory = 4GB
+    // e2s4 = 4 CPU, 16GB -> Can safely do 25 since Memory = 8GB
+    // ...
+    if (max_num_qubits >= 26) {
+      // If the number of qubits is lager than 24, we switch to an
+      // alternate parallelization scheme with runtime:
+      // O(n_circuits * max_j(num_samples[i])) with parallelization being
+      // multiple threads per wavefunction.
+      ComputeLarge(num_qubits, qsim_circuits, pauli_sums, num_samples, context,
+                   &output_tensor);
+    } else {
+      // Runtime: O(n_circuits * max_j(num_samples[i])) with parallelization
+      // being done over number of trials.
+      ComputeSmall(num_qubits, max_num_qubits, qsim_circuits, pauli_sums,
+                   num_samples, context, &output_tensor);
+    }
+  }
+
+ private:
+  void ComputeLarge(const std::vector<int>& num_qubits,
+                    const std::vector<NoisyQsimCircuit>& ncircuits,
+                    const std::vector<std::vector<PauliSum>>& pauli_sums,
+                    const std::vector<std::vector<int>>& num_samples,
+                    tensorflow::OpKernelContext* context,
+                    tensorflow::TTypes<float, 1>::Matrix* output_tensor) {
+    // Instantiate qsim objects.
+    const auto tfq_for = tfq::QsimFor(context);
+    using Simulator = qsim::Simulator<const tfq::QsimFor&>;
+    using StateSpace = Simulator::StateSpace;
+    using QTSimulator =
+        qsim::QuantumTrajectorySimulator<qsim::IO, QsimGate,
+                                         qsim::MultiQubitGateFuser, Simulator>;
+
+    // Begin simulation.
+    int largest_nq = 1;
+    Simulator sim = Simulator(tfq_for);
+    StateSpace ss = StateSpace(tfq_for);
+    auto sv = ss.Create(largest_nq);
+    auto scratch = ss.Create(largest_nq);
+
+    // Simulate programs one by one. Parallelizing over state vectors
+    // we no longer parallelize over circuits. Each time we encounter a
+    // a larger circuit we will grow the Statevector as necessary.
+    for (int i = 0; i < ncircuits.size(); i++) {
+      int nq = num_qubits[i];
+
+      // (#679) Just ignore empty program
+      if (ncircuits[i].channels.size() == 0) {
+        for (int j = 0; j < pauli_sums[i].size(); j++) {
+          (*output_tensor)(i, j) = -2.0;
+        }
+        continue;
+      }
+
+      if (nq > largest_nq) {
+        largest_nq = nq;
+        sv = ss.Create(largest_nq);
+        scratch = ss.Create(largest_nq);
+      }
+      QTSimulator::Parameter param;
+      param.collect_kop_stat = false;
+      param.collect_mea_stat = false;
+      param.normalize_before_mea_gates = true;
+      std::vector<uint64_t> unused_stats;
+      // Track op-wise stats.
+      std::vector<int> run_samples(num_samples[i].size(), 0);
+      std::vector<double> rolling_sums(num_samples[i].size(), 0.0);
+
+      while (1) {
+        ss.SetStateZero(sv);
+        // time since epoch seeds random generator.
+        unsigned long r_seed =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch())
+                .count();
+        QTSimulator::RunOnce(param, ncircuits[i], r_seed, ss, sim, scratch, sv,
+                             unused_stats);
+
+        // Use this trajectory as a source for all expectation calculations.
+        for (int j = 0; j < pauli_sums[i].size(); j++) {
+          if (run_samples[j] >= num_samples[i][j]) {
+            continue;
+          }
+          float exp_v = 0.0;
+          OP_REQUIRES_OK(
+              context, ComputeSampledExpectationQsim(pauli_sums[i][j], sim, ss,
+                                                     sv, scratch, 1, &exp_v));
+          rolling_sums[j] += static_cast<double>(exp_v);
+          run_samples[j]++;
+        }
+        bool break_loop = true;
+        for (int j = 0; j < num_samples[i].size(); j++) {
+          if (run_samples[j] < num_samples[i][j]) {
+            break_loop = false;
+            break;
+          }
+        }
+        if (break_loop) {
+          for (int j = 0; j < num_samples[i].size(); j++) {
+            rolling_sums[j] /= num_samples[i][j];
+            (*output_tensor)(i, j) = static_cast<float>(rolling_sums[j]);
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  void ComputeSmall(const std::vector<int>& num_qubits,
+                    const int max_num_qubits,
+                    const std::vector<NoisyQsimCircuit>& ncircuits,
+                    const std::vector<std::vector<PauliSum>>& pauli_sums,
+                    const std::vector<std::vector<int>>& num_samples,
+                    tensorflow::OpKernelContext* context,
+                    tensorflow::TTypes<float, 1>::Matrix* output_tensor) {
+    using Simulator = qsim::Simulator<const qsim::SequentialFor&>;
+    using StateSpace = Simulator::StateSpace;
+    using QTSimulator =
+        qsim::QuantumTrajectorySimulator<qsim::IO, QsimGate,
+                                         qsim::MultiQubitGateFuser, Simulator>;
+
+    const int output_dim_batch_size = output_tensor->dimension(0);
+    std::vector<tensorflow::mutex> batch_locks(output_dim_batch_size,
+                                               tensorflow::mutex());
+
+    const int num_threads = context->device()
+                                ->tensorflow_cpu_worker_threads()
+                                ->workers->NumThreads();
+
+    // [num_threads, batch_size].
+    std::vector<std::vector<int>> rep_offsets(
+        num_threads, std::vector<int>(output_dim_batch_size, 0));
+
+    BalanceTrajectory(num_samples, num_threads, &rep_offsets);
+
+    output_tensor->setZero();
+
+    Status compute_status = Status::OK();
+    auto c_lock = tensorflow::mutex();
+    auto DoWork = [&](int start, int end) {
+      // Begin simulation.
+      const auto tfq_for = qsim::SequentialFor(1);
+      int largest_nq = 1;
+      Simulator sim = Simulator(tfq_for);
+      StateSpace ss = StateSpace(tfq_for);
+      auto sv = ss.Create(largest_nq);
+      auto scratch = ss.Create(largest_nq);
+
+      for (int i = 0; i < ncircuits.size(); i++) {
+        int nq = num_qubits[i];
+        int rep_offset = rep_offsets[start][i];
+
+        // (#679) Just ignore empty program
+        if (ncircuits[i].channels.size() == 0) {
+          for (int j = 0; j < pauli_sums[i].size(); j++) {
+            (*output_tensor)(i, j) = -2.0;
+          }
+          continue;
+        }
+
+        if (nq > largest_nq) {
+          largest_nq = nq;
+          sv = ss.Create(largest_nq);
+          scratch = ss.Create(largest_nq);
+        }
+        QTSimulator::Parameter param;
+        param.collect_kop_stat = false;
+        param.collect_mea_stat = false;
+        param.normalize_before_mea_gates = true;
+        std::vector<uint64_t> unused_stats;
+        // Track op-wise stats.
+        std::vector<int> run_samples(num_samples[i].size(), 0);
+        std::vector<double> rolling_sums(num_samples[i].size(), 0.0);
+
+        while (1) {
+          ss.SetStateZero(sv);
+          // time since epoch seeds random generator.
+          unsigned long r_seed =
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                  std::chrono::system_clock::now().time_since_epoch())
+                  .count();
+
+          QTSimulator::RunOnce(param, ncircuits[i], r_seed, ss, sim, scratch,
+                               sv, unused_stats);
+
+          // Compute expectations across all ops using this trajectory.
+          for (int j = 0; j < pauli_sums[i].size(); j++) {
+            int p_reps = (num_samples[i][j] + num_threads - 1) / num_threads;
+            if (run_samples[j] >= p_reps + rep_offset) {
+              continue;
+            }
+            float exp_v = 0.0;
+            NESTED_FN_STATUS_SYNC(
+                compute_status,
+                ComputeSampledExpectationQsim(pauli_sums[i][j], sim, ss, sv,
+                                              scratch, 1, &exp_v),
+                c_lock);
+            rolling_sums[j] += static_cast<double>(exp_v);
+            run_samples[j]++;
+          }
+
+          // Check if we have run enough trajectories for all ops.
+          bool break_loop = true;
+          for (int j = 0; j < num_samples[i].size(); j++) {
+            int p_reps = (num_samples[i][j] + num_threads - 1) / num_threads;
+            if (run_samples[j] < p_reps + rep_offset) {
+              break_loop = false;
+              break;
+            }
+          }
+          if (break_loop) {
+            // Lock writing to this batch index in output_tensor.
+            batch_locks[i].lock();
+            for (int j = 0; j < num_samples[i].size(); j++) {
+              rolling_sums[j] /= num_samples[i][j];
+              (*output_tensor)(i, j) += static_cast<float>(rolling_sums[j]);
+            }
+            batch_locks[i].unlock();
+            break;
+          }
+        }
+      }
+    };
+
+    // block_size = 1.
+    tensorflow::thread::ThreadPool::SchedulingParams scheduling_params(
+        tensorflow::thread::ThreadPool::SchedulingStrategy::kFixedBlockSize,
+        absl::nullopt, 1);
+    context->device()->tensorflow_cpu_worker_threads()->workers->ParallelFor(
+        num_threads, scheduling_params, DoWork);
+    OP_REQUIRES_OK(context, compute_status);
+  }
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("TfqNoisySampledExpectation").Device(tensorflow::DEVICE_CPU),
+    TfqNoisySampledExpectationOp);
+
+REGISTER_OP("TfqNoisySampledExpectation")
+    .Input("programs: string")
+    .Input("symbol_names: string")
+    .Input("symbol_values: float")
+    .Input("pauli_sums: string")
+    .Input("num_samples: int32")
+    .Output("expectations: float")
+    .SetShapeFn([](tensorflow::shape_inference::InferenceContext* c) {
+      tensorflow::shape_inference::ShapeHandle programs_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 1, &programs_shape));
+
+      tensorflow::shape_inference::ShapeHandle symbol_names_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &symbol_names_shape));
+
+      tensorflow::shape_inference::ShapeHandle symbol_values_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 2, &symbol_values_shape));
+
+      tensorflow::shape_inference::ShapeHandle pauli_sums_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 2, &pauli_sums_shape));
+
+      tensorflow::shape_inference::ShapeHandle num_samples_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(4), 2, &num_samples_shape));
+
+      tensorflow::shape_inference::DimensionHandle output_rows =
+          c->Dim(programs_shape, 0);
+      tensorflow::shape_inference::DimensionHandle output_cols =
+          c->Dim(pauli_sums_shape, 1);
+      c->set_output(0, c->Matrix(output_rows, output_cols));
+
+      return tensorflow::Status::OK();
+    });
+
+}  // namespace tfq

--- a/tensorflow_quantum/core/src/util_qsim.h
+++ b/tensorflow_quantum/core/src/util_qsim.h
@@ -222,8 +222,11 @@ tensorflow::Status ComputeSampledExpectationQsim(
     if (!status.ok()) {
       return status;
     }
-
-    const int seed = 1234;
+    unsigned long r_seed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
+    const unsigned int seed = static_cast<unsigned int>(r_seed);
     std::vector<uint64_t> state_samples = ss.Sample(scratch, num_samples, seed);
 
     // Find qubits on which to measure parity

--- a/tensorflow_quantum/core/src/util_qsim_test.cc
+++ b/tensorflow_quantum/core/src/util_qsim_test.cc
@@ -91,7 +91,7 @@ TEST_P(TwoTermSampledExpectationFixture, CorrectnessTest) {
   Status s = tfq::ComputeSampledExpectationQsim(p_sum, sim, ss, sv, scratch,
                                                 1000000, &exp_v);
 
-  EXPECT_NEAR(exp_v, std::get<1>(GetParam()), 1e-3);
+  EXPECT_NEAR(exp_v, std::get<1>(GetParam()), 1e-2);
 }
 
 // clang-format off
@@ -277,7 +277,7 @@ TEST(UtilQsimTest, SampledCompoundCase) {
   Status s = tfq::ComputeSampledExpectationQsim(p_sum, sim, ss, sv, scratch,
                                                 10000000, &exp_v);
 
-  EXPECT_NEAR(exp_v, 4.1234, 1e-3);
+  EXPECT_NEAR(exp_v, 4.1234, 1e-2);
 }
 
 TEST(UtilQsimTest, CompoundCase) {

--- a/tensorflow_quantum/python/differentiators/linear_combination_test.py
+++ b/tensorflow_quantum/python/differentiators/linear_combination_test.py
@@ -172,9 +172,9 @@ class LinearCombinationTest(tf.test.TestCase, parameterized.TestCase):
                             rtol=1e-2)
 
     @parameterized.parameters([{
-        'diff': linear_combination.ForwardDifference()
+        'diff': linear_combination.ForwardDifference(grid_spacing=0.01)
     }, {
-        'diff': linear_combination.CentralDifference()
+        'diff': linear_combination.CentralDifference(grid_spacing=0.01)
     }])
     def test_sampled_functional(self, diff):
         """Test that the differentiate_sampled function WORKS."""

--- a/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
@@ -248,7 +248,7 @@ class SampledExpectationTest(tf.test.TestCase):
                 mse = tf.square(tf.reduce_sum(tf.subtract(circuit_out, -1)))
             grads = tape.gradient(mse, layer.trainable_weights)
             optimizer.apply_gradients(zip(grads, layer.trainable_weights))
-        self.assertAllClose(mse.numpy(), 0, atol=1e-3)
+        self.assertAllClose(mse.numpy(), 0, atol=1e-2)
 
 
 class SampledExpectationFunctionalTests(tf.test.TestCase):


### PR DESCRIPTION
Adds support for noisy sample based expectation. Note it's basically identical to the analytical case but we instead call into `ComputeSampledExpectationQsim`. Since we are only ever taking 1 shot per circuit realization I had to modify this function to no longer have a fixed seed. 