### PR TITLE
Improved randomness sources in parallel ops.

### DIFF
--- a/tensorflow_quantum/core/src/util_qsim.h
+++ b/tensorflow_quantum/core/src/util_qsim.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <bitset>
 #include <cstdint>
+#include <random>
 #include <vector>
 
 #include "../qsim/lib/circuit.h"
@@ -189,7 +190,9 @@ template <typename SimT, typename StateSpaceT, typename StateT>
 tensorflow::Status ComputeSampledExpectationQsim(
     const tfq::proto::PauliSum& p_sum, const SimT& sim, const StateSpaceT& ss,
     StateT& state, StateT& scratch, const int num_samples,
-    float* expectation_value) {
+    std::mt19937& random_source, float* expectation_value) {
+  std::uniform_int_distribution<> distrib(1, 1 << 30);
+
   if (num_samples == 0) {
     return tensorflow::Status::OK();
   }
@@ -222,12 +225,8 @@ tensorflow::Status ComputeSampledExpectationQsim(
     if (!status.ok()) {
       return status;
     }
-    unsigned long r_seed =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now().time_since_epoch())
-            .count();
-    const unsigned int seed = static_cast<unsigned int>(r_seed);
-    std::vector<uint64_t> state_samples = ss.Sample(scratch, num_samples, seed);
+    std::vector<uint64_t> state_samples =
+        ss.Sample(scratch, num_samples, distrib(random_source));
 
     // Find qubits on which to measure parity
     std::vector<unsigned int> parity_bits;

--- a/tensorflow_quantum/core/src/util_qsim_test.cc
+++ b/tensorflow_quantum/core/src/util_qsim_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow_quantum/core/src/util_qsim.h"
 
+#include <random>
 #include <vector>
 
 #include "../qsim/lib/circuit.h"
@@ -88,8 +89,9 @@ TEST_P(TwoTermSampledExpectationFixture, CorrectnessTest) {
 
   // Compute expectation and compare to reference values.
   float exp_v = 0;
+  std::mt19937 gen(1234);
   Status s = tfq::ComputeSampledExpectationQsim(p_sum, sim, ss, sv, scratch,
-                                                1000000, &exp_v);
+                                                1000000, gen, &exp_v);
 
   EXPECT_NEAR(exp_v, std::get<1>(GetParam()), 1e-2);
 }
@@ -191,8 +193,9 @@ TEST(UtilQsimTest, SampledEmptyTermCase) {
 
   // Compute expectation and compare to reference values.
   float exp_v = 0;
+  std::mt19937 gen(1234);
   Status s = tfq::ComputeSampledExpectationQsim(p_sum_empty, sim, ss, sv,
-                                                scratch, 100, &exp_v);
+                                                scratch, 100, gen, &exp_v);
 
   EXPECT_NEAR(exp_v, 0.1234, 1e-5);
 }
@@ -274,8 +277,9 @@ TEST(UtilQsimTest, SampledCompoundCase) {
   p_term_scratch->set_coefficient_real(4.0);
   // Compute expectation and compare to reference values.
   float exp_v = 0;
+  std::mt19937 gen(1234);
   Status s = tfq::ComputeSampledExpectationQsim(p_sum, sim, ss, sv, scratch,
-                                                10000000, &exp_v);
+                                                10000000, gen, &exp_v);
 
   EXPECT_NEAR(exp_v, 4.1234, 1e-2);
 }


### PR DESCRIPTION
Over time I was noticing that the randomness sources in our parallel ops weren't behaving very well. This change removes all of the old either constant or not completely thread safe sources of randomness and replaces them with proper random sequence generators from the standard library.