### PR TITLE
Fix #891: add default workflow permissions

### DIFF
--- a/.github/workflows/ci-build-checks.yaml
+++ b/.github/workflows/ci-build-checks.yaml
@@ -4,6 +4,8 @@ run-name: Continuous integration build and test
 
 on: [pull_request]
 
+permissions: read-all
+
 jobs:
   wheel-build:
     name: Wheel test

--- a/.github/workflows/ci-file-checks.yaml
+++ b/.github/workflows/ci-file-checks.yaml
@@ -70,6 +70,8 @@ concurrency:
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
 
+permissions: read-all
+
 jobs:
   Changes:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci-nightly-build-test.yaml
+++ b/.github/workflows/ci-nightly-build-test.yaml
@@ -55,6 +55,8 @@ concurrency:
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
 
+permissions: read-all
+
 jobs:
   Decision:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci-nightly-cirq-test.yaml
+++ b/.github/workflows/ci-nightly-cirq-test.yaml
@@ -70,6 +70,8 @@ concurrency:
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
 
+permissions: read-all
+
 jobs:
   test-compatibility:
     name: Run TFQ tests


### PR DESCRIPTION
This adds default workflow permissions declarations to all the workflows, to satisfy the CodeQL scanner.