### PR TITLE
Set GH_REPO for the `gh` CLI tool

### DIFF
--- a/.github/workflows/ci-build-checks.yaml
+++ b/.github/workflows/ci-build-checks.yaml
@@ -120,6 +120,7 @@ jobs:
         id: files
         env:
           GH_TOKEN: ${{github.token}}
+          GH_REPO: ${{github.repository}}
         # Note that this approach doesn't need to check out a copy of the repo.
         run: |
           set -x +e
@@ -232,6 +233,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_REPO: ${{github.repository}}
         run: |
           key="${{steps.parameters.outputs.python_cache_key}}"
           gh extension install actions/gh-actions-cache

--- a/.github/workflows/ci-file-checks.yaml
+++ b/.github/workflows/ci-file-checks.yaml
@@ -87,6 +87,7 @@ jobs:
         name: Use the user-provided SHA as the basis for comparison
         env:
           GH_TOKEN: ${{github.token}}
+          GH_REPO: ${{github.repository}}
         run: |
           set -x +e
           url="repos/${{github.repository}}/commits/${{inputs.sha}}"
@@ -181,6 +182,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_REPO: ${{github.repository}}
         run: |
           key="${{steps.parameters.outputs.cache_key}}"
           gh extension install actions/gh-actions-cache


### PR DESCRIPTION
Unless executed in a git repository, `gh` no longer seems to get information about the current repo where it's executing, which leads to failures like the one in #889. A simple solution is to set the `$GH_TOKEN` environment variable, which `gh` uses if it's defined.