### PR TITLE
Fix issue #849: incorrect argument passed to test function

### DIFF
--- a/tensorflow_quantum/python/layers/high_level/noisy_controlled_pqc_test.py
+++ b/tensorflow_quantum/python/layers/high_level/noisy_controlled_pqc_test.py
@@ -146,7 +146,7 @@ class NoisyControlledPQCTest(tf.test.TestCase, parameterized.TestCase):
                                                         sample_based=False)
         self.assertEqual(layer.symbols, [a, b, c, d])
 
-    @parameterized.parameters([{'sample_based': True, 'sample_based': False}])
+    @parameterized.parameters([{'sample_based': True}, {'sample_based': False}])
     def test_controlled_pqc_simple_learn(self, sample_based):
         """Test a simple learning scenario using analytic and sample expectation
         on many backends."""


### PR DESCRIPTION
This fixes the incorrect `dict` being passed as an argument to the test function `test_controlled_pqc_simple_learn`, reported in issue #849.