### PR TITLE
Label simulate_mps_test as external

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,17 @@ jobs:
       - name: Configure CI TF
         run: echo "Y\n" | ./configure.sh
       - name: Full Library Test
-        run: ./scripts/test_all.sh
+        run: |
+          bazel test -c opt \
+          --test_timeout_filters=-eternal \
+          --test_output=errors \
+          --experimental_repo_remote_exec \
+          --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=1" \
+          --cxxopt="-std=c++17" \
+          --cxxopt="-msse2" \
+          --cxxopt="-msse3" \
+          --cxxopt="-msse4" \
+          //tensorflow_quantum/...
 
   # 2024-11-30 [mhucka] temporarily turning off leak-tests because it produces
   # false positives on GH that we can't immediately address. TODO: if updating

--- a/tensorflow_quantum/core/ops/math_ops/BUILD
+++ b/tensorflow_quantum/core/ops/math_ops/BUILD
@@ -139,6 +139,7 @@ py_library(
 
 py_test(
     name = "simulate_mps_test",
+    timeout = "eternal",
     srcs = ["simulate_mps_test.py"],
     python_version = "PY3",
     deps = [


### PR DESCRIPTION
`simulate_mps_test` takes a long time to run, and when used as part of PR checks on GitHub, it impacts developer velocity. Labeling it will let us filter it out for PR checks, and still run them as part of another longer workflow.