### PR TITLE
Removed fixed grpcio version.

### DIFF
--- a/release/setup.py
+++ b/release/setup.py
@@ -52,8 +52,7 @@ class InstallPlatlib(install):
 
 REQUIRED_PACKAGES = [
     'cirq == 0.11.0', 'sympy == 1.5', 'googleapis-common-protos==1.52.0',
-    'google-api-core==1.21.0', 'google-auth==1.18.0', 'grpcio==1.30.0',
-    'protobuf==3.13.0'
+    'google-api-core==1.21.0', 'google-auth==1.18.0', 'protobuf==3.13.0'
 ]
 
 # placed as extra to not have required overwrite existing nightly installs if


### PR DESCRIPTION
Fixes #572 . Once we get this merged, we can experiment with the nightly release and if things look good we can cut a point release of 0.5.1 with this cherry picked on.