### PR TITLE
Mark spsa_minimizer_test as flaky

### DIFF
--- a/tensorflow_quantum/python/optimizers/BUILD
+++ b/tensorflow_quantum/python/optimizers/BUILD
@@ -39,6 +39,7 @@ py_test(
 py_test(
     name = "spsa_minimizer_test",
     srcs = ["spsa_minimizer_test.py"],
+    flaky = True,
     python_version = "PY3",
     deps = [
         ":spsa_minimizer",


### PR DESCRIPTION
The test in `tensorflow_quantum/python/optimizers/spsa_minimizer_test.py` sometimes fails to converge. This causes CI workflows to fail, leading to developer time wasted trying to understand the cause. However, Bazel can automatically retry flaky tests if they are marked as such. This PR simply marks that test as flaky so that it hopefully will not cause failures unnecessarily.