### PR TITLE
Update runners to ubuntu-24.04 from deprecated ubuntu-20.04 label

### DIFF
--- a/.github/workflows/ci-nightly-build-test.yaml
+++ b/.github/workflows/ci-nightly-build-test.yaml
@@ -76,7 +76,7 @@ jobs:
     if: needs.Decision.outputs.run == 'true'
     name: Build and test
     needs: Decision
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     steps:
       - name: Check out a copy of the TFQ git repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This is a LSC run by http://go/ghss to upgrade all depreacated ubuntu-20.04 runners to ubuntu-24.04.

On April 1, 2025, GitHub will stop supporting ubuntu-20.04 runners and workflows configured with this label will cease to run.  This PR is an attempt to save you work by doing the upgrade for you.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it and deal with the problem yourselves.

More context and feedback: http://b/406537467
