### PR TITLE
Remove lint/format checks (will put in separate files)

### DIFF
--- a/.github/problem-matchers/pylint.json
+++ b/.github/problem-matchers/pylint.json
@@ -1,0 +1,32 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "pylint-error",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):(\\d+):\\s(([EF]\\d{4}):\\s.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    },
+    {
+      "owner": "pylint-warning",
+      "severity": "warning",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):(\\d+):\\s(([CRW]\\d{4}):\\s.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/check-c++-files.yaml
+++ b/.github/workflows/check-c++-files.yaml
@@ -1,0 +1,104 @@
+# Summary: TFQ continuous integration workflow for checking C++ files.
+# This workflow runs clang-formmat. It only examines C++ and Protobuf files.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: C++ & Protobuf file checks
+run-name: >
+  C++ & Protobuf lint & format checks for ${{github.event_name}}
+  by ${{github.triggering_actor}}
+
+env:
+  # Version of clang-format to use. Can be overridden with workflow_dispatch.
+  # Note: as of 2025-01-14, v. 18 is the latest available on GitHub, and you
+  # have to use Ubuntu 24 to get it.
+  clang_format_ver: '18'
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '**.cc'
+      - '**.h'
+      - '**.proto'
+
+  push:
+    paths:
+      - '**.cc'
+      - '**.h'
+      - '**.proto'
+
+# Cancel previously-started but still active workflow runs on the same branch.
+concurrency:
+  group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  format:
+    name: Check the format of C++ and Protobuf files
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Count how many git commits need to be fetched
+        id: commits
+        env:
+          commits: ${{toJson(github.event.commits)}}
+        run: |
+          printf "%s" "$commits" > ./commits.json
+          num_commits="$(jq length < ./commits.json)"
+          (( num_commits++ ))
+          jq 'sort_by(.timestamp)' < ./commits.json > ./sorted-commits.json
+          first=$(jq -r 'first | .id' < ./sorted-commits.json)
+          last=$(jq -r 'last | .id' < ./sorted-commits.json)
+          # shellcheck disable=SC2086
+          {
+          echo num_commits="$num_commits"
+          echo first_sha=$first
+          echo last_sha=$last
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check out a copy of the TFQ git repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{steps.commits.outputs.num_commits}}
+
+      - name: Run clang-format on C++ and Protobuf files
+        env:
+          first_sha: ${{steps.commits.outputs.first_sha}}
+          last_sha: ${{steps.commits.outputs.last_sha}}
+        run: |
+          set +e
+          set -x
+          # shellcheck disable=SC2086
+          # Get the commit that came before the set of commits in this event.
+          starting_sha=$(git rev-parse $first_sha^)
+          ending_sha=$last_sha
+          # Run git-clang-format on the range of commits in this event.
+          version="${{inputs.clang_format_ver || env.clang_format_ver}}"
+          git clang-format-$version -v --style google --diff \
+            "$starting_sha" "$ending_sha" > diff.out 2>&1
+          exit_code=$?
+          if (( exit_code == 1 )); then
+            # Write output both here and to the job summary.
+            TERM=xterm-color
+            bo=$'\e[1m'
+            bl=$'\e[38;5;117m'
+            rs=$'\e[0m'
+            hi="👋🏻"
+            u="https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+            echo "$hi ${bl}Visit $bo$u${rs}$bl for formatted diff output$rs $hi"
+            echo "::group::clang-format output"
+            cat diff.out
+            echo "::endgroup::"
+            # shellcheck disable=SC2006
+            {
+            echo "## Output from <code>clang-format</code> version $version"
+            echo ""
+            echo '```diff'
+            echo "$(< diff.out)"
+            echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit $exit_code

--- a/.github/workflows/check-python-files.yaml
+++ b/.github/workflows/check-python-files.yaml
@@ -1,0 +1,247 @@
+# Summary: TFQ continuous integration workflow for checking Python files.
+#
+# This workflow runs pylint and yapf. It only examines .py files. It reads the
+# requirements.txt file to find out the versions of pylint and yapf to
+# install, and uses caching to speed up the loading of the Python environment.
+# It can also be invoked manually using the "Run workflow" button on the page at
+# https://github.com/tensorflow/quantum/actions/workflows/lint-python-files.yaml
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: Python file checks
+run-name: >
+  Python lint & format checks for ${{github.event_name}}
+  by ${{github.triggering_actor}}
+
+env:
+  # Python version to use. Can be overridden when workflow dispatch is used.
+  python_ver: '3.10'
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '**.py'
+
+  push:
+    branches:
+      - main
+    paths:
+      - '**.py'
+
+  # Allow manual invocation, with options that might be useful for debugging.
+  workflow_dispatch:
+    inputs:
+      files:
+        description: "Files and/or directories to check:"
+        type: string
+      python_ver:
+        description: 'Python version:'
+        type: string
+      pylint_ver:
+        description: 'Pylint version:'
+        type: string
+      yapf_ver:
+        description: 'Yapf version:'
+        type: string
+
+# Cancel previously-started but still active workflow runs on the same branch.
+concurrency:
+  group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  setup:
+    name: Set up Python environment
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      cache_key: ${{steps.parameters.outputs.cache_key}}
+      cache_paths: ${{steps.parameters.outputs.cache_paths}}
+      files: ${{steps.files.outputs.files_to_check}}
+    steps:
+      - name: Check out a copy of the TFQ git repository
+        uses: actions/checkout@v4
+
+        # Note: setup-python has a cache facility, but we don't use it here
+        # because we want to cache more Python things than setup-python does.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{inputs.python_ver || env.python_ver}}
+
+      - name: Set cache parameters
+        id: parameters
+        run: |
+          key="${{github.workflow_ref}}-${{hashFiles('requirements.txt')}}"
+          echo "cache_key=$key" >> "$GITHUB_OUTPUT"
+          # The paths used for actions/cache need to be on separate lines.
+          # Constructing a multiline value for an output variable is awkward.
+          # shellcheck disable=SC2005
+          {
+          echo 'cache_paths<<EOF'
+          echo "$(pip cache dir)"
+          echo "${{env.pythonLocation}}"
+          echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Test if the cache already exists
+        uses: actions/cache@v4
+        id: check_cache
+        with:
+          lookup-only: true
+          key: ${{steps.parameters.outputs.cache_key}}
+          path: ${{steps.parameters.outputs.cache_paths}}
+
+      - if: steps.check_cache.outputs.cache-hit != 'true'
+        name: Set up the cache
+        uses: actions/cache@v4
+        id: restore_cache
+        with:
+          key: ${{steps.parameters.outputs.cache_key}}
+          path: ${{steps.parameters.outputs.cache_paths}}
+
+      - if: github.event_name != 'workflow_dispatch'
+        name: Get the list of Python files changed in the triggering event
+        id: changes
+        uses: tj-actions/changed-files@v45
+        # Although this workflow is triggered only if Python files are changed,
+        # they might not be the *only* files changed; hence, we have to filter
+        # the set of files down to just the Python files.
+        with:
+          files: |
+            **.py
+
+      - name: Determine the files to be checked
+        id: files
+        run: |
+          # Files/dirs given during manual invocation take precedence.
+          if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
+            if [[ -n "${{inputs.files}}" ]]; then
+              files="${{inputs.files}}"
+            else
+              echo "::error title=Error::No file names or directories provided."
+              exit 1
+            fi
+          else
+            files="${{steps.changes.outputs.all_changed_files}}"
+          fi
+          echo "files_to_check=$files" >> "$GITHUB_OUTPUT"
+
+      - if: steps.check_cache.outputs.cache-hit != 'true'
+        name: Determine the versions of Pylint and Yapf to use
+        id: req
+        run: |
+          # Get the pylint & yapf versions from requirements.txt.
+          # In case of multiple values in the file, the last one will win.
+          echo "pylint_version=" >> "$GITHUB_OUTPUT"
+          echo "yapf_version=" >> "$GITHUB_OUTPUT"
+          number_regex='[0-9]+(\.[0-9]+)?(\.[0-9]+)?'
+          while IFS= read -r line; do
+            if [[ $line =~ ^pylint.* ]]; then
+              if [[ $line =~ $number_regex ]]; then
+                version="${BASH_REMATCH[0]}"
+                echo "pylint_version=$version" >> "$GITHUB_OUTPUT"
+                continue
+              fi
+            fi
+            if [[ $line =~ ^yapf.* ]]; then
+              if [[ $line =~ $number_regex ]]; then
+                version="${BASH_REMATCH[0]}"
+                echo "yapf_version=$version" >> "$GITHUB_OUTPUT"
+                continue
+              fi
+            fi
+          done < "requirements.txt"
+          # If given versions in manual invocation, use them instead.
+          if [[ "${{inputs.pylint_ver}}" != "" ]]; then
+            echo "pylint_version=${{inputs.pylint_ver}}" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ "${{inputs.yapf_ver}}" != "" ]]; then
+            echo "yapf_version=${{inputs.yapf_ver}}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.check_cache.outputs.cache-hit != 'true'
+        name: Install Pylint and Yapf
+        run: |
+          python -m pip install pylint==${{steps.req.outputs.pylint_version}}
+          python -m pip install yapf==${{steps.req.outputs.yapf_version}}
+
+  lint:
+    name: Lint Python files
+    needs: setup
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out a copy of the TFQ git repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{inputs.python_ver || env.python_ver}}
+
+      - name: Restore the Python cache
+        uses: actions/cache@v4
+        with:
+          key: ${{needs.setup.outputs.cache_key}}
+          path: ${{needs.setup.outputs.cache_paths}}
+          fail-on-cache-miss: true
+
+      - name: Set up pylint output problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/pylint.json"
+
+      - name: Lint the changed Python files
+        run: |
+          pylint ${{needs.setup.outputs.files}}
+
+  format:
+    name: Check the format of Python files
+    needs: setup
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out a copy of the TFQ git repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{inputs.python_ver || env.python_ver}}
+
+      - name: Restore the Python cache
+        uses: actions/cache@v4
+        with:
+          key: ${{needs.setup.outputs.cache_key}}
+          path: ${{needs.setup.outputs.cache_paths}}
+          fail-on-cache-miss: true
+
+      - name: Run Yapf on the Python changed files
+        run: |
+          set +e
+          yapf --parallel --diff --style=google \
+            "${{needs.setup.outputs.files}}" > diff.out 2>&1
+          exit_code=$?
+          if [[ -s ./diff.out ]]; then
+            # Write output both here and to the job summary.
+            TERM=xterm-color
+            bo=$'\e[1m'
+            bl=$'\e[38;5;117m'
+            rs=$'\e[0m'
+            hi="👋🏻"
+            u="https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+            echo "$hi ${bl}Visit $bo$u${rs}$bl for formatted diff output$rs $hi"
+            echo "::group::Yapf output"
+            cat diff.out
+            echo "::endgroup::"
+            # shellcheck disable=SC2006
+            {
+            echo "## Output from <code>yapf</code>"
+            echo ""
+            echo '```diff'
+            echo "$(< diff.out)"
+            echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit $exit_code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,35 +4,6 @@ on: [pull_request]
 
 
 jobs:
-  lint:
-    name: Lint check
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.10'
-          architecture: 'x64'
-      - name: Install Lint tools
-        run: pip install --upgrade pip setuptools; pip install -r requirements.txt;
-      - name: Lint All
-        run: ./scripts/lint_all.sh
-
-  format:
-    name: Formatting check
-    runs-on: ubuntu-20.04
-
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.10'
-          architecture: 'x64'
-      - name: Install Format tools
-        run: pip install --upgrade pip setuptools; pip install -r requirements.txt; sudo apt-get install -y clang-format-6.0
-      - name: Format Check
-        run: ./scripts/format_check.sh
-
   wheel-build:
     name: Wheel test
     runs-on: ubuntu-20.04
@@ -55,7 +26,6 @@ jobs:
   bazel-tests:
     name: Library tests
     runs-on: ubuntu-20.04
-    needs: [lint, format]
 
     steps:
       - uses: actions/checkout@v1
@@ -78,7 +48,6 @@ jobs:
   # leak-tests:
   #   name: Memory Leak tests
   #   runs-on: ubuntu-20.04
-  #   needs: [lint, format]
   #
   #   steps:
   #     - uses: actions/checkout@v1
@@ -96,7 +65,7 @@ jobs:
   tutorials-test:
     name: Tutorial tests
     runs-on: ubuntu-20.04
-    needs: [lint, format, wheel-build]
+    needs: wheel-build
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
The current workflow puts all the checks in a single file. Using a single file is not necessary for some of the kinds of checks being done, and advantages can be gained by modularizing checks into separate files.

This pull request moves the lint & format checks from `ci.yaml` into new separate and modular workflows, and in addition, takes advantage of features of GitHub Actions and newer versions of the programs like `clang-format` to reduce the computation time needed by the workflows. Some of the features include:

- Trigger conditions are designed to invoke the workflows only if a pull request or push affects the relevant files. For example, the Python checks workflow is only triggered if the pull request or push affects `.py` files.

- Caching is used so that invocations usually don't need to do (for example) `pip install` every time. This makes invocation much faster.

- Colorized diff output (from `yapf` for Python and `clang-format` for C++) is displayed on the workflow summary page.

Upcoming pull requests will add additional checks workflows for other files, such as shell scripts, Markdow, and others.