### PR TITLE
Remove reference to non-existent directory

### DIFF
--- a/scripts/lint_all.sh
+++ b/scripts/lint_all.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 echo "Checking for lint in python code...";
-linting_outputs=$(pylint --rcfile .pylintrc ./tensorflow_quantum ./examples);
+linting_outputs=$(pylint --rcfile .pylintrc ./tensorflow_quantum);
 exit_code=$?
 if [ "$exit_code" == "0" ]; then
 	echo "Python linting complete!";


### PR DESCRIPTION
The `lint_all.sh` script invoked `pylint` with a couple of subdirectories, including `./examples`. However, that directory doesn't exist.

Apparently Pylint version 2.4.4 didn't complain about this, but later versions of Pylint do.