### PR TITLE
Fix main → master branch name

### DIFF
--- a/.github/workflows/ci-build-checks.yaml
+++ b/.github/workflows/ci-build-checks.yaml
@@ -14,7 +14,7 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches:
-      - main
+      - master
 
   merge_group:
     types:
@@ -22,7 +22,7 @@ on:
 
   push:
     branches:
-      - main
+      - master
 
   # Allow manual invocation, with options that can be useful for debugging.
   workflow_dispatch:

--- a/.github/workflows/ci-file-checks.yaml
+++ b/.github/workflows/ci-file-checks.yaml
@@ -19,7 +19,7 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches:
-      - main
+      - master
 
   merge_group:
     types:
@@ -27,7 +27,7 @@ on:
 
   push:
     branches:
-      - main
+      - master
 
   # Allow manual invocation, with options that can be useful for debugging.
   workflow_dispatch:


### PR DESCRIPTION
I keep forgetting this repo uses `master`, not `main`.