### PR TITLE
constrain xticks in two plt figures

### DIFF
--- a/docs/tutorials/barren_plateaus.ipynb
+++ b/docs/tutorials/barren_plateaus.ipynb
@@ -354,6 +354,7 @@
         "plt.semilogy(n_qubits, theta_var)\n",
         "plt.title('Gradient Variance in QNNs')\n",
         "plt.xlabel('n_qubits')\n",
+        "plt.xticks(n_qubits)\n",
         "plt.ylabel('$\\\\partial \\\\theta$ variance')\n",
         "plt.show()"
       ]
@@ -482,6 +483,7 @@
         "plt.semilogy(n_qubits, heuristic_theta_var)\n",
         "plt.title('Heuristic vs. Random')\n",
         "plt.xlabel('n_qubits')\n",
+        "plt.xticks(n_qubits)\n",
         "plt.ylabel('$\\\\partial \\\\theta$ variance')\n",
         "plt.show()"
       ]


### PR DESCRIPTION
Since we only have data points at x=4, 6, 8, 10, and 12, it is better to get rid of the odd numbered ticks to avoid confusion.