### PR TITLE
Remove parallelization in batch sample.

### DIFF
--- a/tensorflow_quantum/core/ops/batch_util.py
+++ b/tensorflow_quantum/core/ops/batch_util.py
@@ -423,7 +423,6 @@ def batch_sample(circuits, param_resolvers, n_samples, simulator):
         run_c = cirq.resolve_parameters(c_m, resolver)
         bits = simulator.sample(run_c, repetitions=n_samples)
         flat_m = bits[[x[1] for x in qb_keys]].to_numpy().astype(np.int8)
-        return_array[batch, :, :len(qb_keys)] = flat_m[:, ::-1]
+        return_array[batch, :, biggest_circuit - len(qb_keys):] = flat_m
 
-    # Swap big endian little endian.
-    return return_array[:, :, ::-1]
+    return return_array

--- a/tensorflow_quantum/core/ops/batch_util_test.py
+++ b/tensorflow_quantum/core/ops/batch_util_test.py
@@ -174,7 +174,7 @@ class BatchUtilTest(tf.test.TestCase, parameterized.TestCase):
         expected_results = _sample_helper(sim, state, len(qubits), n_samples)
 
         self.assertAllEqual(expected_results, test_results[0])
-        self.assertDTypeEqual(test_results, np.int32)
+        self.assertDTypeEqual(test_results, np.int8)
 
     @parameterized.parameters([{
         'sim': cirq.DensityMatrixSimulator()
@@ -210,7 +210,7 @@ class BatchUtilTest(tf.test.TestCase, parameterized.TestCase):
         for a, b in zip(tfq_histograms, cirq_histograms):
             self.assertLess(stats.entropy(a + 1e-8, b + 1e-8), 0.005)
 
-        self.assertDTypeEqual(results, np.int32)
+        self.assertDTypeEqual(results, np.int8)
 
     @parameterized.parameters([{
         'sim': cirq.DensityMatrixSimulator()
@@ -267,7 +267,7 @@ class BatchUtilTest(tf.test.TestCase, parameterized.TestCase):
             r = _sample_helper(sim, state, len(circuit.all_qubits()), n_samples)
             self.assertAllClose(r, a, atol=1e-5)
 
-        self.assertDTypeEqual(results, np.int32)
+        self.assertDTypeEqual(results, np.int8)
 
     @parameterized.parameters([{
         'sim': cirq.DensityMatrixSimulator()
@@ -297,7 +297,7 @@ class BatchUtilTest(tf.test.TestCase, parameterized.TestCase):
 
         # (4) Test sampling
         results = batch_util.batch_sample([], [], [], sim)
-        self.assertDTypeEqual(results, np.int32)
+        self.assertDTypeEqual(results, np.int8)
         self.assertEqual(np.zeros(shape=(0, 0, 0)).shape, results.shape)
 
 


### PR DESCRIPTION
Removes parallel calls into python simulators when sampling. Also fixes datatype outputs to match that of that high speed C++ ops (int8).