### PR TITLE
Fixing small documentation bug in tfq.layers.Sample

### DIFF
--- a/tensorflow_quantum/python/layers/circuit_executors/sample.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/sample.py
@@ -35,7 +35,7 @@ class Sample(tf.keras.layers.Layer):
     ...     q1 = cirq.GridQubit(1, 0)
     ...     circuit = cirq.Circuit(
     ...         cirq.X(q0),
-    ...         cirq.CNOT(q1)
+    ...         cirq.CNOT(q0, q1)
     ...     )
     ...
     ...     return circuit


### PR DESCRIPTION
The CNOT gate in the first example in tfq.layers.Sample has only 1 input (but needs 2)
![image](https://user-images.githubusercontent.com/42878312/162758413-62fde3f3-efaf-4036-9eba-bafb52559def.png)

This just adds the other input so it matches the diagram