### PR TITLE
Fix random.sample() usage with set for Python 3.11 compatibility (GH#887)

### DIFF
--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -113,7 +113,7 @@ def _apply_random_control(gate, all_qubits):
     if n_open == 0:
         # No open qubits to control. Return unmodified gate.
         return gate
-    control_locs = random.sample(open_qubits, n_open)
+    control_locs = random.sample(list(open_qubits), n_open)
     control_values = random.choices([0, 1], k=n_open)
     # TODO(tonybruguier,#636): Here we call the parent's class controlled_by
     # because Cirq's breaking change #4167 created 3-qubit gates that cannot be


### PR DESCRIPTION
This PR resolves a compatibility issue with Python 3.11 and above, where passing a set directly to random.sample() raises a TypeError.

In util.py, the open_qubits set is now explicitly converted to a list before being passed to random.sample() in the _apply_random_control function.

Audit of other random.sample() calls in util.py:  No changes needed

Line 150: qubits is expected to be a list or tuple .
`locs = tuple(random.sample(qubits, n_qubits))`

Line 199: Same as above, qubits is a tuple. 
`locs = tuple(random.sample(qubits, n_qubits))`

Line 253: qubits is a list. 
`this_term_qubits = random.sample(qubits, term_length)`

Line 255: paulis is a list. 
`[random.sample(paulis,1)[0] for _ in range(term_length)]`

Please let me know if this fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou!
