### PR TITLE
Delete unneeded software to save space on runners

### DIFF
--- a/.github/workflows/ci-build-checks.yaml
+++ b/.github/workflows/ci-build-checks.yaml
@@ -38,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - name: Remove some unnecessary software to free up disk space
+        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android &
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v5
         with:
           python-version: '3.10'


### PR DESCRIPTION
Deleting some of the pre-installed software directories on the runner can save a lot of space. Deleting the Dotnet and Android installations in particular saves ~13 GB. This will hopefully be enough to get past the current problem with builds exceeding space on the runner.

Note: the recursive `rm` is backgrounded because otherwise, that step takes 50-60 s. Doing it in the background lets other steps proceed.

There was a risk that the background process would slow down the rest of the workflow more than the 60s it would take to stop and wait for the `rm` to finish. Thankfully, there's no overall impact: it turns out that the overall workflow takes just as long as before. So, we get the benefit of more space without run-time cost.