### PR TITLE
Updated tensorflow.org/quantum landing cards.

### DIFF
--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -64,6 +64,12 @@ landing_page:
 
   - classname: devsite-landing-row-cards
     items:
+    - heading: "Distributed TensorFlow Quantum"
+      path: https://blog.tensorflow.org/2021/06/training-with-multiple-workers-using-tensorflow-quantum.html
+      image_path: /resources/images/tf-logo-card-16x9.png
+      buttons:
+        - label: "Read on TensorFlow blog"
+          path: https://blog.tensorflow.org/2021/06/training-with-multiple-workers-using-tensorflow-quantum.html
     - heading: "Power of quantum data"
       path: https://blog.tensorflow.org/2020/11/characterizing-quantum-advantage-in.html
       image_path: /resources/images/tf-logo-card-16x9.png
@@ -84,6 +90,12 @@ landing_page:
         path: https://ai.googleblog.com/2020/03/announcing-tensorflow-quantum-open.html
   - classname: devsite-landing-row-cards
     items:
+    - heading: "TensorFlow Quantum<br>Research Snippets"
+      image_path: /resources/images/github-card-16x9.png
+      path: https://github.com/tensorflow/quantum/tree/research
+      buttons:
+      - label: "View on GitHub"
+        path: https://github.com/tensorflow/quantum/tree/research
     - heading: "TensorFlow Quantum (TF Dev Summit '20)"
       youtube_id: -o9AhIz1uvo
       buttons:


### PR DESCRIPTION
Added new link cards on the landing page. First row: a link to the distributed blog post.
Second row: a link to the research branch of the github.