### PR TITLE
Fix warnings "target is both a rule and a file"

### DIFF
--- a/third_party/tf/tf_configure.bzl
+++ b/third_party/tf/tf_configure.bzl
@@ -195,7 +195,7 @@ def _tf_pip_impl(repository_ctx):
         repository_ctx,
         None,
         "",
-        "libtensorflow_framework.so",
+        "libtensorflow_framework_so",
         [tf_shared_library_path],
         ["_pywrap_tensorflow_internal.lib"  if _is_windows(repository_ctx) else "libtensorflow_framework.so"],
     )
@@ -206,7 +206,7 @@ def _tf_pip_impl(repository_ctx):
         repository_ctx,
         None,
         "",
-        "test_log_pb2.py",
+        "test_log_pb2_py",
         [tf_test_log_proto_path],
         ["test_log_pb2.py"],
     )


### PR DESCRIPTION
Bazel 6.5.0 complains about

```
(04:17:26) WARNING: ..../external/local_config_tf/BUILD:8216:8:
target 'libtensorflow_framework.so' is both a rule and a file;
please choose another name for the rule
(04:17:26) WARNING: ..../external/local_config_tf/BUILD:8226:8:
target 'test_log_pb2.py' is both a rule and a file;
please choose another name for the rule
```

(Note: I elided the long pathnames in the messages above by replacing them with '....'.) The warnings come from definitions in `third_party/tf/tf_configure.bzl` where the names of a couple of rules are `libtensorflow_framework.so` and `test_log_pb2.py`. Changing the names to `libtensorflow_framework_so` and `test_log_pb2_py` resolves the problem. Other names are possible, of course, but those seem like good choices in order to keep their meanings clear.