### PR TITLE
Update ***PQC layers to use new backend conventions.

### DIFF
--- a/tensorflow_quantum/python/layers/high_level/controlled_pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/controlled_pqc.py
@@ -86,7 +86,7 @@ class ControlledPQC(tf.keras.layers.Layer):
     to indicate the differentiation scheme this `ControlledPQC` layer
     should use. Here's how you would take the gradients of the
     above example using a `cirq.Simulator` backend (which is slower
-    than `backend=None` which uses C++):
+    than `backend='noiseless'` which uses C++):
 
 
     >>> bit = cirq.GridQubit(0, 0)
@@ -127,7 +127,7 @@ class ControlledPQC(tf.keras.layers.Layer):
                  operators,
                  *,
                  repetitions=None,
-                 backend=None,
+                 backend='noiseless',
                  differentiator=None,
                  **kwargs):
         """Instantiate this layer.
@@ -147,7 +147,7 @@ class ControlledPQC(tf.keras.layers.Layer):
             when estimating expectation values. If `None` analytic expectation
             calculation is used.
         backend: Optional Backend to use to simulate states. Defaults to
-            the native TensorFlow simulator (None), however users may also
+            the noiseless TensorFlow simulator, however users may also
             specify a preconfigured cirq simulation object to use instead.
             If a cirq object is given it must inherit `cirq.Sampler` if
             `sampled_based` is True or it must inherit
@@ -209,22 +209,30 @@ class ControlledPQC(tf.keras.layers.Layer):
                 [[repetitions for _ in range(len(operators))]],
                 dtype=tf.dtypes.int32)
 
-        if not isinstance(backend, cirq.Sampler
-                         ) and repetitions is not None and backend is not None:
+        # Ingest backend and differentiator.
+        if backend == 'noisy':
+            raise ValueError("noisy backend value is not supported in "
+                             "tfq.layers.ControlledPQC. Please use "
+                             "tfq.layers.NoisyControlledPQC instead.")
+
+        not_default = backend is not 'noiseless'
+        not_default &= backend is not None  # legacy backend=None support.
+        if not isinstance(
+                backend,
+                cirq.Sampler) and repetitions is not None and not_default:
             raise TypeError("provided backend does not inherit cirq.Sampler "
                             "and repetitions!=None. Please provide a backend "
                             "that inherits cirq.Sampler or set "
                             "repetitions=None.")
 
         if not isinstance(backend, cirq.sim.simulator.SimulatesExpectationValues
-                         ) and repetitions is None and backend is not None:
+                         ) and repetitions is None and not_default:
             raise TypeError("provided backend does not inherit "
                             "cirq.sim.simulator.SimulatesExpectationValues and "
                             "repetitions=None. Please provide a backend that "
                             "inherits "
                             "cirq.sim.simulator.SimulatesExpectationValues.")
 
-        # Ingest backend and differentiator.
         if self._analytic:
             self._layer = expectation.Expectation(backend=backend,
                                                   differentiator=differentiator)

--- a/tensorflow_quantum/python/layers/high_level/controlled_pqc_test.py
+++ b/tensorflow_quantum/python/layers/high_level/controlled_pqc_test.py
@@ -36,6 +36,17 @@ class ControlledPQCTest(tf.test.TestCase, parameterized.TestCase):
                                      cirq.Z(bit),
                                      repetitions=500)
 
+    def test_controlled_pqc_noisy_error(self):
+        """Ensure error refers to alternate layer."""
+        symbol = sympy.Symbol('alpha')
+        qubit = cirq.GridQubit(0, 0)
+        learnable_flip = cirq.Circuit(cirq.X(qubit)**symbol)
+        with self.assertRaisesRegex(
+                ValueError, expected_regex='tfq.layers.NoisyControlledPQC'):
+            controlled_pqc.ControlledPQC(learnable_flip,
+                                         cirq.Z(qubit),
+                                         backend='noisy')
+
     def test_controlled_pqc_backend_error(self):
         """Test that invalid backends error properly."""
         symbol = sympy.Symbol('alpha')

--- a/tensorflow_quantum/python/layers/high_level/pqc_test.py
+++ b/tensorflow_quantum/python/layers/high_level/pqc_test.py
@@ -34,6 +34,15 @@ class PQCTest(tf.test.TestCase, parameterized.TestCase):
         pqc.PQC(learnable_flip, cirq.Z(qubit))
         pqc.PQC(learnable_flip, cirq.Z(qubit), repetitions=500)
 
+    def test_pqc_noisy_error(self):
+        """Refer to noisy layer."""
+        symbol = sympy.Symbol('alpha')
+        qubit = cirq.GridQubit(0, 0)
+        learnable_flip = cirq.Circuit(cirq.X(qubit)**symbol)
+        with self.assertRaisesRegex(ValueError,
+                                    expected_regex='tfq.layers.NoisyPQC'):
+            pqc.PQC(learnable_flip, cirq.Z(qubit), backend='noisy')
+
     def test_pqc_model_circuit_error(self):
         """Test that invalid circuits error properly."""
         qubit = cirq.GridQubit(0, 0)
@@ -102,6 +111,11 @@ class PQCTest(tf.test.TestCase, parameterized.TestCase):
             def run_sweep(self):
                 """do nothing."""
                 return
+
+        with self.assertRaisesRegex(
+                TypeError,
+                expected_regex="cirq.sim.simulator.SimulatesExpectation"):
+            pqc.PQC(learnable_flip, cirq.Z(qubit), backend='junk')
 
         with self.assertRaisesRegex(TypeError, expected_regex="cirq.Sampler"):
             pqc.PQC(learnable_flip,


### PR DESCRIPTION
Fixes #504 . Sets the default backend to `'noiseless'` for our existing PQC layers and adds errors that will reffer users to the incoming `Noisy***PQC` layers. This comes after the discussions in the weekly sync that it unlike the Expectation and SampledExpectation layers fitting the notion of `noisy` vs `noiseless` into the PQC layers isn't as clean so we will break them up into two seperate layers.