### PR TITLE
QCNN multiworker: pin dependencies to exact versions in Dockerfile

### DIFF
--- a/qcnn_multiworker/Dockerfile
+++ b/qcnn_multiworker/Dockerfile
@@ -15,7 +15,11 @@
 
 FROM tensorflow/tensorflow:2.4.1
 
-RUN pip install tfq-nightly google-cloud-storage tensorboard-plugin-profile
+# google-cloud-core is a dependency of google-cloud-storage
+# Pinning google-cloud-core to 1.5.0 explicitly for now to bypass the
+# requirements conflict between tensorflow-quantum 0.5.0 and and the latest
+# google-cloud-core (1.6.0) over the package google-auth.
+RUN pip install tensorflow-quantum==0.5.0 google-cloud-core==1.5.0 google-cloud-storage==1.38.0 tensorboard-plugin-profile==2.4.0
 
 COPY training/qcnn.py .
 COPY inference/qcnn_inference.py .


### PR DESCRIPTION
Pinning dependency versions to make the tutorial more reproducible. Also explicitly pinning `google-cloud-core` version to temporarily bypass the issue mentioned in https://github.com/tensorflow/quantum/pull/498#issuecomment-851761745.

Without this fix, training fails while trying to look for `OpenSSL` in the package `google-auth`.