### PR TITLE
Add SPSA optimizer

### DIFF
--- a/release/BUILD
+++ b/release/BUILD
@@ -65,5 +65,6 @@ sh_binary(
         "//tensorflow_quantum/python:quantum_context",
         "//tensorflow_quantum/python:util",
         "//tensorflow_quantum/python/optimizers:rotosolve_minimizer",
+        "//tensorflow_quantum/python/optimizers:spsa_minimizer",
     ],
 )

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -67,7 +67,7 @@ def main(unused_argv):
                 "parameter_shift_util", "adjoint"
             ],
             "tfq.datasets": ["cluster_state"],
-            "tfq.optimizers": ["rotosolve_minimizer"],
+            "tfq.optimizers": ["rotosolve_minimizer", "spsa_minimizer"],
             "tfq.util": [
                 "from_tensor", "convert_to_tensor", "exp_identity",
                 "check_commutability", "kwargs_cartesian_product",

--- a/scripts/import_test.py
+++ b/scripts/import_test.py
@@ -81,6 +81,7 @@ def test_imports():
 
     #Optimizers
     _ = tfq.optimizers.rotosolve_minimize
+    _ = tfq.optimizers.spsa_minimize
 
 
 if __name__ == "__main__":

--- a/tensorflow_quantum/python/optimizers/BUILD
+++ b/tensorflow_quantum/python/optimizers/BUILD
@@ -11,6 +11,7 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":rotosolve_minimizer",
+        ":spsa_minimizer",
     ],
 )
 
@@ -19,12 +20,28 @@ py_library(
     srcs = ["rotosolve_minimizer.py"],
 )
 
+py_library(
+    name = "spsa_minimizer",
+    srcs = ["spsa_minimizer.py"],
+)
+
 py_test(
     name = "rotosolve_minimizer_test",
     srcs = ["rotosolve_minimizer_test.py"],
     python_version = "PY3",
     deps = [
         ":rotosolve_minimizer",
+        "//tensorflow_quantum/core/ops:tfq_ps_util_ops_py",
+        "//tensorflow_quantum/python/layers/high_level:pqc",
+    ],
+)
+
+py_test(
+    name = "spsa_minimizer_test",
+    srcs = ["spsa_minimizer_test.py"],
+    python_version = "PY3",
+    deps = [
+        ":spsa_minimizer",
         "//tensorflow_quantum/core/ops:tfq_ps_util_ops_py",
         "//tensorflow_quantum/python/layers/high_level:pqc",
     ],

--- a/tensorflow_quantum/python/optimizers/__init__.py
+++ b/tensorflow_quantum/python/optimizers/__init__.py
@@ -17,3 +17,5 @@
 # Quantum circuit specific optimizers.
 from tensorflow_quantum.python.optimizers.rotosolve_minimizer import (
     minimize as rotosolve_minimize)
+from tensorflow_quantum.python.optimizers.spsa_minimizer import (
+    minimize as spsa_minimize)

--- a/tensorflow_quantum/python/optimizers/__init__.py
+++ b/tensorflow_quantum/python/optimizers/__init__.py
@@ -17,5 +17,5 @@
 # Quantum circuit specific optimizers.
 from tensorflow_quantum.python.optimizers.rotosolve_minimizer import (
     minimize as rotosolve_minimize)
-from tensorflow_quantum.python.optimizers.spsa_minimizer import (
-    minimize as spsa_minimize)
+from tensorflow_quantum.python.optimizers.spsa_minimizer import (minimize as
+                                                                 spsa_minimize)

--- a/tensorflow_quantum/python/optimizers/rotosolve_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/rotosolve_minimizer_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Test module for tfq.python.optimizers.rotosolve_minimizer optimizer."""
+"""Test module for tfq.python.optimizers.spsa_minimizer optimizer."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position
 import sys
@@ -29,7 +29,7 @@ import cirq
 import sympy
 from tensorflow_quantum.python.layers.high_level import pqc
 from tensorflow_quantum.python import util
-from tensorflow_quantum.python.optimizers import rotosolve_minimizer
+from tensorflow_quantum.python.optimizers import spsa_minimizer
 
 
 def loss_function_with_model_parameters(model, loss, train_x, train_y):
@@ -61,7 +61,7 @@ def loss_function_with_model_parameters(model, loss, train_x, train_y):
     # Function accept the parameter and evaluate model
     @tf.function
     def func(params):
-        """A function that can be used by tfq.optimizer.rotosolve_minimize.
+        """A function that can be used by tfq.optimizer.spsa_minimize.
 
         Args:
            params [in]: a 1D tf.Tensor.
@@ -79,44 +79,141 @@ def loss_function_with_model_parameters(model, loss, train_x, train_y):
 
         # evaluate the loss
         loss_value = loss(model(train_x, training=True), train_y)
+        if loss_value.shape != ():
+            loss_value = tf.cast(tf.math.reduce_mean(loss_value), tf.float32)
         return loss_value
 
     return func
 
 
-class RotosolveMinimizerTest(tf.test.TestCase, parameterized.TestCase):
-    """Tests for the rotosolve optimization algorithm."""
-
-    def test_function_optimization(self):
-        """Optimize a simple sinusoid function."""
-
-        n = 10  # Number of parameters to be optimized
-        coefficient = tf.random.uniform(shape=[n])
-        min_value = -tf.math.reduce_sum(tf.abs(coefficient))
-
-        func = lambda x: tf.math.reduce_sum(tf.sin(x) * coefficient)
-
-        result = rotosolve_minimizer.minimize(func, np.random.random(n))
-
-        self.assertAlmostEqual(func(result.position), min_value)
-        self.assertAlmostEqual(result.objective_value, min_value)
-        self.assertTrue(result.converged)
-        self.assertLess(result.num_iterations,
-                        50)  # 50 is the default max iteration
+class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
+    """Tests for the SPSA optimization algorithm."""
 
     def test_nonlinear_function_optimization(self):
         """Test to optimize a non-linear function.
-        A non-linear function cannot be optimized by rotosolve,
-        therefore the optimization must never converge.
         """
         func = lambda x: x[0]**2 + x[1]**2
 
-        result = rotosolve_minimizer.minimize(func,
-                                              tf.random.uniform(shape=[2]))
+        result = spsa_minimizer.minimize(func, tf.random.uniform(shape=[2]))
+        self.assertAlmostEqual(func(result.position).numpy(), 0, delta=1e-4)
+        self.assertTrue(result.converged)
 
+    def test_quadratic_function_optimization(self):
+        """Test to optimize a sum of quadratic function.
+        """
+        n = 2
+        coefficient = tf.random.uniform(minval=0, maxval=1, shape=[n])
+        func = lambda x: tf.math.reduce_sum(np.power(x, 2) * coefficient)
+
+        result = spsa_minimizer.minimize(func, tf.random.uniform(shape=[n]))
+        self.assertAlmostEqual(func(result.position).numpy(), 0, delta=2e-4)
+        self.assertTrue(result.converged)
+
+    def test_noisy_sin_function_optimization(self):
+        """Test noisy ssinusoidal function
+        """
+        n = 10
+        func = lambda x: tf.math.reduce_sum(
+            tf.math.sin(x) + tf.random.uniform(
+                minval=-0.1, maxval=0.1, shape=[n]))
+
+        result = spsa_minimizer.minimize(func, tf.random.uniform(shape=[n]))
+        self.assertLessEqual(func(result.position).numpy(), -n + 0.1 * n)
+
+    def test_failure_optimization(self):
+        """Test a function that is completely random and cannot be minimized
+        """
+        n = 100
+        func = lambda x: np.random.uniform(-10, 10, 1)[0]
+        it = 50
+
+        result = spsa_minimizer.minimize(func,
+                                         tf.random.uniform(shape=[n]),
+                                         max_iterations=it)
         self.assertFalse(result.converged)
-        self.assertEqual(result.num_iterations,
-                         50)  # 50 is the default max iteration
+        self.assertEqual(result.num_iterations, it)
+
+    def test_blocking(self):
+        """Test the blocking functionality.
+        """
+        n = 10
+        it = 50
+
+        init = 1
+        self.incr = 0
+        def block_func1(params):
+            self.incr += init
+            return self.incr
+
+        result = spsa_minimizer.minimize(block_func1,
+                                         tf.random.uniform(shape=[n]),
+                                         blocking=True,
+                                         allowed_increase=0.5,
+                                         max_iterations=it)
+        self.assertFalse(result.converged)
+        self.assertEqual(result.num_iterations, it)
+        self.assertEqual(result.objective_value,
+                         init * 4)  # function executd 3 (in step) +
+        # 1 (initial evaluation) times
+
+        init = 1 / 6 * 0.49
+        self.incr = 0
+        def block_func2(params):
+            self.incr += init
+            return self.incr
+
+        result = spsa_minimizer.minimize(block_func2,
+                                         tf.random.uniform(shape=[n]),
+                                         blocking=True,
+                                         allowed_increase=0.5,
+                                         max_iterations=it)
+        self.assertFalse(result.converged)
+        self.assertEqual(result.num_iterations, it)
+        self.assertEqual(result.objective_value, init * 3 * it + init)
+
+    def test_3_qubit_circuit(self):
+        """Test quantum circuit optimization, adapted from Qiskit SPSA testing
+        https://github.com/Qiskit/qiskit-terra/blob/main/test/python/algorithms/optimizers/test_spsa.py#L37
+        """
+        qubits = [cirq.GridQubit(0, i) for i in range(3)]
+        params = sympy.symbols("q0:9")
+        circuit = cirq.Circuit()
+        for i in qubits:
+            circuit += cirq.ry(np.pi / 4).on(i)
+        circuit += cirq.ry(params[0]).on(qubits[0])
+        circuit += cirq.ry(params[1]).on(qubits[1])
+        circuit += cirq.rz(params[2]).on(qubits[2])
+
+        circuit += cirq.CZ(qubits[0], qubits[1])
+        circuit += cirq.CZ(qubits[1], qubits[2])
+        circuit += cirq.rz(params[3]).on(qubits[0])
+        circuit += cirq.rz(params[4]).on(qubits[1])
+        circuit += cirq.rx(params[5]).on(qubits[2])
+
+        # Build the Keras model.
+        model = tf.keras.Sequential([
+            # The input is the data-circuit, encoded as a tf.string
+            tf.keras.layers.Input(shape=(), dtype=tf.string),
+            # The PQC layer returns the expected value of the
+            # readout gate, range [-1,1].
+            pqc.PQC(circuit,
+                    cirq.Z(qubits[0]) * cirq.Z(qubits[1]),
+                    repetitions=1024),
+        ])
+
+        initial_point = np.array([
+            0.82311034, 0.02611798, 0.21077064, 0.61842177, 0.09828447,
+            0.62013131
+        ])
+
+        result = spsa_minimizer.minimize(loss_function_with_model_parameters(
+            model, lambda x, y: x[0][0],
+            util.convert_to_tensor([cirq.Circuit()]), None),
+                                         initial_point,
+                                         max_iterations=100)
+
+        self.assertTrue(result.converged)
+        self.assertLess(result.objective_value.numpy(), -0.95)
 
     def test_keras_model_optimization(self):
         """Optimizate a PQC based keras model."""
@@ -157,16 +254,16 @@ class RotosolveMinimizerTest(tf.test.TestCase, parameterized.TestCase):
             tf.keras.layers.Input(shape=(), dtype=tf.string),
             # The PQC layer returns the expected value of the
             # readout gate, range [-1,1].
-            pqc.PQC(circuit, cirq.Z(q1)),
+            pqc.PQC(circuit, 2 * cirq.Z(q1)),
         ])
 
         # Initial guess of the parameter from random number
-        result = rotosolve_minimizer.minimize(
+        result = spsa_minimizer.minimize(
             loss_function_with_model_parameters(model, tf.keras.losses.Hinge(),
                                                 x_circ, y),
             tf.random.uniform(shape=[2]) * 2 * np.pi)
 
-        self.assertAlmostEqual(result.objective_value, 0)
+        self.assertAlmostEqual(result.objective_value.numpy(), 0)
         self.assertTrue(result.converged)
 
 

--- a/tensorflow_quantum/python/optimizers/rotosolve_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/rotosolve_minimizer_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Test module for tfq.python.optimizers.spsa_minimizer optimizer."""
+"""Test module for tfq.python.optimizers.rotosolve_minimizer optimizer."""
 # Remove PYTHONPATH collisions for protobuf.
 # pylint: disable=wrong-import-position
 import sys
@@ -29,19 +29,17 @@ import cirq
 import sympy
 from tensorflow_quantum.python.layers.high_level import pqc
 from tensorflow_quantum.python import util
-from tensorflow_quantum.python.optimizers import spsa_minimizer
+from tensorflow_quantum.python.optimizers import rotosolve_minimizer
 
 
 def loss_function_with_model_parameters(model, loss, train_x, train_y):
     """Create a new function that assign the model parameter to the model
     and evaluate its value.
-
     Args:
         model : an instance of `tf.keras.Model` or its subclasses.
         loss : a function with signature loss_value = loss(pred_y, true_y).
         train_x : the input part of training data.
         train_y : the output part of training data.
-
     Returns:
         A function that has a signature of:
             loss_value = f(model_parameters).
@@ -61,11 +59,9 @@ def loss_function_with_model_parameters(model, loss, train_x, train_y):
     # Function accept the parameter and evaluate model
     @tf.function
     def func(params):
-        """A function that can be used by tfq.optimizer.spsa_minimize.
-
+        """A function that can be used by tfq.optimizer.rotosolve_minimize.
         Args:
            params [in]: a 1D tf.Tensor.
-
         Returns:
             Loss function value
         """
@@ -79,141 +75,44 @@ def loss_function_with_model_parameters(model, loss, train_x, train_y):
 
         # evaluate the loss
         loss_value = loss(model(train_x, training=True), train_y)
-        if loss_value.shape != ():
-            loss_value = tf.cast(tf.math.reduce_mean(loss_value), tf.float32)
         return loss_value
 
     return func
 
 
-class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
-    """Tests for the SPSA optimization algorithm."""
+class RotosolveMinimizerTest(tf.test.TestCase, parameterized.TestCase):
+    """Tests for the rotosolve optimization algorithm."""
+
+    def test_function_optimization(self):
+        """Optimize a simple sinusoid function."""
+
+        n = 10  # Number of parameters to be optimized
+        coefficient = tf.random.uniform(shape=[n])
+        min_value = -tf.math.reduce_sum(tf.abs(coefficient))
+
+        func = lambda x: tf.math.reduce_sum(tf.sin(x) * coefficient)
+
+        result = rotosolve_minimizer.minimize(func, np.random.random(n))
+
+        self.assertAlmostEqual(func(result.position), min_value)
+        self.assertAlmostEqual(result.objective_value, min_value)
+        self.assertTrue(result.converged)
+        self.assertLess(result.num_iterations,
+                        50)  # 50 is the default max iteration
 
     def test_nonlinear_function_optimization(self):
         """Test to optimize a non-linear function.
+        A non-linear function cannot be optimized by rotosolve,
+        therefore the optimization must never converge.
         """
         func = lambda x: x[0]**2 + x[1]**2
 
-        result = spsa_minimizer.minimize(func, tf.random.uniform(shape=[2]))
-        self.assertAlmostEqual(func(result.position).numpy(), 0, delta=1e-4)
-        self.assertTrue(result.converged)
+        result = rotosolve_minimizer.minimize(func,
+                                              tf.random.uniform(shape=[2]))
 
-    def test_quadratic_function_optimization(self):
-        """Test to optimize a sum of quadratic function.
-        """
-        n = 2
-        coefficient = tf.random.uniform(minval=0, maxval=1, shape=[n])
-        func = lambda x: tf.math.reduce_sum(np.power(x, 2) * coefficient)
-
-        result = spsa_minimizer.minimize(func, tf.random.uniform(shape=[n]))
-        self.assertAlmostEqual(func(result.position).numpy(), 0, delta=2e-4)
-        self.assertTrue(result.converged)
-
-    def test_noisy_sin_function_optimization(self):
-        """Test noisy ssinusoidal function
-        """
-        n = 10
-        func = lambda x: tf.math.reduce_sum(
-            tf.math.sin(x) + tf.random.uniform(
-                minval=-0.1, maxval=0.1, shape=[n]))
-
-        result = spsa_minimizer.minimize(func, tf.random.uniform(shape=[n]))
-        self.assertLessEqual(func(result.position).numpy(), -n + 0.1 * n)
-
-    def test_failure_optimization(self):
-        """Test a function that is completely random and cannot be minimized
-        """
-        n = 100
-        func = lambda x: np.random.uniform(-10, 10, 1)[0]
-        it = 50
-
-        result = spsa_minimizer.minimize(func,
-                                         tf.random.uniform(shape=[n]),
-                                         max_iterations=it)
         self.assertFalse(result.converged)
-        self.assertEqual(result.num_iterations, it)
-
-    def test_blocking(self):
-        """Test the blocking functionality.
-        """
-        n = 10
-        it = 50
-
-        init = 1
-        self.incr = 0
-        def block_func1(params):
-            self.incr += init
-            return self.incr
-
-        result = spsa_minimizer.minimize(block_func1,
-                                         tf.random.uniform(shape=[n]),
-                                         blocking=True,
-                                         allowed_increase=0.5,
-                                         max_iterations=it)
-        self.assertFalse(result.converged)
-        self.assertEqual(result.num_iterations, it)
-        self.assertEqual(result.objective_value,
-                         init * 4)  # function executd 3 (in step) +
-        # 1 (initial evaluation) times
-
-        init = 1 / 6 * 0.49
-        self.incr = 0
-        def block_func2(params):
-            self.incr += init
-            return self.incr
-
-        result = spsa_minimizer.minimize(block_func2,
-                                         tf.random.uniform(shape=[n]),
-                                         blocking=True,
-                                         allowed_increase=0.5,
-                                         max_iterations=it)
-        self.assertFalse(result.converged)
-        self.assertEqual(result.num_iterations, it)
-        self.assertEqual(result.objective_value, init * 3 * it + init)
-
-    def test_3_qubit_circuit(self):
-        """Test quantum circuit optimization, adapted from Qiskit SPSA testing
-        https://github.com/Qiskit/qiskit-terra/blob/main/test/python/algorithms/optimizers/test_spsa.py#L37
-        """
-        qubits = [cirq.GridQubit(0, i) for i in range(3)]
-        params = sympy.symbols("q0:9")
-        circuit = cirq.Circuit()
-        for i in qubits:
-            circuit += cirq.ry(np.pi / 4).on(i)
-        circuit += cirq.ry(params[0]).on(qubits[0])
-        circuit += cirq.ry(params[1]).on(qubits[1])
-        circuit += cirq.rz(params[2]).on(qubits[2])
-
-        circuit += cirq.CZ(qubits[0], qubits[1])
-        circuit += cirq.CZ(qubits[1], qubits[2])
-        circuit += cirq.rz(params[3]).on(qubits[0])
-        circuit += cirq.rz(params[4]).on(qubits[1])
-        circuit += cirq.rx(params[5]).on(qubits[2])
-
-        # Build the Keras model.
-        model = tf.keras.Sequential([
-            # The input is the data-circuit, encoded as a tf.string
-            tf.keras.layers.Input(shape=(), dtype=tf.string),
-            # The PQC layer returns the expected value of the
-            # readout gate, range [-1,1].
-            pqc.PQC(circuit,
-                    cirq.Z(qubits[0]) * cirq.Z(qubits[1]),
-                    repetitions=1024),
-        ])
-
-        initial_point = np.array([
-            0.82311034, 0.02611798, 0.21077064, 0.61842177, 0.09828447,
-            0.62013131
-        ])
-
-        result = spsa_minimizer.minimize(loss_function_with_model_parameters(
-            model, lambda x, y: x[0][0],
-            util.convert_to_tensor([cirq.Circuit()]), None),
-                                         initial_point,
-                                         max_iterations=100)
-
-        self.assertTrue(result.converged)
-        self.assertLess(result.objective_value.numpy(), -0.95)
+        self.assertEqual(result.num_iterations,
+                         50)  # 50 is the default max iteration
 
     def test_keras_model_optimization(self):
         """Optimizate a PQC based keras model."""
@@ -254,16 +153,16 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
             tf.keras.layers.Input(shape=(), dtype=tf.string),
             # The PQC layer returns the expected value of the
             # readout gate, range [-1,1].
-            pqc.PQC(circuit, 2 * cirq.Z(q1)),
+            pqc.PQC(circuit, cirq.Z(q1)),
         ])
 
         # Initial guess of the parameter from random number
-        result = spsa_minimizer.minimize(
+        result = rotosolve_minimizer.minimize(
             loss_function_with_model_parameters(model, tf.keras.losses.Hinge(),
                                                 x_circ, y),
             tf.random.uniform(shape=[2]) * 2 * np.pi)
 
-        self.assertAlmostEqual(result.objective_value.numpy(), 0)
+        self.assertAlmostEqual(result.objective_value, 0)
         self.assertTrue(result.converged)
 
 

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -82,10 +82,10 @@ SPSAOptimizerResults = collections.namedtuple(
         'gamma',
         # Specifies scaling of the size of the perturbations
         'blocking',
-        # If true, then the optimizer will only accept updates that improve 
+        # If true, then the optimizer will only accept updates that improve
         # the objective function.
         'allowed_increase'
-        # Specifies maximum allowable increase in objective function 
+        # Specifies maximum allowable increase in objective function
         # (only applies if blocking is true).
     ])
 
@@ -212,14 +212,17 @@ def minimize(expectation_value_function,
                                       maxval=2,
                                       dtype=tf.int32) - 1, tf.float32)
 
-            v_m =  expectation_value_function(state.position - state.c * delta_shift)
-            v_p = expectation_value_function(state.position + state.c * delta_shift)
+            v_m = expectation_value_function(state.position -
+                                             state.c * delta_shift)
+            v_p = expectation_value_function(state.position +
+                                             state.c * delta_shift)
 
             gradient_estimate = (v_p - v_m) / (2 * state.c) * delta_shift
             update = state.a * gradient_estimate
 
             current_obj = expectation_value_function(state.position - update)
-            #state.position.assign(tf.math.floormod(state.position - update, 2* np.pi))
+            # state.position.assign(tf.math.floormod(state.position - 
+            #                                        update, 2* np.pi))
             if state.num_objective_evaluations == 0 or state.objective_value_previous_iteration \
                 < current_obj + state.allowed_increase or not state.blocking:
                 state.position.assign(state.position - update)

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -223,7 +223,8 @@ def minimize(expectation_value_function,
             current_obj = expectation_value_function(state.position - update)
             # state.position.assign(tf.math.floormod(state.position -
             #                                        update, 2* np.pi))
-            if state.num_objective_evaluations == 0 or state.objective_value_previous_iteration \
+            if state.num_objective_evaluations == 0 or \
+                state.objective_value_previous_iteration \
                 < current_obj + state.allowed_increase or not state.blocking:
                 state.position.assign(state.position - update)
 

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -194,7 +194,6 @@ def minimize(expectation_value_function,
 
         a_init = tf.convert_to_tensor(a, name='initial_a', dtype='float32')
         c_init = tf.convert_to_tensor(c, name='initial_c', dtype='float32')
-    
 
         def _spsa_once(state):
             """Caclulate single SPSA gradient estimation
@@ -230,7 +229,6 @@ def minimize(expectation_value_function,
 
             return [state]
 
-
         # The `state` here is a `SPSAOptimizerResults` tuple with
         # values for the current state of the algorithm computation.
         def _cond(state):
@@ -241,7 +239,6 @@ def minimize(expectation_value_function,
 
         def _body(state):
             """Main optimization loop."""
-            
             new_a = a_init / (
                 (tf.cast(state.num_iterations + 1, tf.float32) +
                  0.01 * tf.cast(max_iterations, tf.float32))**state.alpha)

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -260,9 +260,8 @@ def minimize(expectation_value_function,
             return [state]
 
         initial_state = _get_initial_state(initial_position, tolerance,
-                                           expectation_value_function, a,
-                                           alpha, c, gamma, blocking,
-                                           allowed_increase)
+                                           expectation_value_function, a, alpha,
+                                           c, gamma, blocking, allowed_increase)
 
         initial_state.objective_value.assign(
             expectation_value_function(initial_state.position))

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -78,12 +78,12 @@ SPSAOptimizerResults = collections.namedtuple(
         # Specifies the learning rate
         'alpha',
         # Specifies scaling of the learning rate
-        'c', 
+        'c',
         # Specifies the size of the perturbations
         'gamma',
         # Specifies scaling of the size of the perturbations
         'blocking',
-        # If true, then the optimizer will only accept updates that improve the objective function. 
+        # If true, then the optimizer will only accept updates that improve the objective function.
         'allowed_increase'
         # Specifies maximum allowable increase in objective function (only applies if blocking is true).
     ])
@@ -206,7 +206,11 @@ def minimize(expectation_value_function,
             Returns:
                 states: A list which the first element is the new state
             """
-            delta_shift = tf.cast(2 * tf.random.uniform(shape=state.position.shape, minval=0, maxval=2, dtype=tf.int32) - 1, tf.float32)
+            delta_shift = tf.cast(
+                2 * tf.random.uniform(shape=state.position.shape,
+                                      minval=0,
+                                      maxval=2,
+                                      dtype=tf.int32) - 1, tf.float32)
 
             v_m, v_p =  expectation_value_function(state.position - state.c * delta_shift),\
                  expectation_value_function(state.position + state.c * delta_shift)
@@ -238,8 +242,11 @@ def minimize(expectation_value_function,
         def _body(state):
             """Main optimization loop."""
             
-            new_a = a_init / ((tf.cast(state.num_iterations + 1, tf.float32) + 0.01 * tf.cast(max_iterations, tf.float32))**state.alpha)
-            new_c = c_init / (tf.cast(state.num_iterations + 1, tf.float32)**state.gamma)
+            new_a = a_init / (
+                (tf.cast(state.num_iterations + 1, tf.float32) +
+                 0.01 * tf.cast(max_iterations, tf.float32))**state.alpha)
+            new_c = c_init / (tf.cast(state.num_iterations + 1, tf.float32)**
+                              state.gamma)
 
             state.a.assign(new_a)
             state.c.assign(new_c)
@@ -252,9 +259,12 @@ def minimize(expectation_value_function,
                 state.tolerance)
             return [state]
 
-        initial_state = _get_initial_state(initial_position, tolerance, expectation_value_function, a, alpha, c, gamma, blocking, allowed_increase)
+            initial_state = _get_initial_state(initial_position, tolerance,
+                                           expectation_value_function, a, alpha,
+                                           c, gamma, blocking, allowed_increase)
 
-        initial_state.objective_value.assign(expectation_value_function(initial_state.position))
+        initial_state.objective_value.assign(
+            expectation_value_function(initial_state.position))
 
         return tf.while_loop(cond=_cond,
                              body=_body,

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -89,7 +89,8 @@ SPSAOptimizerResults = collections.namedtuple(
     ])
 
 
-def _get_initial_state(initial_position, tolerance, expectation_value_function, a, alpha, c, gamma, blocking, allowed_increase):
+def _get_initial_state(initial_position, tolerance, expectation_value_function,
+                       a, alpha, c, gamma, blocking, allowed_increase):
     """Create SPSAOptimizerResults with initial state of search."""
     init_args = {
         "converged": tf.Variable(False),

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -1,0 +1,261 @@
+# Copyright 2021 The TensorFlow Quantum Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""The SPSA minimization algorithm"""
+import collections
+import numpy as np
+import tensorflow as tf
+
+
+def prefer_static_shape(x):
+    """Return static shape of tensor `x` if available,
+
+    else `tf.shape(x)`.
+
+    Args:
+        x: `tf.Tensor` (already converted).
+    Returns:
+        Numpy array (if static shape is obtainable), else `tf.Tensor`.
+    """
+    return prefer_static_value(tf.shape(x))
+
+
+def prefer_static_value(x):
+    """Return static value of tensor `x` if available, else `x`.
+
+    Args:
+        x: `tf.Tensor` (already converted).
+    Returns:
+        Numpy array (if static value is obtainable), else `tf.Tensor`.
+    """
+    static_x = tf.get_static_value(x)
+    if static_x is not None:
+        return static_x
+    return x
+
+
+SPSAOptimizerResults = collections.namedtuple(
+    'SPSAOptimizerResults',
+    [
+        'converged',
+        # Scalar boolean tensor indicating whether the minimum
+        # was found within tolerance.
+        'num_iterations',
+        # The number of iterations of the SPSA update.
+        'num_objective_evaluations',
+        # The total number of objective
+        # evaluations performed.
+        'position',
+        # A tensor containing the last argument value found
+        # during the search. If the search converged, then
+        # this value is the argmin of the objective function.
+        # A tensor containing the value of the objective from
+        # previous iteration
+        'objective_value_previous_iteration',
+        # Save the evaluated value of the objective function
+        # from the previous iteration
+        'objective_value',
+        # A tensor containing the value of the objective
+        # function at the `position`. If the search
+        # converged, then this is the (local) minimum of
+        # the objective function.
+        'tolerance',
+        # Define the stop criteria. Iteration will stop when the
+        # objective value difference between two iterations is
+        # smaller than tolerance
+        'a',
+        # Specifies the learning rate
+        'alpha',
+        # Specifies scaling of the learning rate
+        'c', 
+        # Specifies the size of the perturbations
+        'gamma',
+        # Specifies scaling of the size of the perturbations
+        'blocking',
+        # If true, then the optimizer will only accept updates that improve the objective function. 
+        'allowed_increase'
+        # Specifies maximum allowable increase in objective function (only applies if blocking is true).
+    ])
+
+
+def _get_initial_state(initial_position, tolerance, expectation_value_function, a, alpha, c, gamma, blocking, allowed_increase):
+    """Create SPSAOptimizerResults with initial state of search."""
+    init_args = {
+        "converged": tf.Variable(False),
+        "num_iterations": tf.Variable(0),
+        "num_objective_evaluations": tf.Variable(0),
+        "position": tf.Variable(initial_position),
+        "objective_value": tf.Variable(0.),
+        "objective_value_previous_iteration": tf.Variable(0.),
+        "tolerance": tolerance,
+        "a": tf.Variable(a),
+        "alpha": tf.Variable(alpha),
+        "c": tf.Variable(c),
+        "gamma" : tf.Variable(gamma),
+        "blocking" : tf.Variable(blocking),
+        "allowed_increase" : tf.Variable(allowed_increase)
+    }
+    return SPSAOptimizerResults(**init_args)
+
+
+def minimize(expectation_value_function,
+             initial_position,
+             tolerance=1e-7,
+             max_iterations=60,
+             alpha=0.602,
+             a=1.0,
+             c=1.0,
+             gamma=0.101,
+             blocking=True,
+             allowed_increase=0.5,
+             name=None):
+    """Applies the SPSA algorithm.
+
+    The SPSA algorithm can be used to minimize a noisy function. See:
+
+    [SPSA website](https://www.jhuapl.edu/SPSA/)
+
+    Usage:
+
+    Here is an example of optimize a function which consists summation of
+    a few sinusoids.
+
+    >>> n = 10  # Number of sinusoids
+    >>> coefficient = tf.random.uniform(shape=[n])
+    >>> min_value = -tf.math.reduce_sum(tf.abs(coefficient))
+    >>> func = lambda x:tf.math.reduce_sum(tf.sin(x) * coefficient)
+    >>> # Optimize the function with SPSA, start with random parameters
+    >>> result = tfq.optimizers.SPSA_minimize(func, np.random.random(n))
+    >>> result.converged
+    tf.Tensor(True, shape=(), dtype=bool)
+    >>> result.objective_value
+    tf.Tensor(-4.7045116, shape=(), dtype=float32)
+
+    Args:
+        expectation_value_function:  A Python callable that accepts
+            a point as a real `tf.Tensor` and returns a `tf.Tensor`s
+            of real dtype containing the value of the function.
+            The function to be minimized. The input is of shape `[n]`,
+            where `n` is the size of the trainable parameters.
+            The return value is a real `tf.Tensor` Scalar (matching shape
+            `[1]`).  This must be a linear combination of quantum
+            measurement expectation value, otherwise this algorithm cannot
+            work.
+        initial_position: Real `tf.Tensor` of shape `[n]`. The starting
+            point, or points when using batching dimensions, of the search
+            procedure. At these points the function value and the gradient
+            norm should be finite.
+        tolerance: Scalar `tf.Tensor` of real dtype. Specifies the tolerance
+            for the procedure. If the supremum norm between two iteration
+            vector is below this number, the algorithm is stopped.
+        a: Scalar `tf.Tensor` of real dtype. Specifies the learning rate
+        alpha: Scalar `tf.Tensor` of real dtype. Specifies scaling of the
+            learning rate.
+        c: Scalar `tf.Tensor` of real dtype. Specifies the size of the 
+            perturbations.
+        gamma: Scalar `tf.Tensor` of real dtype. Specifies scaling of the
+            size of the perturbations.
+        blocking: Boolean. If true, then the optimizer will only accept
+            updates that improve the objective function. 
+        allowed_increase: Scalar `tf.Tensor` of real dtype. Specifies maximum 
+            allowable increase in objective function (only applies if blocking
+            is true).
+        name: (Optional) Python `str`. The name prefixed to the ops created
+            by this function. If not supplied, the default name 'minimize'
+            is used.
+
+    Returns:
+        optimizer_results: A SPSAOptimizerResults object contains the
+            result of the optimization process.
+    """
+
+    with tf.name_scope(name or 'minimize'):
+        initial_position = tf.convert_to_tensor(initial_position,
+                                                name='initial_position',
+                                                dtype='float32')
+        dtype = initial_position.dtype.base_dtype
+        tolerance = tf.convert_to_tensor(tolerance,
+                                         dtype=dtype,
+                                         name='grad_tolerance')
+        max_iterations = tf.convert_to_tensor(max_iterations,
+                                              name='max_iterations')
+
+        a_init = tf.convert_to_tensor(a, name='initial a', dtype='float32')
+        c_init = tf.convert_to_tensor(c, name='initial c', dtype='float32')
+    
+
+        def _spsa_once(state):
+            """Caclulate single SPSA gradient estimation
+
+            Args:
+                state: A SPSAOptimizerResults object stores the
+                       current state of the minimizer.
+
+            Returns:
+                states: A list which the first element is the new state
+            """
+            delta_shift = tf.cast(2 * tf.random.uniform(shape=state.position.shape, minval=0, maxval=2, dtype=tf.int32) - 1, tf.float32)
+
+            v_m, v_p =  expectation_value_function(state.position - state.c * delta_shift),\
+                 expectation_value_function(state.position + state.c * delta_shift)
+
+            gradient_estimate = (v_p - v_m) / (2 * state.c) * delta_shift
+            update = state.a * gradient_estimate
+
+            current_obj = expectation_value_function(state.position - update)
+            #state.position.assign(tf.math.floormod(state.position - update, 2* np.pi))
+            if state.num_objective_evaluations == 0 or state.objective_value_previous_iteration < current_obj + state.allowed_increase or not state.blocking:
+                state.position.assign(state.position - update)
+
+            state.num_objective_evaluations.assign_add(2)
+            state.objective_value_previous_iteration.assign(
+                state.objective_value)
+            state.objective_value.assign(current_obj)
+
+            return [state]
+
+
+        # The `state` here is a `SPSAOptimizerResults` tuple with
+        # values for the current state of the algorithm computation.
+        def _cond(state):
+            """Continue if iterations remain and stopping condition
+            is not met."""
+            return (state.num_iterations < max_iterations) \
+                   and (not state.converged)
+
+        def _body(state):
+            """Main optimization loop."""
+            
+            new_a = a_init / ((tf.cast(state.num_iterations + 1, tf.float32) + 0.01 * tf.cast(max_iterations, tf.float32))**state.alpha)
+            new_c = c_init / (tf.cast(state.num_iterations + 1, tf.float32)**state.gamma)
+
+            state.a.assign(new_a)
+            state.c.assign(new_c)
+
+            _spsa_once(state)
+            state.num_iterations.assign_add(1)
+            state.converged.assign(
+                tf.abs(state.objective_value -
+                       state.objective_value_previous_iteration) <
+                state.tolerance)
+            return [state]
+
+        initial_state = _get_initial_state(initial_position, tolerance, expectation_value_function, a, alpha, c, gamma, blocking, allowed_increase)
+
+        initial_state.objective_value.assign(expectation_value_function(initial_state.position))
+
+        return tf.while_loop(cond=_cond,
+                             body=_body,
+                             loop_vars=[initial_state],
+                             parallel_iterations=1)[0]

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -102,9 +102,9 @@ def _get_initial_state(initial_position, tolerance, expectation_value_function, 
         "a": tf.Variable(a),
         "alpha": tf.Variable(alpha),
         "c": tf.Variable(c),
-        "gamma" : tf.Variable(gamma),
-        "blocking" : tf.Variable(blocking),
-        "allowed_increase" : tf.Variable(allowed_increase)
+        "gamma": tf.Variable(gamma),
+        "blocking": tf.Variable(blocking),
+        "allowed_increase": tf.Variable(allowed_increase)
     }
     return SPSAOptimizerResults(**init_args)
 

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -15,6 +15,7 @@
 """The SPSA minimization algorithm"""
 import collections
 import tensorflow as tf
+import numpy as np
 
 
 def prefer_static_shape(x):
@@ -131,13 +132,14 @@ def minimize(expectation_value_function,
 
     Usage:
 
-    Here is an example of optimize a function which consists the 
+    Here is an example of optimize a function which consists the
     summation of a few quadratics.
 
     >>> n = 5  # Number of quadractics
     >>> coefficient = tf.random.uniform(minval=0, maxval=1, shape=[n])
     >>> min_value = 0
-    >>> func = func = lambda x : tf.math.reduce_sum(np.power(x, 2) * coefficient)
+    >>> func = func = lambda x : tf.math.reduce_sum(np.power(x, 2) * \
+            coefficient)
     >>> # Optimize the function with SPSA, start with random parameters
     >>> result = tfq.optimizers.spsa_minimize(func, np.random.random(n))
     >>> result.converged
@@ -223,8 +225,8 @@ def minimize(expectation_value_function,
             state.num_objective_evaluations.assign_add(2)
 
             current_obj = expectation_value_function(state.position - update)
-            if state.objective_value_previous_iteration + state.allowed_increase \
-                >= current_obj or not state.blocking:
+            if state.objective_value_previous_iteration + \
+                state.allowed_increase >= current_obj or not state.blocking:
                 state.position.assign(state.position - update)
                 state.objective_value_previous_iteration.assign(
                     state.objective_value)

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """The SPSA minimization algorithm"""
 import collections
-import numpy as np
 import tensorflow as tf
 
 

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -191,8 +191,8 @@ def minimize(expectation_value_function,
         max_iterations = tf.convert_to_tensor(max_iterations,
                                               name='max_iterations')
 
-        a_init = tf.convert_to_tensor(a, name='initial a', dtype='float32')
-        c_init = tf.convert_to_tensor(c, name='initial c', dtype='float32')
+        a_init = tf.convert_to_tensor(a, name='initial_a', dtype='float32')
+        c_init = tf.convert_to_tensor(c, name='initial_c', dtype='float32')
     
 
         def _spsa_once(state):

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -260,8 +260,9 @@ def minimize(expectation_value_function,
             return [state]
 
             initial_state = _get_initial_state(initial_position, tolerance,
-                                           expectation_value_function, a, alpha,
-                                           c, gamma, blocking, allowed_increase)
+                                               expectation_value_function, a,
+                                               alpha, c, gamma, blocking,
+                                               allowed_increase)
 
         initial_state.objective_value.assign(
             expectation_value_function(initial_state.position))

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -82,9 +82,11 @@ SPSAOptimizerResults = collections.namedtuple(
         'gamma',
         # Specifies scaling of the size of the perturbations
         'blocking',
-        # If true, then the optimizer will only accept updates that improve the objective function.
+        # If true, then the optimizer will only accept updates that improve 
+        # the objective function.
         'allowed_increase'
-        # Specifies maximum allowable increase in objective function (only applies if blocking is true).
+        # Specifies maximum allowable increase in objective function 
+        # (only applies if blocking is true).
     ])
 
 
@@ -162,13 +164,13 @@ def minimize(expectation_value_function,
         a: Scalar `tf.Tensor` of real dtype. Specifies the learning rate
         alpha: Scalar `tf.Tensor` of real dtype. Specifies scaling of the
             learning rate.
-        c: Scalar `tf.Tensor` of real dtype. Specifies the size of the 
+        c: Scalar `tf.Tensor` of real dtype. Specifies the size of the
             perturbations.
         gamma: Scalar `tf.Tensor` of real dtype. Specifies scaling of the
             size of the perturbations.
         blocking: Boolean. If true, then the optimizer will only accept
-            updates that improve the objective function. 
-        allowed_increase: Scalar `tf.Tensor` of real dtype. Specifies maximum 
+            updates that improve the objective function.
+        allowed_increase: Scalar `tf.Tensor` of real dtype. Specifies maximum
             allowable increase in objective function (only applies if blocking
             is true).
         name: (Optional) Python `str`. The name prefixed to the ops created
@@ -210,15 +212,16 @@ def minimize(expectation_value_function,
                                       maxval=2,
                                       dtype=tf.int32) - 1, tf.float32)
 
-            v_m, v_p =  expectation_value_function(state.position - state.c * delta_shift),\
-                 expectation_value_function(state.position + state.c * delta_shift)
+            v_m =  expectation_value_function(state.position - state.c * delta_shift)
+            v_p = expectation_value_function(state.position + state.c * delta_shift)
 
             gradient_estimate = (v_p - v_m) / (2 * state.c) * delta_shift
             update = state.a * gradient_estimate
 
             current_obj = expectation_value_function(state.position - update)
             #state.position.assign(tf.math.floormod(state.position - update, 2* np.pi))
-            if state.num_objective_evaluations == 0 or state.objective_value_previous_iteration < current_obj + state.allowed_increase or not state.blocking:
+            if state.num_objective_evaluations == 0 or state.objective_value_previous_iteration \
+                < current_obj + state.allowed_increase or not state.blocking:
                 state.position.assign(state.position - update)
 
             state.num_objective_evaluations.assign_add(2)

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -221,7 +221,7 @@ def minimize(expectation_value_function,
             update = state.a * gradient_estimate
 
             current_obj = expectation_value_function(state.position - update)
-            # state.position.assign(tf.math.floormod(state.position - 
+            # state.position.assign(tf.math.floormod(state.position -
             #                                        update, 2* np.pi))
             if state.num_objective_evaluations == 0 or state.objective_value_previous_iteration \
                 < current_obj + state.allowed_increase or not state.blocking:

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -159,10 +159,10 @@ def minimize(expectation_value_function,
         tolerance: Scalar `tf.Tensor` of real dtype. Specifies the tolerance
             for the procedure. If the supremum norm between two iteration
             vector is below this number, the algorithm is stopped.
-        a: Scalar `tf.Tensor` of real dtype. Specifies the learning rate
+        lr: Scalar `tf.Tensor` of real dtype. Specifies the learning rate
         alpha: Scalar `tf.Tensor` of real dtype. Specifies scaling of the
             learning rate.
-        c: Scalar `tf.Tensor` of real dtype. Specifies the size of the
+        perturb: Scalar `tf.Tensor` of real dtype. Specifies the size of the
             perturbations.
         gamma: Scalar `tf.Tensor` of real dtype. Specifies scaling of the
             size of the perturbations.
@@ -171,6 +171,8 @@ def minimize(expectation_value_function,
         allowed_increase: Scalar `tf.Tensor` of real dtype. Specifies maximum
             allowable increase in objective function (only applies if blocking
             is true).
+        seed: (Optional) Python integer. Used to create a random seed for the
+            perturbations.
         name: (Optional) Python `str`. The name prefixed to the ops created
             by this function. If not supplied, the default name 'minimize'
             is used.
@@ -182,7 +184,9 @@ def minimize(expectation_value_function,
 
     with tf.name_scope(name or 'minimize'):
         if seed is not None:
-            tf.random.set_seed(seed)
+            generator = tf.random.Generator.from_seed(seed)
+        else:
+            generator = tf.random
 
         initial_position = tf.convert_to_tensor(initial_position,
                                                 name='initial_position',
@@ -210,7 +214,7 @@ def minimize(expectation_value_function,
                 states: A list which the first element is the new state
             """
             delta_shift = tf.cast(
-                2 * tf.random.uniform(shape=state.position.shape,
+                2 * generator.uniform(shape=state.position.shape,
                                       minval=0,
                                       maxval=2,
                                       dtype=tf.int32) - 1, tf.float32)

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -259,10 +259,10 @@ def minimize(expectation_value_function,
                 state.tolerance)
             return [state]
 
-            initial_state = _get_initial_state(initial_position, tolerance,
-                                               expectation_value_function, a,
-                                               alpha, c, gamma, blocking,
-                                               allowed_increase)
+        initial_state = _get_initial_state(initial_position, tolerance,
+                                           expectation_value_function, a,
+                                           alpha, c, gamma, blocking,
+                                           allowed_increase)
 
         initial_state.objective_value.assign(
             expectation_value_function(initial_state.position))

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -248,7 +248,6 @@ def minimize(expectation_value_function,
                  0.01 * tf.cast(max_iterations, tf.float32))**state.alpha)
             new_perturb = perturb_init / (tf.cast(state.num_iterations + 1,
                                                   tf.float32)**state.gamma)
- 
 
             state.lr.assign(new_lr)
             state.perturb.assign(new_perturb)

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
@@ -141,6 +141,7 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
 
         init = 1
         self.incr = 0
+
         def block_func1(params):
             self.incr += init
             return self.incr
@@ -158,6 +159,7 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
 
         init = 1 / 6 * 0.49
         self.incr = 0
+        
         def block_func2(params):
             self.incr += init
             return self.incr

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
@@ -93,7 +93,7 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         """
         func = lambda x: x[0]**2 + x[1]**2
 
-        result = spsa_minimizer(func, tf.random.uniform(shape=[2]))
+        result = spsa_minimizer.minimize(func, tf.random.uniform(shape=[2]))
         self.assertAlmostEqual(func(result.position).numpy(), 0, delta=1e-4)
         self.assertTrue(result.converged)
 
@@ -102,9 +102,9 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         """
         n = 2
         coefficient = tf.random.uniform(minval=0, maxval=1, shape=[n])
-        func = lambda x : tf.math.reduce_sum(np.power(x, 2) * coefficient)
+        func = lambda x: tf.math.reduce_sum(np.power(x, 2) * coefficient)
 
-        result = spsa_minimizer(func, tf.random.uniform(shape=[n]))
+        result = spsa_minimizer.minimize(func, tf.random.uniform(shape=[n]))
         self.assertAlmostEqual(func(result.position).numpy(), 0, delta=2e-4)
         self.assertTrue(result.converged)
 
@@ -112,19 +112,23 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         """Test noisy ssinusoidal function
         """
         n = 10
-        func = lambda x : tf.math.reduce_sum(tf.math.sin(x) + tf.random.uniform(minval=-0.1, maxval=0.1, shape=[n]))
+        func = lambda x: tf.math.reduce_sum(
+            tf.math.sin(x) + tf.random.uniform(
+                minval=-0.1, maxval=0.1, shape=[n]))
 
-        result = spsa_minimizer(func, tf.random.uniform(shape=[n]))
+        result = spsa_minimizer.minimize(func, tf.random.uniform(shape=[n]))
         self.assertLessEqual(func(result.position).numpy(), -n + 0.1 * n)
 
     def test_failure_optimization(self):
         """Test a function that is completely random and cannot be minimized
         """
         n = 100
-        func = lambda x : np.random.uniform(-10, 10, 1)[0]
+        func = lambda x: np.random.uniform(-10, 10, 1)[0]
         it = 50
 
-        result = spsa_minimizer(func, tf.random.uniform(shape=[n]), max_iterations=it)
+        result = spsa_minimizer(func,
+                                tf.random.uniform(shape=[n]),
+                                max_iterations=it)
         self.assertFalse(result.converged)
         self.assertEqual(result.num_iterations, it)
 
@@ -137,7 +141,7 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         params = sympy.symbols("q0:9")
         circuit = cirq.Circuit()
         for i in qubits:
-            circuit += cirq.ry(np.pi/4).on(i)
+            circuit += cirq.ry(np.pi / 4).on(i)
         circuit += cirq.ry(params[0]).on(qubits[0])
         circuit += cirq.ry(params[1]).on(qubits[1])
         circuit += cirq.rz(params[2]).on(qubits[2])
@@ -154,15 +158,21 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
             tf.keras.layers.Input(shape=(), dtype=tf.string),
             # The PQC layer returns the expected value of the
             # readout gate, range [-1,1].
-            pqc.PQC(circuit, cirq.Z(qubits[0]) * cirq.Z(qubits[1]), repetitions=1024),
+            pqc.PQC(circuit,
+                    cirq.Z(qubits[0]) * cirq.Z(qubits[1]),
+                    repetitions=1024),
         ])
 
-        initial_point = np.array(
-            [0.82311034, 0.02611798, 0.21077064, 0.61842177, 0.09828447, 0.62013131]
-        )
+        initial_point = np.array([
+            0.82311034, 0.02611798, 0.21077064, 0.61842177, 0.09828447,
+            0.62013131
+        ])
 
-        result = spsa_minimizer(loss_function_with_model_parameters(model, lambda x, y : x[0][0], 
-            util.convert_to_tensor([cirq.Circuit()]), None), initial_point, max_iterations=100)
+        result = spsa_minimizer(loss_function_with_model_parameters(
+            model, lambda x, y: x[0][0],
+            util.convert_to_tensor([cirq.Circuit()]), None),
+                                initial_point,
+                                max_iterations=100)
 
         self.assertTrue(result.converged)
         self.assertLess(result.objective_value.numpy(), -0.95)
@@ -211,7 +221,7 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         ])
 
         # Initial guess of the parameter from random number
-        result = spsa_minimizer(
+        result = spsa_minimizer.minimize(
             loss_function_with_model_parameters(model, tf.keras.losses.Hinge(),
                                                 x_circ, y),
             tf.random.uniform(shape=[2]) * 2 * np.pi)

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
@@ -91,7 +91,7 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         """
         func = lambda x: x[0]**2 + x[1]**2
 
-        result = spsa_minimizer(func, tf.random.uniform(shape=[2]))
+        result = spsa_minimizer.minimize(func, tf.random.uniform(shape=[2]))
         print(func(result.position))
         self.assertAlmostEqual(func(result.position).numpy(), 0, delta=1e-4)
         self.assertTrue(result.converged)
@@ -140,7 +140,7 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         ])
 
         # Initial guess of the parameter from random number
-        result = spsa_minimizer(
+        result = spsa_minimizer.minimize(
             loss_function_with_model_parameters(model, tf.keras.losses.Hinge(),
                                                 x_circ, y),
             tf.random.uniform(shape=[2]) * 2 * np.pi)

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
@@ -159,7 +159,7 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
 
         init = 1 / 6 * 0.49
         self.incr = 0
-        
+
         def block_func2(params):
             self.incr += init
             return self.incr

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
@@ -128,8 +128,8 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         it = 50
 
         result = spsa_minimizer.minimize(func,
-                                tf.random.uniform(shape=[n]),
-                                max_iterations=it)
+                                         tf.random.uniform(shape=[n]),
+                                         max_iterations=it)
         self.assertFalse(result.converged)
         self.assertEqual(result.num_iterations, it)
 
@@ -141,22 +141,33 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
 
         init = 1
         self.incr = 0
-        def func(params):
+        def block_func1(params):
             self.incr += init
             return self.incr
 
-        result = spsa_minimizer.minimize(func, tf.random.uniform(shape=[n]), blocking=True, allowed_increase=0.5, max_iterations=it)
+        result = spsa_minimizer.minimize(block_func1,
+                                         tf.random.uniform(shape=[n]),
+                                         blocking=True,
+                                         allowed_increase=0.5,
+                                         max_iterations=it)
         self.assertFalse(result.converged)
         self.assertEqual(result.num_iterations, it)
-        self.assertEqual(result.objective_value, init * 4) # function executd 3 (in step) + 1 (initial evaluation) times
+        self.assertEqual(
+            result.objective_value, init *
+            4)  # function executd 3 (in step) +
+            # 1 (initial evaluation) times
 
-        init = 1/6 * 0.49
+        init = 1 / 6 * 0.49
         self.incr = 0
-        def func(params):
+        def block_func2(params):
             self.incr += init
             return self.incr
 
-        result = spsa_minimizer.minimize(func, tf.random.uniform(shape=[n]), blocking=True, allowed_increase=0.5, max_iterations=it)
+        result = spsa_minimizer.minimize(block_func2,
+                                         tf.random.uniform(shape=[n]),
+                                         blocking=True,
+                                         allowed_increase=0.5,
+                                         max_iterations=it)
         self.assertFalse(result.converged)
         self.assertEqual(result.num_iterations, it)
         self.assertEqual(result.objective_value, init * 3 * it + init)
@@ -199,8 +210,8 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         result = spsa_minimizer.minimize(loss_function_with_model_parameters(
             model, lambda x, y: x[0][0],
             util.convert_to_tensor([cirq.Circuit()]), None),
-                                initial_point,
-                                max_iterations=100)
+                                         initial_point,
+                                         max_iterations=100)
 
         self.assertTrue(result.converged)
         self.assertLess(result.objective_value.numpy(), -0.95)

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
@@ -152,10 +152,9 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
                                          max_iterations=it)
         self.assertFalse(result.converged)
         self.assertEqual(result.num_iterations, it)
-        self.assertEqual(
-            result.objective_value, init *
-            4)  # function executd 3 (in step) +
-            # 1 (initial evaluation) times
+        self.assertEqual(result.objective_value,
+                         init * 4)  # function executd 3 (in step) +
+        # 1 (initial evaluation) times
 
         init = 1 / 6 * 0.49
         self.incr = 0

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
@@ -1,0 +1,154 @@
+# Copyright 2020 The TensorFlow Quantum Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Test module for tfq.python.optimizers.spsa_minimizer optimizer."""
+# Remove PYTHONPATH collisions for protobuf.
+# pylint: disable=wrong-import-position
+import sys
+NEW_PATH = [x for x in sys.path if 'com_google_protobuf' not in x]
+sys.path = NEW_PATH
+# pylint: enable=wrong-import-position
+
+from operator import mul
+from functools import reduce
+import numpy as np
+import tensorflow as tf
+from absl.testing import parameterized
+import cirq
+import sympy
+from tensorflow_quantum.python.layers.high_level import pqc
+from tensorflow_quantum.python import util
+from tensorflow_quantum.python.optimizers import spsa_minimizer
+
+def loss_function_with_model_parameters(model, loss, train_x, train_y):
+    """Create a new function that assign the model parameter to the model
+    and evaluate its value.
+
+    Args:
+        model : an instance of `tf.keras.Model` or its subclasses.
+        loss : a function with signature loss_value = loss(pred_y, true_y).
+        train_x : the input part of training data.
+        train_y : the output part of training data.
+
+    Returns:
+        A function that has a signature of:
+            loss_value = f(model_parameters).
+    """
+
+    # obtain the shapes of all trainable parameters in the model
+    shapes = tf.shape_n(model.trainable_variables)
+    count = 0
+    sizes = []
+
+    # Record the shape of each parameter
+    for shape in shapes:
+        n = reduce(mul, shape)
+        sizes.append(n)
+        count += n
+
+    # Function accept the parameter and evaluate model
+    @tf.function
+    def func(params):
+        """A function that can be used by tfq.optimizer.spsa_minimize.
+
+        Args:
+           params [in]: a 1D tf.Tensor.
+
+        Returns:
+            Loss function value
+        """
+
+        # update the parameters of the model
+        start = 0
+        for i, size in enumerate(sizes):
+            model.trainable_variables[i].assign(
+                tf.reshape(params[start:start + size], shape))
+            start += size
+
+        # evaluate the loss
+        loss_value = loss(model(train_x, training=True), train_y)
+        return loss_value
+
+    return func
+
+
+class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
+    """Tests for the SPSA optimization algorithm."""
+
+    def test_nonlinear_function_optimization(self):
+        """Test to optimize a non-linear function.
+        """
+        func = lambda x: x[0]**2 + x[1]**2
+
+        result = spsa_minimizer(func, tf.random.uniform(shape=[2]))
+        print(func(result.position))
+        self.assertAlmostEqual(func(result.position).numpy(), 0, delta=1e-4)
+        self.assertTrue(result.converged)
+
+
+    def test_keras_model_optimization(self):
+        """Optimizate a PQC based keras model."""
+
+        x = np.asarray([
+            [0, 0],
+            [0, 1],
+            [1, 0],
+            [1, 1],
+        ], dtype=float)
+
+        y = np.asarray([[-1], [1], [1], [-1]], dtype=np.float32)
+
+        def convert_to_circuit(input_data):
+            """Encode into quantum datapoint."""
+            values = np.ndarray.flatten(input_data)
+            qubits = cirq.GridQubit.rect(1, 2)
+            circuit = cirq.Circuit()
+            for i, value in enumerate(values):
+                if value:
+                    circuit.append(cirq.X(qubits[i]))
+            return circuit
+
+        x_circ = util.convert_to_tensor([convert_to_circuit(x) for x in x])
+
+        # Create two qubits
+        q0, q1 = cirq.GridQubit.rect(1, 2)
+
+        # Create an anzatz on these qubits.
+        a, b = sympy.symbols('a b')  # parameters for the circuit
+        circuit = cirq.Circuit(
+            cirq.rx(a).on(q0),
+            cirq.ry(b).on(q1), cirq.CNOT(control=q0, target=q1))
+
+        # Build the Keras model.
+        model = tf.keras.Sequential([
+            # The input is the data-circuit, encoded as a tf.string
+            tf.keras.layers.Input(shape=(), dtype=tf.string),
+            # The PQC layer returns the expected value of the
+            # readout gate, range [-1,1].
+            pqc.PQC(circuit, cirq.Z(q1)),
+        ])
+
+        # Initial guess of the parameter from random number
+        result = spsa_minimizer(
+            loss_function_with_model_parameters(model, tf.keras.losses.Hinge(),
+                                                x_circ, y),
+            tf.random.uniform(shape=[2]) * 2 * np.pi)
+
+        self.assertAlmostEqual(result.objective_value.numpy(), 0, delta=1e-4)
+        self.assertTrue(result.converged)
+
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
@@ -31,6 +31,7 @@ from tensorflow_quantum.python.layers.high_level import pqc
 from tensorflow_quantum.python import util
 from tensorflow_quantum.python.optimizers import spsa_minimizer
 
+
 def loss_function_with_model_parameters(model, loss, train_x, train_y):
     """Create a new function that assign the model parameter to the model
     and evaluate its value.
@@ -96,7 +97,6 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAlmostEqual(func(result.position).numpy(), 0, delta=1e-4)
         self.assertTrue(result.converged)
 
-
     def test_keras_model_optimization(self):
         """Optimizate a PQC based keras model."""
 
@@ -147,7 +147,6 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAlmostEqual(result.objective_value.numpy(), 0, delta=1e-4)
         self.assertTrue(result.converged)
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
SPSA is a common optimizer that plays a prominent role in many quantum optimization procedures. It already exists in other popular packages such as [qiskit](https://qiskit.org/documentation/stubs/qiskit.algorithms.optimizers.SPSA.html#qiskit.algorithms.optimizers.SPSA). Although there are external implementations (e.g. noisyopt), providing a built in version offers a number of advantages (not the least of which is ease of use). The code is short and not complex (and shares the same format as the rotosolve optimizer). I would also like to answer two question which may arise (and I had when implementing):

Why SPSA? 
There are a number of black box optimization algorithms; however, SPSA is probably one of most common in the field of quantum optimization. It is a go to optimizer for VQE (see https://www.nature.com/articles/nature23879) as it can be somewhat robust to noise and take O(1) forward passes independent of the number of parameters (unlike PS or other grad approaches). Additionally, the most common black box optimization package (scipy optimize minimize) does not include it. 

Why as an optimizer? 
Theoretically, the gradient approach SPSA uses could be implemented as a differentiator (just do the gradient estimation as a differentiation approach). However, I think there are two primary drawbacks to this. One, there is well documented knowledge about the hyperparameters to be used in SPSA (see https://ieeexplore.ieee.org/document/705889). If the gradient update was implemented as a differentiator, these would have to be incorporated into a TF optimizer somehow and would likely not be a friendly interface (adjusting how the differentiation is done, e.g. the perturbation parameter, during optimization external to the class doesn't sound good). Additionally, (and this may not actually be true, it is purely based on intuition and some toy examples), the noisy-ness of the gradient estimation (which is fine on average) may be problematic for hybrid systems (e.g. when using the gradients and backproping through) thus the optimizer more readily encourages non-hybrid systems. 

I recognize this is an unsolicited (if you will) PR so if this isn't something that is a desired inclusion it's fine, but I have been using SPSA extensively in qiskit and I think TFQ would benefit from its inclusion. This PR is a simple implementation I drafted this afternoon but there is room for advancements (e.g. second order approximations). 