### PR TITLE
Force old version of numpy in `noise.ipynb`

### DIFF
--- a/docs/tutorials/noise.ipynb
+++ b/docs/tutorials/noise.ipynb
@@ -106,7 +106,7 @@
         "id": "J2CRbYRqrLdt"
       },
       "source": [
-        "!pip install tensorflow==2.7.0 tensorflow-quantum==0.7.2"
+        "!pip install tensorflow==2.7.0 tensorflow-quantum==0.7.2 'numpy<1.24'"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
This currently works in colab, but will break when it's updated, and breaks in the TF docs publishing infra.

The TFQ code is referencing NumPy's `np.float`, which is removed in v1.24. [Details here](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated). This is quick hack to get the docs working again.