### PR TITLE
Fix #887: pass a list to random.sample()

### DIFF
--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -113,7 +113,7 @@ def _apply_random_control(gate, all_qubits):
     if n_open == 0:
         # No open qubits to control. Return unmodified gate.
         return gate
-    control_locs = random.sample(open_qubits, n_open)
+    control_locs = random.sample(list(open_qubits), n_open)
     control_values = random.choices([0, 1], k=n_open)
     # TODO(tonybruguier,#636): Here we call the parent's class controlled_by
     # because Cirq's breaking change #4167 created 3-qubit gates that cannot be


### PR DESCRIPTION
Using a set in a call to the `sample(…)` method from the Python `random` standard library has been deprecated since Python 3.9, and in Python 3.11, it causes an error. This was happening in the function `util.py:_apply_random_control(…)` starting on line 111. Changing the set to a list in the call is probably the most efficient way of addressing this compatibility problem, and is backward-compatible with Python versions prior to 3.11.

I searched but could not find another place where a set was being passed to `sample()`. (There are other calls to `random.sample()`, but none involve sets, as far as I have been able to determine.)