### PR TITLE
Adding parallelization to "tfq.convert_to_tensor" for performance (#336)

### DIFF
--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -329,11 +329,11 @@ def convert_to_tensor(items_to_convert, deterministic_proto_serialize=False):
                             "got: {}".format(curr_type, type(item)))
             
     with concurrent.futures.ProcessPoolExecutor() as executor:
-        tensored_items = list(executor.map(convert_item, items_to_convert,
+        items = list(executor.map(convert_item, items_to_convert,
                                            [None]*len(items_to_convert)))
 
     # This will catch impossible dimensions
-    return tf.convert_to_tensor(tensored_items)
+    return tf.convert_to_tensor(items)
 
 
 def _parse_single(item):

--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -329,11 +329,11 @@ def convert_to_tensor(items_to_convert, deterministic_proto_serialize=False):
                             "got: {}".format(curr_type, type(item)))
             
     with concurrent.futures.ProcessPoolExecutor() as executor:
-        items = list(executor.map(convert_item, items_to_convert,
+        tensored_items = list(executor.map(convert_item, items_to_convert,
                                            [None]*len(items_to_convert)))
 
     # This will catch impossible dimensions
-    return tf.convert_to_tensor(items)
+    return tf.convert_to_tensor(tensored_items)
 
 
 def _parse_single(item):


### PR DESCRIPTION
## Overview

Hi, this is a draft pull request for improving the `tfq.convert_to_tensor` function by adding parallelization (tensorflow#336). I'm confused about how the benchmarking suite works, so I am creating a draft pull request.  For parallelization, I made sure to follow the [Python documentation](https://docs.python.org/3.9/library/concurrent.futures.html) for `concurrent.futures` and used `ProcessPoolExecutor`.

Since the `convert_item` function is mostly CPU-bound and doesn't require heavy communication between processes, using `ProcessPoolExecutor` should provide a significant speed-up for large inputs.

I have simply added parallelization to the `tfq.convert_to_tensor` function and need help with benchmarking and testing.

## Changes

Parallelization: used `concurrent.futures.ProcessPoolExecutor` to parallelize the conversion of items. Each item in the list is processed independently, which allows for significant speedup for converting large lists of items.

Docstrings: the original function had informative docstrings that described the `tfq.convert_to_tensor` function. I made sure to keep most of it and only added the necessary changes and fixed typos.

## Concerns

I wasn't able to benchmark my changes or run unit tests. I tried my best to follow the [Contribution guidelines](https://github.com/tensorflow/quantum/blob/f56257bceb988b743790e1e480eac76fd036d4ff/CONTRIBUTING.md) but ran into a lot of errors with Bazel. I am still working on the issue and wanted to inform you that the code has not been benchmarked using the [Benchmark guidelines](https://github.com/tensorflow/quantum/tree/master/benchmarks). 

If the function needs to handle extremely deep nested lists, the `convert_item()` function may need to be iterative rather than recursive. However, the original author already made a comment to dismiss this concern.