### PR TITLE
Update nbconvert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@ cirq-core>=0.13.1
 cirq-google>=0.13.1
 sympy==1.8
 numpy==1.19.5  # TensorFlow can detect if it was built against other versions.
-nbconvert==5.6.1
-nbformat==4.4.0
 pylint==2.4.4
 yapf==0.28.0
 tensorflow==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ cirq-core>=0.13.1
 cirq-google>=0.13.1
 sympy==1.8
 numpy==1.19.5  # TensorFlow can detect if it was built against other versions.
+nbformat==4.4.0
 pylint==2.4.4
 yapf==0.28.0
 tensorflow==2.7.0

--- a/scripts/ci_validate_tutorials.sh
+++ b/scripts/ci_validate_tutorials.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 # Run the tutorials using the installed pip package
-pip install jupyter nbformat==4.4.0 nbconvert==5.5.0 jupyter-client==6.1.12 ipython==7.22.0
+pip install jupyter nbformat==4.4.0 nbconvert==6.4.3 jupyter-client==6.1.12 ipython==7.22.0
 # Workaround for ipykernel - see https://github.com/ipython/ipykernel/issues/422
 pip install ipykernel==5.1.1
 # OpenAI Gym pip package needed for the quantum reinforcement learning tutorial

--- a/scripts/ci_validate_tutorials.sh
+++ b/scripts/ci_validate_tutorials.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 # Run the tutorials using the installed pip package
-pip install jupyter nbformat==4.4.0 nbconvert==6.4.3 jupyter-client==6.1.12 ipython==7.22.0
+pip install jupyter nbconvert==6.4.3 jupyter-client==6.1.12 ipython==7.22.0
 # Workaround for ipykernel - see https://github.com/ipython/ipykernel/issues/422
 pip install ipykernel==5.1.1
 # OpenAI Gym pip package needed for the quantum reinforcement learning tutorial


### PR DESCRIPTION
Resolves #679 

Removed `nbconvert` from requirements since only used in `test_tutorials.py` called from `ci_validate_tutorials.sh`, while `nbformat` is additionally called from `format_ipynb.py`.