### PR TITLE
Fix Math Rendering in Fidelity Docstring and Enable MathJax for Sphinx Docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,3 @@
+extensions = [
+    'sphinx.ext.mathjax',
+]

--- a/tensorflow_quantum/core/ops/math_ops/fidelity_op.py
+++ b/tensorflow_quantum/core/ops/math_ops/fidelity_op.py
@@ -25,9 +25,11 @@ def fidelity(programs, symbol_names, symbol_values, other_programs):
     Compute (potentially many) fidelities between the given circuits and
     the symbol free comparison circuits.
 
-    Calculates out[i][j] = $ | \langle \psi_{\text{programs[i]}} \\
-     (\text{symbol\_values[i]}) | \psi_{\text{other\_programs[j]}} \rangle \\
-     |^2 $
+    Calculates out[i][j] as:
+    $$
+    |\langle \psi_{\text{programs[i]}}(\text{symbol\_values[i]}) \mid
+    \psi_{\text{other\_programs[j]}} \rangle|^2
+    $$
 
 
     >>> symbols = sympy.symbols('alpha beta')

--- a/tensorflow_quantum/core/ops/math_ops/inner_product_op.py
+++ b/tensorflow_quantum/core/ops/math_ops/inner_product_op.py
@@ -75,8 +75,11 @@ def inner_product(programs, symbol_names, symbol_values, other_programs):
     Compute (potentially many) inner products between the given circuits and
     the symbol free comparison circuits.
 
-    Calculates out[i][j] = $ \langle \psi_{\text{programs[i]}} \\
-     (\text{symbol\_values[i]}) | \psi_{\text{other\_programs[j]}} \rangle $
+    Calculates out[i][j] as:
+    $$
+    \langle \psi_{\text{programs[i]}}(\text{symbol\_values[i]}) \mid
+    \psi_{\text{other\_programs[j]}} \rangle
+    $$
 
 
     >>> symbols = sympy.symbols('alpha beta')


### PR DESCRIPTION
#594
This PR updates the docstring for the fidelity operation to use proper LaTeX block math formatting, ensuring that the fidelity formula renders correctly in the generated documentation.

Additionally, I attempted to add conf.py to enable MathJax in the Sphinx configuration, but I am not fully certain if this change is required or the best approach. 

Please let me know if this fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou!