### PR TITLE
Fix typo in Hello, many worlds

### DIFF
--- a/docs/tutorials/hello_many_worlds.ipynb
+++ b/docs/tutorials/hello_many_worlds.ipynb
@@ -786,7 +786,7 @@
         ")\n",
         "datapoint_circuits = tfq.convert_to_tensor([\n",
         "  noisy_preparation\n",
-        "] * 2)  # Make two copied of this circuit"
+        "] * 2)  # Make two copies of this circuit"
       ]
     },
     {


### PR DESCRIPTION
## Changes
Fixed typo of 'Make two copied of this circuit' to 'Make two copies of this circuit'