### PR TITLE
Gradient circuits 4/n: update LinearCombination

### DIFF
--- a/tensorflow_quantum/core/ops/noise/noisy_samples_op_test.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_samples_op_test.py
@@ -175,7 +175,7 @@ class NoisySamplingTest(tf.test.TestCase, parameterized.TestCase):
               for symbol in symbol_names]
              for resolver in resolver_batch])
 
-        n_samples = 10000
+        n_samples = 20000
         op_samples = noisy_samples_op.samples(
             util.convert_to_tensor(circuit_batch), symbol_names,
             symbol_values_array, [n_samples]).to_list()

--- a/tensorflow_quantum/core/ops/noise/noisy_samples_op_test.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_samples_op_test.py
@@ -175,7 +175,7 @@ class NoisySamplingTest(tf.test.TestCase, parameterized.TestCase):
               for symbol in symbol_names]
              for resolver in resolver_batch])
 
-        n_samples = 20000
+        n_samples = 10000
         op_samples = noisy_samples_op.samples(
             util.convert_to_tensor(circuit_batch), symbol_names,
             symbol_values_array, [n_samples]).to_list()
@@ -187,7 +187,7 @@ class NoisySamplingTest(tf.test.TestCase, parameterized.TestCase):
             cirq.DensityMatrixSimulator() if noisy else cirq.Simulator())
 
         cirq_hists = self._compute_hists(cirq_samples, n_qubits)
-        tol = 1.3 if noisy else 1.0
+        tol = 1.5 if noisy else 1.0
         for a, b in zip(op_hists, cirq_hists):
             self.assertLess(stats.entropy(a + 1e-8, b + 1e-8), tol)
 

--- a/tensorflow_quantum/python/differentiators/linear_combination.py
+++ b/tensorflow_quantum/python/differentiators/linear_combination.py
@@ -151,11 +151,12 @@ class LinearCombination(differentiator.Differentiator):
         batch_symbol_values = bare_symbol_values + all_perts
 
         # The weights for all the programs.
-        tiled_weights = tf.tile(tf.expand_dims(self.non_zero_weights, 0), [n_symbols, 1])
+        tiled_weights = tf.tile(tf.expand_dims(self.non_zero_weights, 0),
+                                [n_symbols, 1])
         tiled_zero_weights = tf.tile(tf.expand_dims(self.zero_weights, 0),
                                      [n_symbols, 1])
-        single_program_weights = tf.concat(
-            [tiled_zero_weights, tiled_weights], 1)
+        single_program_weights = tf.concat([tiled_zero_weights, tiled_weights],
+                                           1)
         # Mapping is also the same for each program.
         batch_weights = tf.tile(tf.expand_dims(single_program_weights, 0),
                                 [n_programs, 1, 1])
@@ -166,9 +167,12 @@ class LinearCombination(differentiator.Differentiator):
             [n_symbols, self.n_non_zero_perturbations])
         single_program_mapper = tf.cond(
             self.n_non_zero_perturbations < self.n_perturbations,
-            lambda: tf.concat([tf.zeros([n_symbols, 1], dtype=tf.int32), single_program_mapper_base + 1], 1),
-            lambda: single_program_mapper_base)
-        batch_mapper = tf.tile(tf.expand_dims(single_program_mapper, 0), [n_programs, 1, 1])
+            lambda: tf.concat([
+                tf.zeros([n_symbols, 1], dtype=tf.int32),
+                single_program_mapper_base + 1
+            ], 1), lambda: single_program_mapper_base)
+        batch_mapper = tf.tile(tf.expand_dims(single_program_mapper, 0),
+                               [n_programs, 1, 1])
 
         return (batch_programs, new_symbol_names, batch_symbol_values,
                 batch_weights, batch_mapper)

--- a/tensorflow_quantum/python/differentiators/linear_combination.py
+++ b/tensorflow_quantum/python/differentiators/linear_combination.py
@@ -111,6 +111,7 @@ class LinearCombination(differentiator.Differentiator):
         self.n_non_zero_perturbations = tf.gather(
             tf.shape(self.non_zero_perturbations), 0)
 
+    @tf.function
     def get_gradient_circuits(self, programs, symbol_names, symbol_values):
         """See base class description."""
         n_programs = tf.gather(tf.shape(programs), 0)

--- a/tensorflow_quantum/python/differentiators/linear_combination.py
+++ b/tensorflow_quantum/python/differentiators/linear_combination.py
@@ -111,7 +111,6 @@ class LinearCombination(differentiator.Differentiator):
         self.n_non_zero_perturbations = tf.gather(
             tf.shape(self.non_zero_perturbations), 0)
 
-    @tf.function
     def get_gradient_circuits(self, programs, symbol_names, symbol_values):
         """See base class description."""
         n_programs = tf.gather(tf.shape(programs), 0)
@@ -151,20 +150,28 @@ class LinearCombination(differentiator.Differentiator):
                                      [1, m_tile, 1])
         batch_symbol_values = bare_symbol_values + all_perts
 
-        stacked_weights = tf.stack([perts_zeros_pad, self.non_zero_weights])
-        gathered_weights = tf.gather(stacked_weights,
-                                     tf.eye(n_symbols, dtype=tf.int32))
-        reshaped_weights = tf.concat(tf.unstack(gathered_weights), 1)
+        # The weights for all the programs.
+        tiled_weights = tf.tile(tf.expand_dims(self.non_zero_weights, 0), [n_symbols, 1])
         tiled_zero_weights = tf.tile(tf.expand_dims(self.zero_weights, 0),
                                      [n_symbols, 1])
-        single_program_mapper = tf.concat(
-            [tiled_zero_weights, reshaped_weights], 1)
+        single_program_weights = tf.concat(
+            [tiled_zero_weights, tiled_weights], 1)
         # Mapping is also the same for each program.
-        batch_mapper = tf.tile(tf.expand_dims(single_program_mapper, 0),
-                               [n_programs, 1, 1])
+        batch_weights = tf.tile(tf.expand_dims(single_program_weights, 0),
+                                [n_programs, 1, 1])
+
+        # The mapper selects the zero weight if it exists.
+        single_program_mapper_base = tf.reshape(
+            tf.range(n_symbols * self.n_non_zero_perturbations),
+            [n_symbols, self.n_non_zero_perturbations])
+        single_program_mapper = tf.cond(
+            self.n_non_zero_perturbations < self.n_perturbations,
+            lambda: tf.concat([tf.zeros([n_symbols, 1], dtype=tf.int32), single_program_mapper_base + 1], 1),
+            lambda: single_program_mapper_base)
+        batch_mapper = tf.tile(tf.expand_dims(single_program_mapper, 0), [n_programs, 1, 1])
 
         return (batch_programs, new_symbol_names, batch_symbol_values,
-                batch_mapper)
+                batch_weights, batch_mapper)
 
     @differentiator.catch_empty_inputs
     @tf.function

--- a/tensorflow_quantum/python/differentiators/linear_combination_test.py
+++ b/tensorflow_quantum/python/differentiators/linear_combination_test.py
@@ -248,8 +248,7 @@ class LinearCombinationTest(tf.test.TestCase, parameterized.TestCase):
             [individual_batch_weights, individual_batch_weights])
 
         # The mapper selects the expectations.
-        single_program_mapper = tf.constant([[0, 1],
-                                             [2, 3]])
+        single_program_mapper = tf.constant([[0, 1], [2, 3]])
         expected_batch_mapper = tf.tile(
             tf.expand_dims(single_program_mapper, 0), [2, 1, 1])
 
@@ -304,8 +303,8 @@ class LinearCombinationTest(tf.test.TestCase, parameterized.TestCase):
         ops_tensor = util.convert_to_tensor(psums)
 
         # Get gradients using expectations of gradient circuits.
-        (batch_programs, new_symbol_names, batch_symbol_values,
-         batch_weights, batch_mapper) = differentiator.get_gradient_circuits(
+        (batch_programs, new_symbol_names, batch_symbol_values, batch_weights,
+         batch_mapper) = differentiator.get_gradient_circuits(
              programs, symbol_names_tensor, symbol_values_tensor)
         analytic_op = circuit_execution_ops.get_expectation_op()
         batch_pauli_sums = tf.tile(tf.expand_dims(ops_tensor, 1),

--- a/tensorflow_quantum/python/differentiators/parameter_shift.py
+++ b/tensorflow_quantum/python/differentiators/parameter_shift.py
@@ -56,6 +56,7 @@ class ParameterShift(differentiator.Differentiator):
 
     """
 
+    @tf.function
     def get_gradient_circuits(self, programs, symbol_names, symbol_values):
         """See base class description."""
         # these get used a lot


### PR DESCRIPTION
For after #532.  During implementation of that PR, I discovered a more efficient way to represent the gradient structure: separating the old `batch_mapper` into a weights tensor and an index tensor.  In the updated tests in this PR, it can be seen that this eliminates the zero padding previously required.