### PR TITLE
Ensure gradient of tf.math.fidelity remains float32 when autographed.

### DIFF
--- a/tensorflow_quantum/core/ops/math_ops/fidelity_op_test.py
+++ b/tensorflow_quantum/core/ops/math_ops/fidelity_op_test.py
@@ -86,6 +86,7 @@ class FidelityTest(tf.test.TestCase, parameterized.TestCase):
                 out_arr[i][j] = np.abs(np.vdot(final_wf, internal_wf))**2
 
         self.assertAllClose(out, out_arr, atol=1e-5)
+        self.assertDTypeEqual(out, tf.float32.as_numpy_dtype)
 
     @parameterized.parameters([
         {
@@ -138,6 +139,7 @@ class FidelityTest(tf.test.TestCase, parameterized.TestCase):
                 out_arr[i][j] = np.abs(np.vdot(final_wf, internal_wf))**2
 
         self.assertAllClose(out, out_arr, atol=1e-5)
+        self.assertDTypeEqual(out, tf.float32.as_numpy_dtype)
 
     def test_correctness_empty(self):
         """Tests the fidelity with empty circuits."""
@@ -151,6 +153,7 @@ class FidelityTest(tf.test.TestCase, parameterized.TestCase):
                                    other_program)
         expected = np.array([[1.0]], dtype=np.complex64)
         self.assertAllClose(out, expected)
+        self.assertDTypeEqual(out, tf.float32.as_numpy_dtype)
 
         qubit = cirq.GridQubit(0, 0)
         non_empty_circuit = util.convert_to_tensor(
@@ -235,6 +238,7 @@ class FidelityTest(tf.test.TestCase, parameterized.TestCase):
                         out_arr[i][k] += grad_fid
 
         self.assertAllClose(out, out_arr, atol=1e-3)
+        self.assertDTypeEqual(out, tf.float32.as_numpy_dtype)
 
     @parameterized.parameters([
         {
@@ -272,6 +276,7 @@ class FidelityTest(tf.test.TestCase, parameterized.TestCase):
                                       other_programs)
         out = tape.gradient(ip, symbol_values)
         self.assertAllClose(out, tf.zeros_like(symbol_values), atol=1e-3)
+        self.assertDTypeEqual(out, tf.float32.as_numpy_dtype)
 
     def test_correctness_no_circuit(self):
         """Test the inner product between no circuits."""
@@ -284,6 +289,7 @@ class FidelityTest(tf.test.TestCase, parameterized.TestCase):
         out = fidelity_op.fidelity(empty_circuit, empty_symbols, empty_values,
                                    other_program)
         self.assertShapeEqual(np.zeros((0, 0)), out)
+        self.assertDTypeEqual(out, tf.float32.as_numpy_dtype)
 
     def test_tf_gradient_correctness_no_circuit(self):
         """Test the inner product grad between no circuits."""
@@ -299,6 +305,7 @@ class FidelityTest(tf.test.TestCase, parameterized.TestCase):
                                        empty_values, other_program)
 
         self.assertShapeEqual(np.zeros((0, 0)), out)
+        self.assertDTypeEqual(out, tf.float32.as_numpy_dtype)
 
 
 if __name__ == "__main__":

--- a/tensorflow_quantum/core/ops/math_ops/tfq_inner_product_grad.cc
+++ b/tensorflow_quantum/core/ops/math_ops/tfq_inner_product_grad.cc
@@ -479,9 +479,18 @@ REGISTER_OP("TfqInnerProductGrad")
           c->Dim(programs_shape, 0);
       tensorflow::shape_inference::DimensionHandle output_cols =
           c->Dim(symbol_names_shape, 0);
-      std::vector<tensorflow::shape_inference::DimensionHandle> dims = {
-          output_rows, output_cols};
-      c->set_output(0, c->MakeShape(dims));
+
+      // Use kUnknownDim instead to prevent shape inference from breaking
+      //   @tf.custom_gradient code in fidelity_op.py. The grad function has
+      //   an implicit data dependency on `sybmol_names` that shape infrence
+      //   can't (and shouldn't) see. Not specifying shape prevents this break.
+      // std::vector<tensorflow::shape_inference::DimensionHandle> dims = {
+      //     output_rows,
+      //     tensorflow::shape_inference::InferenceContext::kUnknownDim};
+      c->set_output(
+          0, c->MakeShape(
+                 {output_rows,
+                  tensorflow::shape_inference::InferenceContext::kUnknownDim}));
 
       return tensorflow::Status::OK();
     });


### PR DESCRIPTION
When calling:

```python3
tf.GradientTape() as tape:
   tape.gradient(some fid op)
```

The fid op would backprop through to the inner_product op who's gradients are complex64 (as they should be). However this can be unintuitive to the user who might not be expecting this. This PR ensures that the gradient of the fidelity op remains f32 at all times. It does not change the types of the inner_product grad which would still remain complex64.