### PR TITLE
Fix #884 by avoiding using `--pre` with pip install in nightly Cirq compatibility checks

### DIFF
--- a/.github/workflows/ci-nightly-cirq-test.yaml
+++ b/.github/workflows/ci-nightly-cirq-test.yaml
@@ -95,7 +95,7 @@ jobs:
         run: |
           echo 'numpy<2.0.0' > constraint.txt
           export PIP_CONSTRAINT=constraint.txt
-          pip install -U cirq --pre
+          pip install --upgrade cirq~=1.0.dev
 
       - name: Configure Bazel options
         run: |


### PR DESCRIPTION
It turns out the pip `--pre` flag carries over to other packages that get installed as transitive dependencies. This can cause unexpected compatibility issues. We can avoid using `--pre` by switching to using `cirq~=1.0.dev`, which is more limited in its scope and gets us the latest dev version. Doing so ends up resolving issue #884.