### PR TITLE
Move CI lint/format checks into separate file

### DIFF
--- a/.github/workflows/ci-build-checks.yaml
+++ b/.github/workflows/ci-build-checks.yaml
@@ -2,37 +2,7 @@ name: Continuous Integration
 
 on: [pull_request]
 
-
 jobs:
-  lint:
-    name: Lint check
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.10'
-          architecture: 'x64'
-      - name: Install Lint tools
-        run: pip install --upgrade pip setuptools; pip install -r requirements.txt;
-      - name: Lint All
-        run: ./scripts/lint_all.sh
-
-  format:
-    name: Formatting check
-    runs-on: ubuntu-20.04
-
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.10'
-          architecture: 'x64'
-      - name: Install Format tools
-        run: pip install --upgrade pip setuptools; pip install -r requirements.txt; sudo apt-get install -y clang-format-6.0
-      - name: Format Check
-        run: ./scripts/format_check.sh
-
   wheel-build:
     name: Wheel test
     runs-on: ubuntu-20.04
@@ -55,7 +25,6 @@ jobs:
   bazel-tests:
     name: Library tests
     runs-on: ubuntu-20.04
-    needs: [lint, format]
 
     steps:
       - uses: actions/checkout@v1
@@ -78,7 +47,6 @@ jobs:
   # leak-tests:
   #   name: Memory Leak tests
   #   runs-on: ubuntu-20.04
-  #   needs: [lint, format]
   #
   #   steps:
   #     - uses: actions/checkout@v1
@@ -96,7 +64,7 @@ jobs:
   tutorials-test:
     name: Tutorial tests
     runs-on: ubuntu-20.04
-    needs: [lint, format, wheel-build]
+    needs: wheel-build
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci-file-checks.yaml
+++ b/.github/workflows/ci-file-checks.yaml
@@ -1,0 +1,34 @@
+name: CI file checks
+
+on: [pull_request]
+
+jobs:
+  lint:
+    name: Lint check
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.10'
+          architecture: 'x64'
+      - name: Install Lint tools
+        run: pip install --upgrade pip setuptools; pip install -r requirements.txt;
+      - name: Lint All
+        run: ./scripts/lint_all.sh
+
+  format:
+    name: Formatting check
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.10'
+          architecture: 'x64'
+      - name: Install Format tools
+        run: pip install --upgrade pip setuptools; pip install -r requirements.txt; sudo apt-get install -y clang-format-6.0
+      - name: Format Check
+        run: ./scripts/format_check.sh
+


### PR DESCRIPTION
This is the first PR in what will be several PRs to update and improve the CI checks workflows. This PR simply moves the lint & format checks to a new, separate workflow file (`ci-file-checks.yaml`) and renames `ci.yaml` to `ci-build-checks.yaml`. There are no functional changes, apart from adjusting the conditions of the build tests in `ci-build-checks.yaml` to not condition them on passing lint/format checks.

Lint/format checks are not a strictly necessary precondition to testing builds and doing unit tests, and running them in parallel affords a couple of advantages:

- Faster overall CI execution.
- Potential for more feedback. If a lint step fails, it doesn't necessarily mean that the code won't compile, and proceeding with the build tests gives devs as much feedback as possible.

There is of course the danger that the code changes won't compile, and the resulting build will be pointless (and possibly produce confusing error messages). I think devs will be smart enough to realize that if they see _both_ lint/format errors and build errors, they should fix the former first. In addition, we can tune the conditions in the builds so that they fail early.