### PR TITLE
Minimum changes to make CI workflows work again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,23 +70,28 @@ jobs:
       - name: Full Library Test
         run: ./scripts/test_all.sh
 
-  leak-tests:
-    name: Memory Leak tests
-    runs-on: ubuntu-20.04
-    needs: [lint, format]
-
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.10'
-          architecture: 'x64'
-      - name: Install Bazel on CI
-        run: ./scripts/ci_install.sh
-      - name: Configure CI TF
-        run: echo "Y\n" | ./configure.sh
-      - name: Leak Test qsim and src
-        run: ./scripts/msan_test.sh
+  # 2024-11-30 [mhucka] temporarily turning off leak-tests because it produces
+  # false positives on GH that we can't immediately address. TODO: if updating
+  # TFQ to use Clang and the latest TF does not resolve this, find a way to
+  # skip the handful of failing tests and renable the rest of the msan tests.
+  #
+  # leak-tests:
+  #   name: Memory Leak tests
+  #   runs-on: ubuntu-20.04
+  #   needs: [lint, format]
+  #
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - uses: actions/setup-python@v1
+  #       with:
+  #         python-version: '3.10'
+  #         architecture: 'x64'
+  #     - name: Install Bazel on CI
+  #       run: ./scripts/ci_install.sh
+  #     - name: Configure CI TF
+  #       run: echo "Y\n" | ./configure.sh
+  #     - name: Leak Test qsim and src
+  #       run: ./scripts/msan_test.sh
 
   tutorials-test:
     name: Tutorial tests

--- a/.github/workflows/cirq_compatibility.yaml
+++ b/.github/workflows/cirq_compatibility.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   consistency:
     name: Nightly Compatibility
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1


### PR DESCRIPTION
The aim of this PR is to stop the current CI workflow failures in `ci.yaml` and `cirq_compatibility.yaml` (both in `.github/workflows/`).

In the case of the failure in `ci.yaml`, the change is only a stopgap measure: it disables the address sanitizer tests.  The failures happen when the workflow runners are updated from Ubuntu 16.04 to 20.04; this update is necessary because GitHub no longer offers the Ubuntu 16 runners.

After spending a ridiculous amount of time testing various combinations of TensorFlow, TensorFlow Quantum, and compiler toolchains on a more recent Linux, my conclusion is that the ASAN failures stem from differences in the toolchains used to produce the copy of TensorFlow 2.15.0 we get from PyPI, and what we get under Ubuntu 20 when compiling TFQ on GitHub. This conclusion comes from the fact if I build a local copy of TensorFlow 2.15.0, and then build TFQ against _that_, using Clang for everything, the ASAN failures go away.

Given that we can't build TensorFlow as part of this workflow (it takes 2 hours to build using 24 cores on a fast machine), it's not clear what can be done to resolve the ASAN failures correctly. So, I'm temporarily commenting out the leak tests in this workflow so that we can proceed on doing other updates and releasing a new version of TFQ. However, this needs to be revisited at some point.
