### PR TITLE
[PR5/last from #774] Add use_cuquantum arg into PQC layers

### DIFF
--- a/tensorflow_quantum/python/layers/high_level/controlled_pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/controlled_pqc.py
@@ -128,6 +128,7 @@ class ControlledPQC(tf.keras.layers.Layer):
                  *,
                  repetitions=None,
                  backend='noiseless',
+                 use_cuquantum=False,
                  differentiator=None,
                  **kwargs):
         """Instantiate this layer.
@@ -153,6 +154,8 @@ class ControlledPQC(tf.keras.layers.Layer):
             `sampled_based` is True or it must inherit
             `cirq.sim.simulator.SimulatesExpectationValues` if `sample_based` is
             False.
+        use_cuquantum: Optional Python `bool` indicating whether or not to use
+            GPU ops
         differentiator: Optional `tfq.differentiator` object to specify how
             gradients of `model_circuit` should be calculated.
         """
@@ -235,10 +238,13 @@ class ControlledPQC(tf.keras.layers.Layer):
 
         if self._analytic:
             self._layer = expectation.Expectation(backend=backend,
-                                                  differentiator=differentiator)
+                                                  differentiator=differentiator,
+                                                  use_cuquantum=use_cuquantum)
         else:
             self._layer = sampled_expectation.SampledExpectation(
-                backend=backend, differentiator=differentiator)
+                backend=backend,
+                differentiator=differentiator,
+                use_cuquantum=use_cuquantum)
 
         self._append_layer = elementary.AddCircuit()
 

--- a/tensorflow_quantum/python/layers/high_level/noisy_controlled_pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/noisy_controlled_pqc.py
@@ -142,6 +142,7 @@ class NoisyControlledPQC(tf.keras.layers.Layer):
                  repetitions=None,
                  sample_based=None,
                  differentiator=None,
+                 use_cuquantum=False,
                  **kwargs):
         """Instantiate this layer.
 
@@ -163,6 +164,8 @@ class NoisyControlledPQC(tf.keras.layers.Layer):
             trajectory.
         differentiator: Optional `tfq.differentiator` object to specify how
             gradients of `model_circuit` should be calculated.
+        use_cuquantum: Optional `bool` indicating whether to use GPU for
+            simulation or not. Defaults to `False`. NOT IMPLEMENTED YET.
         """
         super().__init__(**kwargs)
         # Ingest model_circuit.
@@ -217,6 +220,11 @@ class NoisyControlledPQC(tf.keras.layers.Layer):
         # Ingest differentiator.
         if differentiator is None:
             differentiator = parameter_shift.ParameterShift()
+
+        # Use gpu not supported yet.
+        if use_cuquantum:
+            raise NotImplementedError("GPU support for noisy controlled PQC \
+                is not yet implemented.")
 
         # Ingest and promote sample based.
         if sample_based is None:

--- a/tensorflow_quantum/python/layers/high_level/noisy_pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/noisy_pqc.py
@@ -139,6 +139,7 @@ class NoisyPQC(tf.keras.layers.Layer):
             repetitions=None,
             sample_based=None,
             differentiator=None,
+            use_cuquantum=False,
             initializer=tf.keras.initializers.RandomUniform(0, 2 * np.pi),
             regularizer=None,
             constraint=None,
@@ -164,6 +165,8 @@ class NoisyPQC(tf.keras.layers.Layer):
             trajectory.
         differentiator: Optional `tfq.differentiator` object to specify how
             gradients of `model_circuit` should be calculated.
+        use_cuquantum: Python `bool` indicating whether to use GPU ops
+            (currently not supported/implemented).
         initializer: Optional `tf.keras.initializer` object to specify how the
             symbols in `model_circuit` should be initialized when creating
             the managed variables.
@@ -219,6 +222,11 @@ class NoisyPQC(tf.keras.layers.Layer):
         self._repetitions = tf.constant(
             [[repetitions for _ in range(len(operators))]],
             dtype=tf.dtypes.int32)
+
+        # Use gpu not supported yet.
+        if use_cuquantum:
+            raise NotImplementedError("GPU support for noisy PQC is not \
+                                      yet implemented.")
 
         # Ingest differentiator.
         if differentiator is None:

--- a/tensorflow_quantum/python/layers/high_level/pqc.py
+++ b/tensorflow_quantum/python/layers/high_level/pqc.py
@@ -137,6 +137,7 @@ class PQC(tf.keras.layers.Layer):
             *,
             repetitions=None,
             backend='noiseless',
+            use_cuquantum=False,
             differentiator=None,
             initializer=tf.keras.initializers.RandomUniform(0, 2 * np.pi),
             regularizer=None,
@@ -166,6 +167,8 @@ class PQC(tf.keras.layers.Layer):
             `cirq.sim.simulator.SimulatesExpectationValues` if analytic
             expectations are desired or `cirq.Sampler` if sampled expectations
             are desired.
+        use_cuquantum: Optional Python `bool` indicating whether or not to use
+            GPU ops.
         differentiator: Optional `tfq.differentiator` object to specify how
             gradients of `model_circuit` should be calculated.
         initializer: Optional `tf.keras.initializer` object to specify how the
@@ -248,10 +251,14 @@ class PQC(tf.keras.layers.Layer):
                             "cirq.sim.simulator.SimulatesExpectationValues.")
         if self._analytic:
             self._executor = expectation.Expectation(
-                backend=backend, differentiator=differentiator)
+                backend=backend,
+                differentiator=differentiator,
+                use_cuquantum=use_cuquantum)
         else:
             self._executor = sampled_expectation.SampledExpectation(
-                backend=backend, differentiator=differentiator)
+                backend=backend,
+                differentiator=differentiator,
+                use_cuquantum=use_cuquantum)
 
         self._append_layer = elementary.AddCircuit()
 


### PR DESCRIPTION
This PR is the last sub PR from #774 

- PQC and ControlledPQC : cuQuantum enabled.
- NoisyPQC and NoisyControlledPQC : not supported.