### PR TITLE
Documentation: Fix TF Quantum MNIST by adding arg names in Seaborn barplot

### DIFF
--- a/docs/tutorials/mnist.ipynb
+++ b/docs/tutorials/mnist.ipynb
@@ -1100,8 +1100,8 @@
         "cnn_accuracy = cnn_results[1]\n",
         "fair_nn_accuracy = fair_nn_results[1]\n",
         "\n",
-        "sns.barplot([\"Quantum\", \"Classical, full\", \"Classical, fair\"],\n",
-        "            [qnn_accuracy, cnn_accuracy, fair_nn_accuracy])"
+        "sns.barplot(x=[\"Quantum\", \"Classical, full\", \"Classical, fair\"],\n",
+        "            y=[qnn_accuracy, cnn_accuracy, fair_nn_accuracy])"
       ]
     }
   ],


### PR DESCRIPTION
Fixes build failure by specifying the `x` and `y` axis in `sns.barplot`.

From the API docs:

```
seaborn.barplot(data=None, *, x=None, y=None,...)
```
(reference: https://seaborn.pydata.org/generated/seaborn.barplot.html) 

LMKWYT @MichaelBroughton @MarkDaoust 