### PR TITLE
Constrain numpy version to be less than 2.x

### DIFF
--- a/.github/workflows/ci-nightly-cirq-test.yaml
+++ b/.github/workflows/ci-nightly-cirq-test.yaml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Install the nightly build version of Cirq
         run: |
+          echo 'numpy<2.0.0' > constraint.txt
+          export PIP_CONSTRAINT=constraint.txt
           pip install -U cirq --pre
 
       - name: Configure Bazel options


### PR DESCRIPTION

Although the latest release of Cirq is compatible with NumPy 2, other
dependencies for TFQ are not, and this leads to failures at run-time.
For now, tell `pip` not to install NumPy 2.