### PR TITLE
Added noisy backend to sample layer.

### DIFF
--- a/tensorflow_quantum/core/ops/noise/tfq_noisy_samples.cc
+++ b/tensorflow_quantum/core/ops/noise/tfq_noisy_samples.cc
@@ -257,6 +257,9 @@ class TfqNoisySamplesOp : public tensorflow::OpKernel {
         int nq = num_qubits[i];
         int j = start > 0 ? offset_prefix_sum[start - 1][i] : 0;
         int needed_samples = offset_prefix_sum[start][i] - j;
+        if (needed_samples <= 0) {
+          continue;
+        }
 
         if (nq > largest_nq) {
           largest_nq = nq;

--- a/tensorflow_quantum/python/layers/circuit_executors/BUILD
+++ b/tensorflow_quantum/python/layers/circuit_executors/BUILD
@@ -64,6 +64,7 @@ py_library(
     deps = [
         ":input_checks",
         "//tensorflow_quantum/core/ops:circuit_execution_ops",
+        "//tensorflow_quantum/core/ops/noise:noisy_samples_op_py",
     ],
 )
 

--- a/tensorflow_quantum/python/layers/circuit_executors/sample.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sample.py
@@ -18,6 +18,7 @@ import numbers
 import tensorflow as tf
 
 from tensorflow_quantum.core.ops import circuit_execution_ops
+from tensorflow_quantum.core.ops.noise import noisy_samples_op
 from tensorflow_quantum.python.layers.circuit_executors import input_checks
 
 
@@ -138,7 +139,7 @@ class Sample(tf.keras.layers.Layer):
 
     """
 
-    def __init__(self, backend=None, **kwargs):
+    def __init__(self, backend='noiseless', **kwargs):
         """Instantiate this Layer.
 
         Create a layer that will output bitstring samples taken from either a
@@ -146,12 +147,20 @@ class Sample(tf.keras.layers.Layer):
 
         Args:
             backend: Optional Backend to use to simulate this state. Defaults
-                to the native Tensorflow simulator (None), however users may
-                also specify a preconfigured cirq execution object to use
-                instead, which must inherit `cirq.Sampler`.
+                to the noiseless simulator. Options are {'noisy', 'noiseless'},
+                however users may also specify a preconfigured cirq execution
+                object to use instead, which must inherit `cirq.Sampler`.
         """
         super().__init__(**kwargs)
-        self.sample_op = circuit_execution_ops.get_sampling_op(backend)
+        used_op = None
+        if backend == 'noiseless':
+            used_op = circuit_execution_ops.get_sampling_op(None)
+        elif backend == 'noisy':
+            used_op = noisy_samples_op.samples
+        else:
+            used_op = circuit_execution_ops.get_sampling_op(backend)
+
+        self.sample_op = used_op
 
     def call(self,
              inputs,

--- a/tensorflow_quantum/python/layers/circuit_executors/sample_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sample_test.py
@@ -76,13 +76,20 @@ class SampleTest(tf.test.TestCase, parameterized.TestCase):
                 TypeError, expected_regex="cannot be parsed to int32 tensor"):
             sampler([cirq.Circuit()], repetitions=[10])
 
-    @parameterized.parameters([{
-        'backend': None
-    }, {
-        'backend': cirq.Simulator()
-    }, {
-        'backend': cirq.DensityMatrixSimulator()
-    }])
+    @parameterized.parameters([
+        {
+            'backend': 'noiseless'
+        },
+        {
+            'backend': 'noisy'
+        },
+        {
+            'backend': cirq.Simulator()
+        },
+        {
+            'backend': None  # old API usage.
+        }
+    ])
     def test_sample_invalid_combinations(self, backend):
         """Test with valid type inputs and valid value, but incorrect combo."""
         sampler = sample.Sample(backend)
@@ -152,11 +159,10 @@ class SampleTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.parameters(
         list(
             util.kwargs_cartesian_product(
-                backend=[None,
-                         cirq.Simulator(),
-                         cirq.DensityMatrixSimulator()],
-                all_n_qubits=[[3], [8], [3, 4], [3, 4, 10]],
-                n_samples=[1, 10, 100],
+                backend=['noiseless', 'noisy',
+                         cirq.Simulator(), None],
+                all_n_qubits=[[3, 4, 10]],
+                n_samples=[1],
                 symbol_names=[[], ['a', 'b']])))
     def test_sample_output(self, backend, all_n_qubits, n_samples,
                            symbol_names):
@@ -178,6 +184,7 @@ class SampleTest(tf.test.TestCase, parameterized.TestCase):
                                symbol_names=symbol_names,
                                symbol_values=symbol_values,
                                repetitions=n_samples).to_list()
+
         self.assertEqual(expected_outputs, layer_output)
 
 


### PR DESCRIPTION
Like #540 this PR adds the noisy backend to the `Sample` layer and also helps with #504 . These tests also helped me find an issue on our C++ op where if we set n_samples = 1 and n_circuits < n_threads we might encounter race conditions on writes, so there is also a very small tweak to the .cc file as well.