### PR TITLE
update README.md with compatible versions for tfq

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ for Quantum Computing research that would not have otherwise been possible.
 
 See the [installation instructions](https://github.com/tensorflow/quantum/blob/master/docs/install.md).
 
+### Compatible Versions
+
+- The installations currently work with the following versions:
+    - Python 3.8.18
+    - Cirq 0.13.1
+    - Tensorflow 2.7.0
+    - Tensorflow Quantum 0.7.2
 
 ## Examples
 


### PR DESCRIPTION
Currently, due to a Google Colabs update, the libraries are not compatible with the current version of a few dependencies. This description in the README.md document includes compatible versions for the following packages: Cirq, Tensorflow, Python, and Tensorflow Quantum. 

The configuration was tested and successfully ran on a MacBook Air 1.6 GHz Dual-Core Intel Core i5 (macOS 14.0).