### PR TITLE
Add missing yamllint config file

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,10 @@
+# Summary: yamllint configuration for TensorFlow Quantum.
+# See https://yamllint.readthedocs.io/ for info about configuration options.
+
+rules:
+  line-length:
+    # A common occurrence in YAML files is long URLs. The next two settings are
+    # not specific to URLs, but help. It saves developer time by not requiring
+    # comment directives to disable warnings at every occurrence.
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true


### PR DESCRIPTION
Somehow, my previous PRs for adding yamllint did not include the `.yamllintrc` file. Here it is.