### PR TITLE
Cleaned up latex and docs rendering.

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -73,6 +73,11 @@ def main(unused_argv):
                 "check_commutability", "kwargs_cartesian_product",
                 "random_circuit_resolver_batch", "random_pauli_sums",
                 "random_symbol_circuit", "random_symbol_circuit_resolver_batch"
+            ],
+            "tfq.math": ["fidelity_op", "inner_product_op"],
+            "tfq.noise": [
+                "noisy_expectation_op", "noisy_sampled_expectation_op",
+                "noisy_samples_op"
             ]
         })
 

--- a/tensorflow_quantum/core/ops/math_ops/fidelity_op.py
+++ b/tensorflow_quantum/core/ops/math_ops/fidelity_op.py
@@ -25,8 +25,8 @@ def fidelity(programs, symbol_names, symbol_values, other_programs):
     the symbol free comparison circuits.
 
     Calculates out[i][j] = $ | \langle \psi_{\text{programs[i]}} \\
-        (\text{symbol_values[i]}) | \psi_{\text{other_programs[j]}} \rangle \\
-        |^2 $
+     (\text{symbol\_values[i]}) | \psi_{\text{other\_programs[j]}} \rangle \\
+     |^2 $
 
 
     >>> symbols = sympy.symbols('alpha beta')

--- a/tensorflow_quantum/core/ops/math_ops/inner_product_op.py
+++ b/tensorflow_quantum/core/ops/math_ops/inner_product_op.py
@@ -76,7 +76,7 @@ def inner_product(programs, symbol_names, symbol_values, other_programs):
     the symbol free comparison circuits.
 
     Calculates out[i][j] = $ \langle \psi_{\text{programs[i]}} \\
-        (\text{symbol_values[i]}) | \psi_{\text{other_programs[j]}} \rangle $
+     (\text{symbol\_values[i]}) | \psi_{\text{other\_programs[j]}} \rangle $
 
 
     >>> symbols = sympy.symbols('alpha beta')


### PR DESCRIPTION
Fixes #577 . Also removes accidental renderings of op modules like [this one](https://www.tensorflow.org/quantum/api_docs/python/tfq/math/fidelity_op)