### PR TITLE
update bazel version in install.md to 5.3.0 to work with TF v2.11.0

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -84,7 +84,7 @@ As noted in the TensorFlow
 guide, the <a href="https://bazel.build/" class="external">Bazel</a>
 build system will be required.
 
-Our latest source builds use TensorFlow 2.11.0. To ensure compatibility we use `bazel` version 5.1.0. To remove any existing version of Bazel:
+Our latest source builds use TensorFlow 2.11.0. To ensure compatibility we use `bazel` version 5.3.0. To remove any existing version of Bazel:
 
 <!-- common_typos_disable -->
 <pre class="devsite-click-to-copy">
@@ -92,13 +92,13 @@ Our latest source builds use TensorFlow 2.11.0. To ensure compatibility we use `
 </pre>
 <!-- common_typos_enable -->
 
-Download and install `bazel` version 5.1.0:
+Download and install `bazel` version 5.3.0:
 
 <!-- common_typos_disable -->
 <pre class="devsite-click-to-copy">
-  <code class="devsite-terminal">wget https://github.com/bazelbuild/bazel/releases/download/5.1.0/bazel_5.1.0-linux-x86_64.deb
+  <code class="devsite-terminal">wget https://github.com/bazelbuild/bazel/releases/download/5.3.0/bazel_5.3.0-linux-x86_64.deb
 </code>
-  <code class="devsite-terminal">sudo dpkg -i bazel_5.1.0-linux-x86_64.deb</code>
+  <code class="devsite-terminal">sudo dpkg -i bazel_5.3.0-linux-x86_64.deb</code>
 </pre>
 <!-- common_typos_enable -->
 


### PR DESCRIPTION
This PR accompanies #755

Updates the `docs/install.md` file to download bazel 5.3.0 instead of 5.1.0 which causes errors when building Tensorflow 2.11.0