### PR TITLE
Update version of pylint to 3.3.3

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,131 +1,1014 @@
-[MASTER]
+# Summary: TFQ config file for Pylint versions 3.0 and above.
+# See https://pylint.readthedocs.io/ for info about options available.
 
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=.git,.github,.mypy_cache,.pytest_cache,__pycache__,docs,third_party
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.10
+
+# Discover python modules and packages in the file system subtree.
+recursive=yes
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+argument-rgx=[a-z_][a-z0-9_]{0,30}$
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+attr-rgx=[a-z_][a-z0-9_]{0,30}$
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          baz
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+function-rgx=[a-z_][a-z0-9_]{2,65}$
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _,
+           n,
+           m,
+           x,
+           y,
+           z
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=yes
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+method-rgx=[a-z_][a-z0-9_]{2,60}$
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+variable-rgx=[a-z_][a-z0-9_]{0,30}$
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=15
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=20
+
+# Maximum number of locals for function / method body.
+max-locals=35
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=5
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=30
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=70
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^(\s*(#\s*)?<?https?://\S+>?)$
+
+# Number of spaces of indent required inside a hanging or continued line.indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
 max-line-length=80
+
+# Maximum number of lines in a module.
+max-module-lines=10000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=new
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
 disable=all
-output-format=colorized
-score=no
-reports=no
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
 enable=
+#    abstract-class-instantiated,
+#    abstract-method,
+    access-member-before-definition,
+#    anomalous-backslash-in-string,
+    anomalous-unicode-escape-in-string,
+#    arguments-differ,
+    arguments-out-of-order,
+    arguments-renamed,
+    assert-on-string-literal,
     assert-on-tuple,
+    assigning-non-slot,
+    assignment-from-no-return,
+    assignment-from-none,
+#    attribute-defined-outside-init,
+    await-outside-async,
+    bad-chained-comparison,
+#    bad-classmethod-argument,
+    bad-except-order,
+    bad-exception-cause,
+    bad-file-encoding,
+    bad-format-character,
+    bad-format-string,
+    bad-format-string-key,
     bad-indentation,
-    bad-option-value,
+    bad-inline-option,
+    bad-mcs-classmethod-argument,
+    bad-mcs-method-argument,
+    bad-open-mode,
     bad-reversed-sequence,
+    bad-staticmethod-argument,
+    bad-str-strip-call,
+    bad-string-format-type,
     bad-super-call,
+    bad-thread-instantiation,
+#    bare-except,
+    bidirectional-unicode,
+    binary-op-exception,
+    boolean-datetime,
+    broad-exception-caught,
+    broad-exception-raised,
+    c-extension-no-member,
+    catching-non-exception,
+#    cell-var-from-loop,
+    chained-comparison,
+    class-variable-slots-conflict,
+    comparison-of-constants,
+    comparison-with-callable,
+    comparison-with-itself,
+    condition-evals-to-constant,
+    confusing-with-statement,
+    consider-iterating-dictionary,
     consider-merging-isinstance,
+    consider-swap-variables,
+    consider-using-dict-comprehension,
+#    consider-using-dict-items,
+#    consider-using-enumerate,
+#    consider-using-f-string,
+#    consider-using-from-import,
+    consider-using-generator,
+    consider-using-get,
+#    consider-using-in,
+    consider-using-join,
+    consider-using-max-builtin,
+    consider-using-min-builtin,
+    consider-using-set-comprehension,
+    consider-using-sys-exit,
+    consider-using-ternary,
+#    consider-using-with,
+    contextmanager-generator-missing-cleanup,
     continue-in-finally,
     cyclic-import,
     dangerous-default-value,
+    declare-non-slot,
+    deprecated-argument,
+    deprecated-attribute,
+    deprecated-class,
+    deprecated-decorator,
+    deprecated-method,
+#    deprecated-module,
+    deprecated-pragma,
+    dict-iter-missing-items,
+    disallowed-name,
     duplicate-argument-name,
+    duplicate-bases,
+    duplicate-code,
+    duplicate-except,
+#    duplicate-key,
+    duplicate-string-formatting-argument,
+    duplicate-value,
     empty-docstring,
+    eval-used,
+    exec-used,
     expression-not-assigned,
+    f-string-without-interpolation,
+    file-ignored,
+#    fixme,
+    forgotten-debug-statement,
+    format-combined-specification,
+    format-needs-mapping,
+#    format-string-without-interpolation,
     function-redefined,
+    global-at-module-level,
+#    global-statement,
+    global-variable-not-assigned,
+    global-variable-undefined,
+    implicit-flag-alias,
+    implicit-str-concat,
+    import-error,
+    import-outside-toplevel,
     import-self,
-    invalid-name,
-    relative-import,
     inconsistent-mro,
+    inconsistent-quotes,
+    inconsistent-return-statements,
+    inherit-non-class,
     init-is-generator,
+    invalid-all-format,
+    invalid-all-object,
+    invalid-bool-returned,
+    invalid-bytes-returned,
+    invalid-character-backspace,
+    invalid-character-carriage-return,
+    invalid-character-esc,
+    invalid-character-nul,
+    invalid-character-sub,
+    invalid-character-zero-width-space,
+    invalid-characters-in-docstring,
+    invalid-class-object,
+    invalid-enum-extension,
+    invalid-envvar-default,
+    invalid-envvar-value,
+    invalid-field-call,
+    invalid-format-index,
+    invalid-format-returned,
+    invalid-getnewargs-ex-returned,
+    invalid-getnewargs-returned,
+    invalid-hash-returned,
+    invalid-index-returned,
+    invalid-length-hint-returned,
+    invalid-length-returned,
+    invalid-metaclass,
+    invalid-name,
+    invalid-overridden-method,
+    invalid-repr-returned,
+    invalid-sequence-index,
+    invalid-slice-index,
+    invalid-slice-step,
+    invalid-slots,
+    invalid-slots-object,
+    invalid-star-assignment-target,
+    invalid-str-returned,
+    invalid-unary-operand-type,
+    invalid-unicode-codec,
+    isinstance-second-argument-not-valid-type,
+    keyword-arg-before-vararg,
+    kwarg-superseded-by-positional-arg,
     line-too-long,
+    literal-comparison,
+#    locally-disabled,
+    logging-format-interpolation,
+    logging-format-truncated,
+    logging-fstring-interpolation,
+    logging-not-lazy,
+    logging-too-few-args,
+    logging-too-many-args,
+    logging-unsupported-format,
     lost-exception,
-    missing-docstring,
+    method-cache-max-size-none,
+    method-check-failed,
+    method-hidden,
+    misplaced-bare-raise,
+    misplaced-format-function,
+    misplaced-future,
+    missing-class-docstring,
+#    missing-final-newline,
+    missing-format-argument-key,
+    missing-format-attribute,
+    missing-format-string-key,
+    missing-function-docstring,
     missing-kwoa,
-    mixed-indentation,
+    missing-module-docstring,
+    missing-parentheses-for-call-in-test,
+    missing-timeout,
+    mixed-format-string,
     mixed-line-endings,
+    modified-iterating-dict,
+    modified-iterating-list,
+    modified-iterating-set,
     multiple-imports,
+    multiple-statements,
+    named-expr-without-context,
+    nan-comparison,
+    nested-min-max,
+    no-classmethod-decorator,
+    no-else-break,
+#    no-else-continue,
+    no-else-raise,
     no-else-return,
-    not-callable,
+#    no-member,
+    no-method-argument,
+#    no-name-in-module,
+    no-self-argument,
+    no-staticmethod-decorator,
     no-value-for-parameter,
+    non-ascii-file-name,
+    non-ascii-module-import,
+    non-ascii-name,
+    non-iterator-returned,
+    non-parent-init-called,
+    non-str-assignment-to-dunder-name,
     nonexistent-operator,
+    nonlocal-and-global,
+    nonlocal-without-binding,
+    not-a-mapping,
+    not-an-iterable,
+    not-async-context-manager,
+    not-callable,
+    not-context-manager,
     not-in-loop,
+    notimplemented-raised,
+    overridden-final-method,
+    pointless-exception-statement,
     pointless-statement,
+    pointless-string-statement,
+    positional-only-arguments-expected,
+    possibly-unused-variable,
+    possibly-used-before-assignment,
+    potential-index-error,
+    preferred-module,
+    property-with-parameters,
+#    protected-access,
+#    raise-missing-from,
+    raising-bad-type,
+    raising-format-tuple,
+    raising-non-exception,
+    raw-checker-failed,
+    redeclared-assigned-name,
+    redefined-argument-from-local,
     redefined-builtin,
-    relative-import,
+    redefined-outer-name,
+    redefined-slots-in-subclass,
+    redundant-keyword-arg,
+    redundant-u-string-prefix,
+    redundant-unittest-assert,
+    reimported,
+    relative-beyond-top-level,
+    repeated-keyword,
     return-arg-in-generator,
+    return-in-finally,
     return-in-init,
     return-outside-function,
+    self-assigning-variable,
+    self-cls-assignment,
+    shadowed-import,
+    shallow-copy-environ,
+#    signature-differs,
+    simplifiable-condition,
+#    simplifiable-if-expression,
     simplifiable-if-statement,
+    simplify-boolean-expression,
+    single-string-used-for-slots,
+    singledispatch-method,
+    singledispatchmethod-function,
+    singleton-comparison,
+    star-needs-assignment-target,
+    stop-iteration-return,
+    subclassed-final-class,
+    subprocess-popen-preexec-fn,
+    subprocess-run-check,
+    super-init-not-called,
+    super-with-arguments,
+    super-without-brackets,
+#    superfluous-parens,
+#    suppressed-message,
     syntax-error,
+    too-few-format-args,
+    too-few-public-methods,
+    too-many-ancestors,
+#    too-many-arguments,
+    too-many-boolean-expressions,
+    too-many-branches,
+    too-many-format-args,
     too-many-function-args,
+    too-many-instance-attributes,
+    too-many-lines,
+    too-many-locals,
+    too-many-nested-blocks,
+#   too-many-positional-arguments,
+    too-many-public-methods,
+#    too-many-return-statements,
+    too-many-star-expressions,
+    too-many-statements,
+    trailing-comma-tuple,
+    trailing-newlines,
     trailing-whitespace,
+    truncated-format-string,
+    try-except-raise,
+    typevar-double-variance,
+    typevar-name-incorrect-variance,
+    typevar-name-mismatch,
+    unbalanced-dict-unpacking,
+    unbalanced-tuple-unpacking,
+    undefined-all-variable,
+    undefined-loop-variable,
     undefined-variable,
     unexpected-keyword-arg,
-    unhashable-dict-key,
+    unexpected-line-ending-format,
+    unexpected-special-method-signature,
+    ungrouped-imports,
+    unhashable-member,
+    unidiomatic-typecheck,
+    unknown-option-value,
+#    unnecessary-comprehension,
+    unnecessary-dict-index-lookup,
+    unnecessary-direct-lambda-call,
+    unnecessary-dunder-call,
+    unnecessary-ellipsis,
+#    unnecessary-lambda,
+#    unnecessary-lambda-assignment,
+    unnecessary-list-index-lookup,
+#    unnecessary-negation,
     unnecessary-pass,
+    unnecessary-semicolon,
+    unpacking-non-sequence,
     unreachable,
     unrecognized-inline-option,
-    unused-import,
-    unnecessary-semicolon,
+#    unspecified-encoding,
+    unsubscriptable-object,
+    unsupported-assignment-operation,
+    unsupported-binary-operation,
+    unsupported-delete-operation,
+    unsupported-membership-test,
+#    unused-argument,
+    unused-format-string-argument,
+    unused-format-string-key,
+#    unused-import,
+    unused-private-member,
     unused-variable,
     unused-wildcard-import,
+#    use-a-generator,
+#    use-dict-literal,
+    use-implicit-booleaness-not-comparison,
+#    use-implicit-booleaness-not-comparison-to-string,
+#    use-implicit-booleaness-not-comparison-to-zero,
+    use-implicit-booleaness-not-len,
+    use-list-literal,
+    use-maxsplit-arg,
+    use-sequence-for-iteration,
+#    use-symbolic-message-instead,
+    use-yield-from,
+#    used-before-assignment,
+    used-prior-global-declaration,
+    useless-else-on-loop,
+    useless-import-alias,
+    useless-object-inheritance,
+    useless-option-value,
+#    useless-parent-delegation,
+    useless-return,
+#    useless-suppression,
+    useless-with-lock,
+    using-assignment-expression-in-unsupported-version,
+    using-constant-test,
+    using-exception-groups-in-unsupported-version,
+    using-f-string-in-unsupported-version,
+    using-final-decorator-in-unsupported-version,
+    using-generic-type-syntax-in-unsupported-version,
+    using-positional-only-args-in-unsupported-version,
     wildcard-import,
+    wrong-exception-operation,
     wrong-import-order,
     wrong-import-position,
     wrong-spelling-in-comment,
-    wrong-spelling-in-docstrin,
-    wildcard-import,
-    yield-outside-function,
+    wrong-spelling-in-docstring,
+    yield-inside-async-function,
+    yield-outside-function
 
-# Ignore long lines containing urls or pylint directives.
-ignore-long-lines=^(\s*(#\s*)?<?https?://\S+>?)$
 
-# Include a hint for the correct naming format with invalid-name
-include-naming-hint=yes
+[METHOD_ARGS]
 
-# Regular expression matching correct function names
-function-rgx=[a-z_][a-z0-9_]{2,65}$
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
 
-# Naming hint for function names
-function-name-hint=[a-z_][a-z0-9_]{2,65}$
 
-# Regular expression matching correct variable names
-variable-rgx=[a-z_][a-z0-9_]{0,30}$
+[MISCELLANEOUS]
 
-# Naming hint for variable names
-variable-name-hint=[a-z_][a-z0-9_]{0,30}$
+# List of note tags to take in consideration, separated by a comma.
+#notes=FIXME,
+#      TODO
 
-# Regular expression matching correct constant names
-const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+# Regular expression of note tags to take in consideration.
+notes-rgx=
 
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
-# Regular expression matching correct attribute names
-attr-rgx=[a-z_][a-z0-9_]{0,30}$
+[REFACTORING]
 
-# Naming hint for attribute names
-attr-name-hint=[a-z_][a-z0-9_]{0,30}$
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
 
-# Regular expression matching correct argument names
-argument-rgx=[a-z_][a-z0-9_]{0,30}$
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
 
-# Naming hint for argument names
-argument-name-hint=[a-z_][a-z0-9_]{0,30}$
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
 
-# Regular expression matching correct class attribute names
-class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+[REPORTS]
 
-# Regular expression matching correct inline iteration names
-inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
 
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
 
-# Regular expression matching correct class names
-class-rgx=[A-Z_][a-zA-Z0-9]+$
+# Set the output format. Available formats are: text, parseable, colorized,
+# json2 (improved json format), json (old json format) and msvs (visual
+# studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+#output-format=
 
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
+# Tells whether to display a full report or only the messages.
+reports=no
 
-# Regular expression matching correct module names
-module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+# Activate the evaluation score.
+score=no
 
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
-# Regular expression matching correct method names
-method-rgx=[a-z_][a-z0-9_]{2,60}$
+[SIMILARITIES]
 
-# Naming hint for method names
-method-name-hint=[a-z_][a-z0-9_]{2,60}$
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=100
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=yes
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ cirq-google==1.3.0
 sympy==1.12
 numpy==1.24.2  # TensorFlow can detect if it was built against other versions.
 nbformat==5.1.3
-pylint==2.4.4
+pylint==3.3.3
 yapf==0.40.2
 tensorflow==2.15.0

--- a/scripts/lint_all.sh
+++ b/scripts/lint_all.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 echo "Checking for lint in python code...";
-linting_outputs=$(pylint --rcfile .pylintrc ./tensorflow_quantum ./examples);
+linting_outputs=$(pylint --rcfile .pylintrc ./tensorflow_quantum);
 exit_code=$?
 if [ "$exit_code" == "0" ]; then
 	echo "Python linting complete!";


### PR DESCRIPTION
This updates `requirements.txt` to use Pylint version 3.3.3 and also updates `.pylintrc` such that it's compatible with 3.3.3 yet does not raise any new warnings in the code base. The intention of this PR is to make only the minimal changes needed to use pylint 3.3.3.

The `.pylintrc` started life as the config file produced by pylint 3.3.3 with the `--generate-rcfile` option. I then compared it to the previous `.pylintrc` and adjusted the settings to match, followed by a long period of test-adjust-retest:

1. run `pylint` on the existing code base
2. look at the warnings, find the relevant flags & turn them off
3. if there are more warnings, go back to step 1

This `.pylintrc` file thus has a lot of pylint checkers commented out. We should systematically re-enable the checkers and fix the warnings in the code. However, that should be left to separate PRs. 