### PR TITLE
Add some common repository files for GitHub best practices

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,31 @@
+# Reporting security issues
+
+The TensorFlow Quantum developers and community take security bugs in TensorFlow
+Quantum seriously. We appreciate your efforts to disclose your findings
+responsibly, and will make every effort to acknowledge your contributions.
+
+Please **do not** use GitHub issues to report security vulnerabilities; GitHub
+issues are public, and doing so could allow someone to exploit the information
+before the problem can be addressed. Instead, please use the GitHub ["Report a
+Vulnerability"](https://github.com/tensorflow/quantum/security/advisories/new)
+interface from the _Security_ tab of the TensorFlow Quantum repository.
+
+Please report security issues in third-party modules to the person or team
+maintaining the module rather than the TensorFlow Quantum project stewards,
+unless you believe that some action needs to be taken with TensorFlow Quantum in
+order to guard against the effects of a security vulnerability in a third-party
+module.
+
+## Responses to security reports
+
+The project stewards at Google Quantum AI will send a response indicating the
+next steps in handling your report. After the initial reply to your report, the
+project stewards will keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+## Additional points of contact
+
+Please contact the project stewards at Google Quantum AI via email at
+quantum-oss-maintainers@google.com if you have questions or other concerns. If
+for any reason you are uncomfortable reaching out to the project stewards,
+please email opensource@google.com.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,91 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+*   Using welcoming and inclusive language
+*   Being respectful of differing viewpoints and experiences
+*   Gracefully accepting constructive criticism
+*   Focusing on what is best for the community
+*   Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+*   The use of sexualized language or imagery and unwelcome sexual attention or
+    advances
+*   Trolling, insulting/derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or electronic
+    address, without explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a
+    professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+This Code of Conduct also applies outside the project spaces when the Project
+Stewards have a reasonable belief that an individual's behavior may have a
+negative impact on the project or its community.
+
+## Conflict Resolution
+
+We do not believe that all conflict is bad; healthy debate and disagreement
+often yield positive results. However, it is never okay to be disrespectful or
+to engage in behavior that violates the project’s Code of Conduct.
+
+If you see someone violating the Code of Conduct, you are encouraged to address
+the behavior directly with those involved. Many issues can be resolved quickly
+and easily, and this gives people more control over the outcome of their
+dispute. If you are unable to resolve the matter for any reason, or if the
+behavior is threatening or harassing, report it. We are dedicated to providing
+an environment where participants feel welcome and safe.
+
+Reports should be directed to quantumai-oss-maintainers@googlegroups.com,
+the project stewards at Google Quantum AI. They will then work with a committee
+consisting of representatives from the Open Source Programs Office and the
+Google Open Source Strategy team. If for any reason you are uncomfortable
+reaching out to the Project Stewards, please email opensource@google.com.
+
+We will investigate every complaint, but you may not receive a direct response.
+We will use our discretion in determining when and how to follow up on reported
+incidents, which may range from not taking action to permanent expulsion from
+the project and project-sponsored spaces. We will notify the accused of the
+report and provide them an opportunity to discuss it before any action is taken.
+The identity of the reporter will be omitted from the details of the report
+supplied to the accused. In potentially harmful situations, such as ongoing
+harassment or threats to anyone's safety, we may take action without notice.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4,
+available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,22 @@
+# Support
+
+Thank you for your interest in this project! If you are experiencing problems or
+have questions, the following are some suggestions for how to get help.
+
+> [!NOTE]
+> Before participating in our community, please read our [code of
+> conduct](CODE_OF_CONDUCT.md). By interacting with this repository,
+> organization, or community, you agree to abide by its terms.
+
+## Report an issue or request a feature
+
+To report an issue or request a feature in TensorFlow Quantum, please first
+search the [issue tracker on
+GitHub](https://github.com/tensorflow/quantum/issues) to check if there is
+already an open issue identical or similar to your bug report/feature request.
+If there is none, go ahead and file a new issue in the issue tracker.
+
+## Contact the maintainers
+
+For any questions or concerns not addressed here, please email
+[quantum-oss-maintainers@google.com](mailto:quantum-oss-maintainers@google.com).


### PR DESCRIPTION
This adds a security policy, code of conduct, and general support info, per GitHub and Google best practices.