### PR TITLE
Added noise support to SampledExpectation.

### DIFF
--- a/tensorflow_quantum/core/ops/cirq_ops.py
+++ b/tensorflow_quantum/core/ops/cirq_ops.py
@@ -310,7 +310,8 @@ def _get_cirq_sampled_expectation(simulator=cirq.Simulator()):
         _input_check_helper(programs, symbol_names, symbol_values)
         if not (pauli_sums.dtype == tf.dtypes.string):
             raise TypeError('pauli_sums tensor must be of type string.')
-        if not (pauli_sums.shape[0] == programs.shape[0]):
+        if not (pauli_sums.shape[0] == programs.shape[0]) or \
+            len(pauli_sums.shape) != 2:
             raise TypeError('pauli_sums tensor must have the same batch shape '
                             'as programs tensor.')
 

--- a/tensorflow_quantum/python/layers/circuit_executors/BUILD
+++ b/tensorflow_quantum/python/layers/circuit_executors/BUILD
@@ -48,6 +48,7 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":input_checks",
+        "//tensorflow_quantum/core/ops/noise:noisy_sampled_expectation_op_py",
         "//tensorflow_quantum/core/ops:circuit_execution_ops",
         "//tensorflow_quantum/python:util",
         "//tensorflow_quantum/python/differentiators:differentiator",

--- a/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation.py
@@ -21,6 +21,7 @@ import tensorflow as tf
 
 import cirq
 from tensorflow_quantum.core.ops import circuit_execution_ops
+from tensorflow_quantum.core.ops.noise import noisy_sampled_expectation_op
 from tensorflow_quantum.python.differentiators import differentiator as diff
 from tensorflow_quantum.python.differentiators import parameter_shift
 from tensorflow_quantum.python.layers.circuit_executors import input_checks
@@ -212,30 +213,24 @@ class SampledExpectation(tf.keras.layers.Layer):
 
     """
 
-    def __init__(self, backend=None, differentiator=None, **kwargs):
+    def __init__(self, backend='noiseless', differentiator=None, **kwargs):
         """Instantiate this Layer.
 
         Create a layer that will output expectation values gained from
         simulating a quantum circuit.
 
         Args:
-            backend: Optional Backend to use to simulate states. Defaults to
-                the native TensorFlow simulator (None), however users may also
+            backend: Optional Backend to use to simulate states. Can be either
+                {'noiseless', 'noisy'} users may also
                 specify a preconfigured cirq simulation object to use instead,
-                which must inherit `cirq.SimulatesFinalState`.
+                which must inherit `cirq.Sampler`.
             differentiator: Optional Differentiator to use to calculate analytic
                 derivative values of given operators_to_measure and circuit,
                 which must inherit `tfq.differentiators.Differentiator`.
-                Defaults to None, which uses `parameter_shift.ParameterShift()`.
+                Defaults to `parameter_shift.ParameterShift()` (None argument).
 
         """
         super().__init__(**kwargs)
-
-        # Ingest backend.
-        if not isinstance(backend, cirq.Sampler) and \
-                isinstance(backend, cirq.SimulatesFinalState):
-            raise TypeError("Backend implements cirq.SimulatesFinalState but "
-                            "not cirq.Sampler. Please use Expectation instead.")
 
         # Ingest differentiator.
         if differentiator is None:
@@ -245,9 +240,24 @@ class SampledExpectation(tf.keras.layers.Layer):
             raise TypeError("Differentiator must inherit from "
                             "tfq.differentiators.Differentiator")
 
+        # Ingest backend.
+        if not isinstance(backend, cirq.Sampler) and \
+                isinstance(backend, cirq.SimulatesFinalState):
+            raise TypeError("Backend implements cirq.SimulatesFinalState but "
+                            "not cirq.Sampler. Please use Expectation instead.")
+
+        used_op = None
+        if backend == 'noiseless':
+            used_op = circuit_execution_ops.get_sampled_expectation_op(
+                backend=None)
+        elif backend == 'noisy':
+            used_op = noisy_sampled_expectation_op.sampled_expectation
+        else:
+            used_op = circuit_execution_ops.get_sampled_expectation_op(
+                backend=backend)
+
         self._expectation_op = differentiator.generate_differentiable_op(
-            sampled_op=circuit_execution_ops.get_sampled_expectation_op(
-                backend=backend))
+            sampled_op=used_op)
 
         self._w = None
 

--- a/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
@@ -75,15 +75,20 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
                 TypeError, expected_regex="tfq.differentiators.Differentiator"):
             sampled_expectation.SampledExpectation(differentiator='junk')
 
-    @parameterized.parameters([{
-        'backend': 'noisy'
-    }, {
-        'backend': 'noiseless'
-    }, {
-        'backend': cirq.Simulator()
-    }, {
-        'backend': None # older API usage.
-    }])
+    @parameterized.parameters([
+        {
+            'backend': 'noisy'
+        },
+        {
+            'backend': 'noiseless'
+        },
+        {
+            'backend': cirq.Simulator()
+        },
+        {
+            'backend': None  # older API usage.
+        }
+    ])
     def test_sampled_expectation_type_inputs_error(self, backend):
         """Test that SampledExpectation errors within Keras call."""
 
@@ -115,15 +120,20 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
             sampled_expectation.SampledExpectation(backend=backend)(
                 reg_circuit, operators=test_psum, repetitions='junk')
 
-    @parameterized.parameters([{
-        'backend': 'noisy'
-    }, {
-        'backend': 'noiseless'
-    }, {
-        'backend': cirq.Simulator()
-    }, {
-        'backend': None # older API usage.
-    }])
+    @parameterized.parameters([
+        {
+            'backend': 'noisy'
+        },
+        {
+            'backend': 'noiseless'
+        },
+        {
+            'backend': cirq.Simulator()
+        },
+        {
+            'backend': None  # older API usage.
+        }
+    ])
     def test_sampled_expectation_op_error(self, backend):
         """Test that expectation errors within underlying ops correctly."""
         # Note the expected_regex is left blank here since there is a
@@ -185,15 +195,20 @@ class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
                 operators=test_psum,
                 repetitions=5)
 
-    @parameterized.parameters([{
-        'backend': 'noisy'
-    }, {
-        'backend': 'noiseless'
-    }, {
-        'backend': cirq.Simulator()
-    }, {
-        'backend': None # older API usage.
-    }])
+    @parameterized.parameters([
+        {
+            'backend': 'noisy'
+        },
+        {
+            'backend': 'noiseless'
+        },
+        {
+            'backend': cirq.Simulator()
+        },
+        {
+            'backend': None  # older API usage.
+        }
+    ])
     def test_static_cases(self, backend):
         """Run inputs through in complex cases."""
 

--- a/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sampled_expectation_test.py
@@ -15,6 +15,7 @@
 """Tests for tensorflow_quantum.layers.circuit_executors.sampled_expectation."""
 
 import numpy as np
+from absl.testing import parameterized
 import sympy
 import tensorflow as tf
 
@@ -25,7 +26,7 @@ from tensorflow_quantum.python.differentiators import linear_combination
 from tensorflow_quantum.python import util
 
 
-def _gen_single_bit_rotation_problem(bit, symbols):
+def _gen_single_bit_rotation_problem(bit, symbols, noisy):
     """Generate a toy problem on 1 qubit."""
     starting_state = np.random.uniform(0, 2 * np.pi, 3)
     circuit = cirq.Circuit(
@@ -35,17 +36,20 @@ def _gen_single_bit_rotation_problem(bit, symbols):
         cirq.rz(symbols[2])(bit),
         cirq.ry(symbols[1])(bit),
         cirq.rx(symbols[0])(bit))
+    if noisy:
+        circuit += cirq.depolarize(0.01)(bit)
 
     return circuit
 
 
-class SampledExpectationTest(tf.test.TestCase):
+class SampledExpectationTest(parameterized.TestCase, tf.test.TestCase):
     """Basic tests for the SampledExpectation layer."""
 
     def test_sampled_expectation_symbol_input(self):
         """Test that SampledExpectation only accepts valid permutations of
         symbols."""
-        sampled_expectation.SampledExpectation()
+        sampled_expectation.SampledExpectation(backend='noiseless')
+        sampled_expectation.SampledExpectation(backend='noisy')
         sampled_expectation.SampledExpectation(backend=cirq.Simulator())
         sampled_expectation.SampledExpectation(
             differentiator=linear_combination.ForwardDifference())
@@ -71,7 +75,16 @@ class SampledExpectationTest(tf.test.TestCase):
                 TypeError, expected_regex="tfq.differentiators.Differentiator"):
             sampled_expectation.SampledExpectation(differentiator='junk')
 
-    def test_sampled_expectation_type_inputs_error(self):
+    @parameterized.parameters([{
+        'backend': 'noisy'
+    }, {
+        'backend': 'noiseless'
+    }, {
+        'backend': cirq.Simulator()
+    }, {
+        'backend': None # older API usage.
+    }])
+    def test_sampled_expectation_type_inputs_error(self, backend):
         """Test that SampledExpectation errors within Keras call."""
 
         bit = cirq.GridQubit(0, 0)
@@ -83,25 +96,35 @@ class SampledExpectationTest(tf.test.TestCase):
 
         with self.assertRaisesRegex(RuntimeError,
                                     expected_regex="repetitions not provided"):
-            sampled_expectation.SampledExpectation()(symb_circuit,
-                                                     symbol_names=[symbol],
-                                                     symbol_values=[[0.5]],
-                                                     operators=test_psum)
+            sampled_expectation.SampledExpectation(backend=backend)(
+                symb_circuit,
+                symbol_names=[symbol],
+                symbol_values=[[0.5]],
+                operators=test_psum)
 
         with self.assertRaisesRegex(Exception,
                                     expected_regex="Unknown initializer"):
-            sampled_expectation.SampledExpectation()(reg_circuit,
-                                                     operators=test_psum,
-                                                     initializer='junk',
-                                                     repetitions=1)
+            sampled_expectation.SampledExpectation(backend=backend)(
+                reg_circuit,
+                operators=test_psum,
+                initializer='junk',
+                repetitions=1)
 
         with self.assertRaisesRegex(Exception,
                                     expected_regex="cannot be parsed"):
-            sampled_expectation.SampledExpectation()(reg_circuit,
-                                                     operators=test_psum,
-                                                     repetitions='junk')
+            sampled_expectation.SampledExpectation(backend=backend)(
+                reg_circuit, operators=test_psum, repetitions='junk')
 
-    def test_sampled_expectation_op_error(self):
+    @parameterized.parameters([{
+        'backend': 'noisy'
+    }, {
+        'backend': 'noiseless'
+    }, {
+        'backend': cirq.Simulator()
+    }, {
+        'backend': None # older API usage.
+    }])
+    def test_sampled_expectation_op_error(self, backend):
         """Test that expectation errors within underlying ops correctly."""
         # Note the expected_regex is left blank here since there is a
         # discrepancy between the error strings provided between backends.
@@ -112,64 +135,66 @@ class SampledExpectationTest(tf.test.TestCase):
         symb_circuit = cirq.Circuit(cirq.H(bit)**symbol)
         reg_circuit = cirq.Circuit(cirq.H(bit))
 
-        with self.assertRaisesRegex(Exception, expected_regex="pauli_sums"):
+        with self.assertRaisesRegex(Exception, expected_regex="pauli"):
             # Operators has wrong rank. Parse error.
-            sampled_expectation.SampledExpectation()(
+            sampled_expectation.SampledExpectation(backend=backend)(
                 [reg_circuit],
                 operators=util.convert_to_tensor([test_psum]),
                 repetitions=1)
 
         with self.assertRaisesRegex(Exception, expected_regex="symbol_values"):
             # symbol_values has wrong rank.
-            sampled_expectation.SampledExpectation()([symb_circuit],
-                                                     symbol_names=[symbol],
-                                                     symbol_values=[0.5],
-                                                     operators=test_psum,
-                                                     repetitions=1)
+            sampled_expectation.SampledExpectation(backend=backend)(
+                [symb_circuit],
+                symbol_names=[symbol],
+                symbol_values=[0.5],
+                operators=test_psum,
+                repetitions=1)
 
-        with self.assertRaisesRegex(
-                Exception,
-                expected_regex="Number of circuits and PauliSums do not match"):
+        with self.assertRaisesRegex(Exception, expected_regex="pauli"):
             # Wrong batch size for pauli operators.
-            sampled_expectation.SampledExpectation()(symb_circuit,
-                                                     symbol_names=[symbol],
-                                                     operators=[[test_psum],
-                                                                [test_psum]],
-                                                     repetitions=1)
+            sampled_expectation.SampledExpectation(backend=backend)(
+                symb_circuit,
+                symbol_names=[symbol],
+                operators=[[test_psum], [test_psum]],
+                repetitions=1)
 
-        with self.assertRaisesRegex(
-                Exception,
-                expected_regex="Number of circuits and PauliSums do not match"):
+        with self.assertRaisesRegex(Exception, expected_regex="pauli"):
             # Wrong batch size for pauli operators.
-            sampled_expectation.SampledExpectation()(reg_circuit,
-                                                     operators=[[test_psum],
-                                                                [test_psum]],
-                                                     repetitions=1)
+            sampled_expectation.SampledExpectation(backend=backend)(
+                reg_circuit,
+                operators=[[test_psum], [test_psum]],
+                repetitions=1)
 
-        with self.assertRaisesRegex(Exception, expected_regex="greater than 0"):
+        with self.assertRaisesRegex(Exception, expected_regex="0"):
             # Wrong repetitions.
-            sampled_expectation.SampledExpectation()(reg_circuit,
-                                                     operators=test_psum,
-                                                     repetitions=-1)
+            sampled_expectation.SampledExpectation(backend=backend)(
+                reg_circuit, operators=test_psum, repetitions=-1)
 
-        with self.assertRaisesRegex(
-                Exception,
-                expected_regex="num_samples and pauli_sums do not match"):
+        with self.assertRaisesRegex(Exception, expected_regex=""):
             # Wrong second dimension size for repetitions & pauli operators.
-            sampled_expectation.SampledExpectation()(reg_circuit,
-                                                     operators=test_psum,
-                                                     repetitions=[5, 4, 3])
+            sampled_expectation.SampledExpectation(backend=backend)(
+                reg_circuit, operators=test_psum, repetitions=[5, 4, 3])
 
-        with self.assertRaisesRegex(Exception, expected_regex="do not match."):
+        with self.assertRaisesRegex(Exception, expected_regex=""):
             # Wrong batch_size for symbol values.
-            sampled_expectation.SampledExpectation()([reg_circuit],
-                                                     symbol_names=[symbol],
-                                                     symbol_values=np.zeros(
-                                                         (3, 1)),
-                                                     operators=test_psum,
-                                                     repetitions=5)
+            sampled_expectation.SampledExpectation(backend=backend)(
+                [reg_circuit],
+                symbol_names=[symbol],
+                symbol_values=np.zeros((3, 1)),
+                operators=test_psum,
+                repetitions=5)
 
-    def test_static_cases(self):
+    @parameterized.parameters([{
+        'backend': 'noisy'
+    }, {
+        'backend': 'noiseless'
+    }, {
+        'backend': cirq.Simulator()
+    }, {
+        'backend': None # older API usage.
+    }])
+    def test_static_cases(self, backend):
         """Run inputs through in complex cases."""
 
         bit = cirq.GridQubit(0, 0)
@@ -180,18 +205,18 @@ class SampledExpectationTest(tf.test.TestCase):
         reg_circuit = cirq.Circuit(cirq.H(bit))
 
         # Passing a 2d operators input requires a 1d circuit input.
-        sampled_expectation.SampledExpectation()(
+        sampled_expectation.SampledExpectation(backend=backend)(
             [reg_circuit, reg_circuit],
             operators=[[test_psum, test_psum], [test_psum, test_psum]],
             repetitions=1)
 
         # Passing 2d operators along with other inputs.
-        sampled_expectation.SampledExpectation()(
+        sampled_expectation.SampledExpectation(backend=backend)(
             [symb_circuit, symb_circuit],
             symbol_names=[symbol],
             operators=[[test_psum, test_psum], [test_psum, test_psum]],
             repetitions=1)
-        sampled_expectation.SampledExpectation()(
+        sampled_expectation.SampledExpectation(backend=backend)(
             [symb_circuit, symb_circuit],
             symbol_names=[symbol],
             symbol_values=[[0.5], [0.8]],
@@ -199,33 +224,34 @@ class SampledExpectationTest(tf.test.TestCase):
             repetitions=1)
 
         # Ensure tiling up of circuits works as expected.
-        sampled_expectation.SampledExpectation()(reg_circuit,
-                                                 operators=test_psum,
-                                                 repetitions=1)
-        sampled_expectation.SampledExpectation()(
+        sampled_expectation.SampledExpectation(backend=backend)(
+            reg_circuit, operators=test_psum, repetitions=1)
+        sampled_expectation.SampledExpectation(backend=backend)(
             reg_circuit, operators=[test_psum, test_psum], repetitions=1)
 
         # Ensure tiling up of symbol_values works as expected.
-        sampled_expectation.SampledExpectation()(symb_circuit,
-                                                 symbol_names=[symbol],
-                                                 symbol_values=[[0.5], [0.8]],
-                                                 operators=test_psum,
-                                                 repetitions=1)
-        sampled_expectation.SampledExpectation()(symb_circuit,
-                                                 symbol_names=[symbol],
-                                                 symbol_values=[[0.5]],
-                                                 operators=test_psum,
-                                                 repetitions=1)
+        sampled_expectation.SampledExpectation(backend=backend)(
+            symb_circuit,
+            symbol_names=[symbol],
+            symbol_values=[[0.5], [0.8]],
+            operators=test_psum,
+            repetitions=1)
+        sampled_expectation.SampledExpectation(backend=backend)(
+            symb_circuit,
+            symbol_names=[symbol],
+            symbol_values=[[0.5]],
+            operators=test_psum,
+            repetitions=1)
 
         # Test multiple operators with integer valued repetition.
-        sampled_expectation.SampledExpectation()(
+        sampled_expectation.SampledExpectation(backend=backend)(
             symb_circuit,
             symbol_names=[symbol],
             symbol_values=[[0.5]],
             operators=[-1.0 * cirq.Z(bit),
                        cirq.X(bit) + 2.0 * cirq.Z(bit)],
             repetitions=1)
-        sampled_expectation.SampledExpectation()(
+        sampled_expectation.SampledExpectation(backend=backend)(
             symb_circuit,
             symbol_names=[symbol],
             symbol_values=[[0.5]],
@@ -251,10 +277,12 @@ class SampledExpectationTest(tf.test.TestCase):
         self.assertAllClose(mse.numpy(), 0, atol=1e-2)
 
 
-class SampledExpectationFunctionalTests(tf.test.TestCase):
+class SampledExpectationFunctionalTests(parameterized.TestCase,
+                                        tf.test.TestCase):
     """Test hybrid/integrated models that include a SampledExpectation layer."""
 
-    def test_simple_param_value_input(self):
+    @parameterized.parameters([{'backend': 'noisy'}, {'backend': 'noiseless'}])
+    def test_simple_param_value_input(self, backend):
         """Train a densely connected hybrid model.
 
         This model will put a qubit in the zero or one state from a random state
@@ -262,13 +290,14 @@ class SampledExpectationFunctionalTests(tf.test.TestCase):
         """
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x y z')
-        circuit = _gen_single_bit_rotation_problem(bit, symbols)
+        circuit = _gen_single_bit_rotation_problem(
+            bit, symbols, True if backend == 'noisy' else False)
 
         inputs = tf.keras.Input(shape=(1,), dtype=tf.dtypes.float64)
         datum = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
         l1 = tf.keras.layers.Dense(10)(inputs)
         l2 = tf.keras.layers.Dense(3)(l1)
-        outputs = sampled_expectation.SampledExpectation()(
+        outputs = sampled_expectation.SampledExpectation(backend=backend)(
             datum,
             symbol_names=symbols,
             operators=cirq.Z(bit),
@@ -287,7 +316,8 @@ class SampledExpectationFunctionalTests(tf.test.TestCase):
         history = model.fit(x=[circuits, data_in], y=data_out, epochs=30)
         self.assertAllClose(history.history['loss'][-1], 0, atol=0.3)
 
-    def test_simple_op_input(self):
+    @parameterized.parameters([{'backend': 'noisy'}, {'backend': 'noiseless'}])
+    def test_simple_op_input(self, backend):
         """Test a simple operator input
 
         Learn qubit in the z+ state using two different measurement operators.
@@ -297,18 +327,20 @@ class SampledExpectationFunctionalTests(tf.test.TestCase):
         ops = util.convert_to_tensor([[cirq.Z(bit)], [cirq.Z(bit)]])
         n = tf.convert_to_tensor([[5000], [5000]], dtype=tf.int32)
 
-        circuit = util.convert_to_tensor(
-            [_gen_single_bit_rotation_problem(bit, symbols)] * 2)
+        circuit = util.convert_to_tensor([
+            _gen_single_bit_rotation_problem(
+                bit, symbols, True if backend == 'noisy' else False)
+        ] * 2)
 
         data_out = tf.convert_to_tensor(np.array([[1], [1]]))
         op_inp = tf.keras.Input(shape=(1,), dtype=tf.dtypes.string)
         n_inp = tf.keras.Input(shape=(1,), dtype=tf.dtypes.int32)
         circuit_inp = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
-        circuit_output = sampled_expectation.SampledExpectation()(
-            circuit_inp,
-            symbol_names=symbols,
-            operators=op_inp,
-            repetitions=n_inp)
+        circuit_output = sampled_expectation.SampledExpectation(
+            backend=backend)(circuit_inp,
+                             symbol_names=symbols,
+                             operators=op_inp,
+                             repetitions=n_inp)
         model = tf.keras.Model(inputs=[circuit_inp, op_inp, n_inp],
                                outputs=[circuit_output])
 
@@ -323,7 +355,8 @@ class SampledExpectationFunctionalTests(tf.test.TestCase):
 
         self.assertAllClose(history.history['loss'][-1], 0, atol=1e-2)
 
-    def test_simple_op_and_param_input(self):
+    @parameterized.parameters([{'backend': 'noisy'}, {'backend': 'noiseless'}])
+    def test_simple_op_and_param_input(self, backend):
         """Test a simple operator and parameter input.
 
         Train a NN to put a qubit in the z+ or x+ states based on a classical
@@ -333,8 +366,10 @@ class SampledExpectationFunctionalTests(tf.test.TestCase):
         symbols = sympy.symbols('x y z')
         ops = util.convert_to_tensor([[cirq.Z(bit)], [cirq.Z(bit)]])
         n = tf.convert_to_tensor([[5000], [5000]], dtype=tf.int32)
-        circuits = util.convert_to_tensor(
-            [_gen_single_bit_rotation_problem(bit, symbols)] * 2)
+        circuits = util.convert_to_tensor([
+            _gen_single_bit_rotation_problem(
+                bit, symbols, True if backend == 'noisy' else False)
+        ] * 2)
         data_in = np.array([[1], [0]])
         data_out = np.array([[1], [1]])
 
@@ -344,12 +379,12 @@ class SampledExpectationFunctionalTests(tf.test.TestCase):
         circuit_inp = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
         dense_1 = tf.keras.layers.Dense(10)(data_inp)
         dense_2 = tf.keras.layers.Dense(3)(dense_1)
-        circuit_output = sampled_expectation.SampledExpectation()(
-            circuit_inp,
-            symbol_names=symbols,
-            symbol_values=dense_2,
-            operators=op_inp,
-            repetitions=n_inp)
+        circuit_output = sampled_expectation.SampledExpectation(
+            backend=backend)(circuit_inp,
+                             symbol_names=symbols,
+                             symbol_values=dense_2,
+                             operators=op_inp,
+                             repetitions=n_inp)
 
         functional_model = tf.keras.Model(
             inputs=[circuit_inp, data_inp, op_inp, n_inp],
@@ -364,7 +399,8 @@ class SampledExpectationFunctionalTests(tf.test.TestCase):
                                        epochs=20)
         self.assertAllClose(history.history['loss'][-1], 0, atol=3)
 
-    def test_dnn_qnn_dnn(self):
+    @parameterized.parameters([{'backend': 'noisy'}, {'backend': 'noiseless'}])
+    def test_dnn_qnn_dnn(self, backend):
         """Train a fully hybrid network using an SampledExpectation layer.
 
         Train the network to output +-5 given an input of 1 or 0. This tests
@@ -372,8 +408,10 @@ class SampledExpectationFunctionalTests(tf.test.TestCase):
         """
         bit = cirq.GridQubit(0, 0)
         symbols = sympy.symbols('x, y, z')
-        circuits = util.convert_to_tensor(
-            [_gen_single_bit_rotation_problem(bit, symbols)] * 2)
+        circuits = util.convert_to_tensor([
+            _gen_single_bit_rotation_problem(
+                bit, symbols, True if backend == 'noisy' else False)
+        ] * 2)
         data_in = np.array([[1], [0]], dtype=np.float32)
         data_out = np.array([[5], [-5]], dtype=np.float32)
 
@@ -381,7 +419,7 @@ class SampledExpectationFunctionalTests(tf.test.TestCase):
         circuit_input = tf.keras.Input(shape=(), dtype=tf.dtypes.string)
         d1 = tf.keras.layers.Dense(10)(classical_input)
         d2 = tf.keras.layers.Dense(3)(d1)
-        quantum = sampled_expectation.SampledExpectation()(
+        quantum = sampled_expectation.SampledExpectation(backend=backend)(
             circuit_input,
             symbol_names=symbols,
             symbol_values=d2,


### PR DESCRIPTION
Modifies `SampledExpectation` to support noisy and noiseless backends. This also improves on #504 by giving more intuitive meaning to the `backend` parameter. I wasn't able to modify the differentiator default behavior because: https://florimond.dev/blog/articles/2018/08/python-mutable-defaults-are-the-source-of-all-evil/  and we must create a new instance for each layer. I remember now why we didn't do this to begin with.

This change still supports legacy calls into the layer with `backend=None` in the same fashion as the old API, so it is not a breaking change. Please review closely.

cc: @lockwo .