### PR TITLE
Add new Trove classifier term for quantum computing

### DIFF
--- a/release/setup.py
+++ b/release/setup.py
@@ -109,6 +109,7 @@ setup(
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Scientific/Engineering :: Physics',
+        'Topic :: Scientific/Engineering :: Quantum Computing',
     ],
     license='Apache 2.0',
     keywords='tensorflow machine learning quantum qml',


### PR DESCRIPTION
PyPI now supports a classifier term for quantum computing.