### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cirq==0.12.0
+six==1.15.0
 sympy==1.8
 numpy==1.19.5  # TensorFlow can detect if it was built against other versions.
 nbconvert==5.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cirq==0.11.0
+cirq==0.12.0
 sympy==1.8
 numpy==1.19.5  # TensorFlow can detect if it was built against other versions.
 nbconvert==5.6.1


### PR DESCRIPTION
When we import tensorflow quantum 0.6.0, we got this message:

```
2021-08-17 02:22:43.492826: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
Traceback (most recent call last):
    import tensorflow_quantum as tfq
  File "/usr/local/home/jaeyoo/lib/python3.9/site-packages/tensorflow_quantum/__init__.py", line 18, in <module>
    from tensorflow_quantum.core import (append_circuit, get_expectation_op,
  File "/usr/local/home/jaeyoo/lib/python3.9/site-packages/tensorflow_quantum/core/__init__.py", line 17, in <module>
    from tensorflow_quantum.core.ops import (get_expectation_op,
  File "/usr/local/home/jaeyoo/lib/python3.9/site-packages/tensorflow_quantum/core/ops/__init__.py", line 18, in <module>
    from tensorflow_quantum.core.ops.circuit_execution_ops import (
  File "/usr/local/home/jaeyoo/lib/python3.9/site-packages/tensorflow_quantum/core/ops/circuit_execution_ops.py", line 20, in <module>
    from tensorflow_quantum.core.ops import (cirq_ops, tfq_simulate_ops,
  File "/usr/local/home/jaeyoo/lib/python3.9/site-packages/tensorflow_quantum/core/ops/cirq_ops.py", line 23, in <module>
    from tensorflow_quantum.core.ops import batch_util
  File "/usr/local/home/jaeyoo/lib/python3.9/site-packages/tensorflow_quantum/core/ops/batch_util.py", line 26, in <module>
    class TFQPauliSumCollector(cirq.work.collector.Collector):
AttributeError: module 'cirq' has no attribute 'work'
```

and the `cirq.work` is introduced `cirq>=0.12.0`