### PR TITLE
Fix auditwheel script

### DIFF
--- a/third_party/tf/auditwheel
+++ b/third_party/tf/auditwheel
@@ -1,6 +1,6 @@
 TF_SHARED_LIBRARY_NAME=$(grep -r TF_SHARED_LIBRARY_NAME .bazelrc | awk -F= '{print$2}')
 
-POLICY_JSON=$(find / -name policy.json)
+POLICY_JSON=$(find / -name manylinux-policy.json)
 
 sed -i "s/libresolv.so.2\"/libresolv.so.2\", $TF_SHARED_LIBRARY_NAME/g" $POLICY_JSON
 


### PR DESCRIPTION
The recent change in auditwheel shows different file name for the `policy.json`. Let's use the right json file for manylinux as located at:

https://github.com/pypa/auditwheel/blob/main/src/auditwheel/policy/manylinux-policy.json