### PR TITLE
Add Scorecard and OSV security scanning workflows 

### DIFF
--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -1,0 +1,153 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Summary: run the Open Source Vulnerabilities scanner on PRs & weekly.
+#
+# The OSV scanner is a dependency vulnerability scanner that identifies known
+# vulnerabilities in a project's dependencies. It supports C/C++, Python, Java,
+# JavaScript, and others. The findings are reported in the repo's code-scanning
+# results page, https://github.com/quantumlib/REPO/security/code-scanning/.
+# For more OSV scanner examples and options, including how to ignore specific
+# vulnerabilities, see https://google.github.io/osv-scanner/github-action/.
+
+name: OSV vulnerabilities scan
+run-name: Run open-source vulnerabilities (OSV) scanner
+
+on:
+  schedule:
+    # Run weekly on Saturdays.
+    - cron: '30 10 * * 6'
+
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+      - master
+
+  # Support merge queues.
+  merge_group:
+    types:
+      - checks_requested
+
+  # Allow manual invocation.
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Run with debugging options'
+        type: boolean
+        default: true
+
+concurrency:
+  # Cancel any previously-started but still active runs on the same branch.
+  cancel-in-progress: true
+  group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+
+# Declare default workflow permissions as read only.
+permissions: read-all
+
+jobs:
+  osv-scan:
+    if: github.repository_owner == 'quantumlib'
+    name: OSV scanner
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      # Needed to upload the results to code-scanning dashboard:
+      security-events: write
+    env:
+      # Setting Bash SHELLOPTS here takes effect for all shell commands below.
+      SHELLOPTS: ${{inputs.debug && 'xtrace' || '' }}
+    steps:
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Check out the target branch
+        run: |
+          git checkout ${{github.base_ref || github.ref_name}}
+          git submodule update --recursive
+
+      - name: Run OSV scanner on existing code
+        # yamllint disable rule:line-length
+        uses: google/osv-scanner-action/osv-scanner-action@b00f71e051ddddc6e46a193c31c8c0bf283bf9e6 # v2.1.0
+        continue-on-error: true
+        with:
+          scan-args: |-
+            --include-git-root
+            --format=json
+            --output=old-results.json
+            --recursive
+            ./
+
+      - name: Check out current branch
+        # Use -f in case any changes were made by osv-scanner.
+        run: |
+          git checkout -f "$GITHUB_SHA"
+          git submodule update --recursive
+
+      - name: Run OSV scanner on new code
+        # yamllint disable rule:line-length
+        uses: google/osv-scanner-action/osv-scanner-action@b00f71e051ddddc6e46a193c31c8c0bf283bf9e6 # v2.1.0
+        continue-on-error: true
+        with:
+          scan-args: |-
+            --include-git-root
+            --format=json
+            --output=new-results.json
+            --recursive
+            ./
+
+      - name: Run the OSV scanner reporter for the job summary page
+        # yamllint disable rule:line-length
+        uses: google/osv-scanner-action/osv-reporter-action@b00f71e051ddddc6e46a193c31c8c0bf283bf9e6 # v2.1.0
+        with:
+          scan-args: |-
+            --output=markdown:output.md
+            --old=old-results.json
+            --new=new-results.json
+            --fail-on-vuln=false
+
+      - name: Write the results to the job summary page
+        run: cat output.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run the OSV scanner reporter for the code-scanning dashboard
+        # yamllint disable rule:line-length
+        uses: google/osv-scanner-action/osv-reporter-action@b00f71e051ddddc6e46a193c31c8c0bf283bf9e6 # v2.1.0
+        with:
+          scan-args: |-
+            --output=osv-results.sarif
+            --old=old-results.json
+            --new=new-results.json
+            --gh-annotations=true
+            --fail-on-vuln=true
+
+      - name: Upload results to the repository's code-scanning results dashboard
+        id: upload_artifact
+        # yamllint disable rule:line-length
+        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+        with:
+          sarif_file: osv-results.sarif
+
+      - if: github.event.inputs.debug == true
+        name: Upload results as artifacts to the workflow Summary page
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: osv-results.sarif
+          retention-days: 5
+
+      - name: Error troubleshooter
+        if: ${{always() && steps.upload_artifact.outcome == 'failure'}}
+        run: echo '::error::Artifact upload failed. Check the workflow logs.'

--- a/.github/workflows/scorecard-scanner.yaml
+++ b/.github/workflows/scorecard-scanner.yaml
@@ -1,0 +1,109 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Summary: run the OSSF Scorecard scanner on PRs and every night.
+#
+# Scorecard (https://github.com/ossf/scorecard) is a repository-scanning tool
+# that evaluates a project's security practices. Its use is suggested by
+# Google's GitHub team. Scorecard's findings are reported in a repo's scanning
+# results page, https://github.com/quantumlib/REPO/security/code-scanning/.
+
+name: Scorecard analysis
+run-name: Run Scorecard scanner for security best practices
+
+on:
+  schedule:
+    # Run weekly on Saturdays.
+    - cron:  '30 9 * * 6'
+
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+      - master
+
+  # Support merge queues.
+  merge_group:
+    types:
+      - checks_requested
+
+  # Allow manual invocation.
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Run with debugging options'
+        type: boolean
+        default: true
+
+concurrency:
+  # Cancel any previously-started but still active runs on the same branch.
+  cancel-in-progress: true
+  group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+
+# Declare default workflow permissions as read only.
+permissions: read-all
+
+jobs:
+  run-scorecard:
+    if: github.repository_owner == 'quantumlib'
+    name: Scorecard analyzer
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+      id-token: write
+    timeout-minutes: 15
+    steps:
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
+        with:
+          # Save the results
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          # See https://github.com/ossf/scorecard-action#publishing-results.
+          publish_results: true
+
+      - name: Upload results to code-scanning dashboard
+        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+        with:
+          sarif_file: scorecard-results.sarif
+
+      - if: github.event.inputs.debug == true
+        name: Upload results as artifacts to the workflow Summary page
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: Scorecard SARIF file
+          path: scorecard-results.sarif
+          retention-days: 5
+
+  # Scorecard currently (ver. 2.4.x) doesn't allow submissions from jobs having
+  # steps that use "run:". To print to the summary, we need to use another job.
+  write-summary:
+    name: Scorecard results
+    needs: run-scorecard
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Write the Scorecard report page link to the workflow summary
+        run: |
+          repo="${{github.repository}}"
+          url="https://scorecard.dev/viewer/?uri=github.com/${repo}"
+          {
+          echo -n "The results are available on the OpenSSF Scorecard "
+          echo "[report page for ${{github.repository}}]($url)."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Google's OSS guidance recommend the use of security scanners to detect vulnerabilities in code. This PR adds Scorecard and the Open-Source Vulnerabilities (OSV) scanners. Both of these are being used in our Quantumlib repos.

The configurations here will run the scanners on these events:
* pull requests
* merge queue merges
* manual invocation
* weekly on Saturdays