### PR TITLE
Fix #884: use Python 3.11 in nightly Cirq pre-release compatibility test 

### DIFF
--- a/.github/workflows/ci-nightly-cirq-test.yaml
+++ b/.github/workflows/ci-nightly-cirq-test.yaml
@@ -22,10 +22,10 @@ on:
       py_version:
         description: Version of Python to use
         type: string
-        default: "3.10.15"
+        default: "3.11.9"
 
       bazel_version:
-        description: Version of Bazel Python to use
+        description: Version of Bazel to use
         type: string
 
       arch:
@@ -50,7 +50,7 @@ on:
 
 env:
   # Default Python version to use.
-  py_version: "3.10.15"
+  py_version: "3.11.9"
 
   # Bazel version. Note: this needs to match what is used in TF & TFQ.
   bazel_version: 6.5.0

--- a/.github/workflows/ci-nightly-cirq-test.yaml
+++ b/.github/workflows/ci-nightly-cirq-test.yaml
@@ -13,6 +13,11 @@ name: CI nightly Cirq compatibility test
 run-name: Continuous integration Cirq compatibility test
 
 on:
+  push:
+    paths:
+      - .github/workflows/ci-nightly-cirq-test.yaml
+
+
   schedule:
     - cron: "10 7 * * *"
 

--- a/.github/workflows/ci-nightly-cirq-test.yaml
+++ b/.github/workflows/ci-nightly-cirq-test.yaml
@@ -15,8 +15,7 @@ run-name: Continuous integration Cirq compatibility test
 on:
   push:
     paths:
-      - .github/workflows/ci-nightly-cirq-test.yaml
-
+      - '.github/workflows/ci-nightly-cirq-test.yaml'
 
   schedule:
     - cron: "10 7 * * *"


### PR DESCRIPTION
The Python `typing` package changed in at least one respect between Python 3.10 and 3.11: in 3.10, it did not have the symbol `Self`). Cirq 1.6+ assumes that the `Self` is defined by importing `typing`, and fails in Python 3.10. This leads to the error seen in the CI runs

https://github.com/tensorflow/quantum/actions/runs/17288698138/job/49070859286

```
ImportError: cannot import name 'Self' from 'typing'
```

Since Cirq 1.6 requires Python 3.11 anyway, this workflow (for testing against the Cirq pre-release) should probably use 3.11. Doing so avoids the problem.

An additional change in this PR is to make this workflow trigger on pushes that affect this workflow file, so that the results of edits to the workflow can be seen immediately during development.