### PR TITLE
Support merge queues for CI workflows

### DIFF
--- a/.github/workflows/ci-build-checks.yaml
+++ b/.github/workflows/ci-build-checks.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 The TensorFlow Quantum Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: 'CI: build & test'
 run-name: Continuous integration build and test
 

--- a/.github/workflows/ci-build-checks.yaml
+++ b/.github/workflows/ci-build-checks.yaml
@@ -1,8 +1,14 @@
 name: 'CI: build & test'
 run-name: Continuous integration build and test
 
+on:
+  pull_request:
+    branches:
+      - master
 
-on: [pull_request]
+  merge_group:
+    types:
+      - checks_requested
 
 jobs:
   wheel-build:

--- a/.github/workflows/ci-file-checks.yaml
+++ b/.github/workflows/ci-file-checks.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 The TensorFlow Quantum Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Summary: TFQ continuous integration workflow for static code analysis.
 #
 # This workflow runs linters and code format/style checkers on certain events
@@ -10,7 +24,6 @@
 # workflow summary to make it easier to learn the outcome. Finally, It can be
 # invoked manually using the "Run workflow" button on the page at
 # https://github.com/tensorflow/quantum/actions/workflows/ci-file-checks.yaml
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 name: 'CI: lint & check formating'
 run-name: Continuous integration lint and format checks

--- a/.github/workflows/ci-nightly-build-test.yaml
+++ b/.github/workflows/ci-nightly-build-test.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 The TensorFlow Quantum Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Summary: TFQ nightly full build & test.
 #
 # This workflow compiles TFQ and runs all test cases, to verify everything
@@ -12,7 +26,7 @@
 #
 # This workflow also can be invoked manually via the "Run workflow" button at
 # https://github.com/tensorflow/quantum/actions/workflows/ci-build-checks.yaml
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 # yamllint disable rule:line-length
 
 name: CI nightly full test

--- a/.github/workflows/ci-nightly-cirq-test.yaml
+++ b/.github/workflows/ci-nightly-cirq-test.yaml
@@ -1,13 +1,26 @@
+# Copyright 2025 The TensorFlow Quantum Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Summary: GitHub CI workflow for testing TFQ against Cirq releases
 #
 # This workflow is executed every night on a schedule. By default, this
 # workflow will save Bazel build artifacts if an error occurs during a run.
-#
 # For testing, this workflow can be invoked manually from the GitHub page at
 # https://github.com/tensorflow/quantum/actions/workflows/ci-nightly-cirq-test.yaml
 # Clicking the "Run workflow" button there will present a form interface with
 # options for overridding some of the parameters for the run.
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 # yamllint disable rule:line-length
 
 name: CI nightly Cirq compatibility test


### PR DESCRIPTION
This adds support for GitHub [merge queues](https://github.blog/news-insights/product-news/github-merge-queue-is-generally-available/). Merge queues help make sure a pull request is compatible with other changes ahead of it. It's being used in Quantumlib projects successfully.

This PR also adds missing copyright headers to the workflow files.