### PR TITLE
Set default workflow permissions

### DIFF
--- a/.github/workflows/ci-build-checks.yaml
+++ b/.github/workflows/ci-build-checks.yaml
@@ -85,10 +85,13 @@ env:
     ^\.github/problem-matchers/.*
     ^benchmarks/.*
 
+# Cancel any previously-started but still active runs on the same branch.
 concurrency:
-  # Cancel any previously-started but still active runs on the same branch.
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+
+# Declare default permissions as read-only.
+permissions: read-all
 
 jobs:
   # Summary of basic strategy:

--- a/.github/workflows/ci-file-checks.yaml
+++ b/.github/workflows/ci-file-checks.yaml
@@ -65,10 +65,13 @@ env:
   # GitHub, and you have to use Ubuntu 24 to get it.
   clang_format_ver: '18'
 
+# Cancel any previously-started but still active runs on the same branch.
 concurrency:
-  # Cancel any previously-started but still active runs on the same branch.
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+
+# Declare default permissions as read-only.
+permissions: read-all
 
 jobs:
   Changes:

--- a/.github/workflows/ci-nightly-build-test.yaml
+++ b/.github/workflows/ci-nightly-build-test.yaml
@@ -49,10 +49,13 @@ env:
     test --test_timeout=6000
     test --test_verbose_timeout_warnings
 
+# Cancel any previously-started but still active runs on the same branch.
 concurrency:
-  # Cancel any previously-started but still active runs on the same branch.
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+
+# Declare default permissions as read-only.
+permissions: read-all
 
 jobs:
   Decision:

--- a/.github/workflows/ci-nightly-cirq-test.yaml
+++ b/.github/workflows/ci-nightly-cirq-test.yaml
@@ -64,10 +64,13 @@ env:
     build --verbose_failures
     test --test_timeout=3000
 
+# Cancel any previously-started but still active runs on the same branch.
 concurrency:
-  # Cancel any previously-started but still active runs on the same branch.
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+
+# Declare default permissions as read-only.
+permissions: read-all
 
 jobs:
   test-compatibility:


### PR DESCRIPTION
Per recommended security best practices, this explicitly sets the workflow default permissions.