### PR TITLE
Update yapf to version 0.43.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ sympy==1.12
 numpy==1.24.2  # TensorFlow can detect if it was built against other versions.
 nbformat==5.1.3
 pylint==2.4.4
-yapf==0.40.2
+yapf==0.43.0
 tensorflow==2.15.0


### PR DESCRIPTION
Yapf version 0.43.0 seems to be entirely compatible with the previously-used version 0.40.2. Running it recursively on the codebase produced no output.