### PR TITLE
Add Jupyter Notebook Format Check to format_check.sh

### DIFF
--- a/scripts/format_check.sh
+++ b/scripts/format_check.sh
@@ -91,6 +91,22 @@ else
     exit 1
 fi
 
+# Check Jupyter Notebook format
+echo "Checking Jupyter Notebook format..."
+if ! command -v nbstripout &> /dev/null
+then
+    echo "nbstripout could not be found, please install it with 'pip install nbstripout'"
+    exit 1
+fi
+
+for notebook in $(find . -name "*.ipynb"); do
+    nbstripout --check "$notebook"
+    if [ $? -ne 0 ]; then
+        echo "Notebook $notebook is not in the correct format. Please strip output and metadata."
+        exit 1
+    fi
+done
+
 echo "Checking C++ formatting...";
 formatting_outputs=$(find tensorflow_quantum/ -iname *.h -o -iname *.cc | xargs clang-format -style=google -output-replacements-xml);
 CFORMATCHECK=0


### PR DESCRIPTION
#681 
This PR adds a check to format_check.sh to ensure all Jupyter Notebook (.ipynb) files are in the correct format before merging. The script now uses nbstripout --check to verify that notebooks do not contain unwanted outputs or metadata.

Please let me know if this fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou!