### PR TITLE
Use larger runners for nightly jobs

### DIFF
--- a/.github/workflows/ci-nightly-build-test.yaml
+++ b/.github/workflows/ci-nightly-build-test.yaml
@@ -80,7 +80,7 @@ jobs:
       have-changes: ${{steps.commits.outputs.count > 0}}
     steps:
       - name: Check out a sparse copy of the git repo for TFQ
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           sparse-checkout: .
 
@@ -98,7 +98,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out a copy of the TFQ git repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up Python ${{inputs.py_version || env.py_version}}
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
@@ -107,7 +107,7 @@ jobs:
           cache: pip
 
       - name: Set up Bazel
-        uses: bazel-contrib/setup-bazel@f3f50ea6791b9b0f4c4eeabba4507422426462f5 # 0.9.1
+        uses: bazel-contrib/setup-bazel@4fd964a13a440a8aeb0be47350db2fc640f19ca8 # v1
         with:
           bazelisk-cache: true
           repository-cache: true
@@ -131,7 +131,7 @@ jobs:
 
       - if: failure() || inputs.save_artifacts == 'true'
         name: Make artifacts downloadable
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-artifacts
           retention-days: 7

--- a/.github/workflows/ci-nightly-cirq-test.yaml
+++ b/.github/workflows/ci-nightly-cirq-test.yaml
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out a copy of the TFQ git repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
@@ -72,7 +72,7 @@ jobs:
           cache: pip
 
       - name: Set up Bazel
-        uses: bazel-contrib/setup-bazel@529dbc2648ea79358c64f2bfa5f3ec98f07859e4 # 0.12.1
+        uses: bazel-contrib/setup-bazel@4fd964a13a440a8aeb0be47350db2fc640f19ca8 # v1
         with:
           bazelisk-cache: true
           repository-cache: true
@@ -110,7 +110,7 @@ jobs:
 
       - if: failure() || inputs.save_artifacts == 'true'
         name: Make artifacts downloadable
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bazel-out
           retention-days: 7


### PR DESCRIPTION
The nightly jobs are failing due to running out of disk space. (It's the same problem we had recently with the CI checks workflow.) This PR updates the jobs to use the larger self-hosted runners from Google ML Velocity. 

In addition, this PR makes some simplifications to the workflows to get rid of some of the overelaborate things I did before, and make minor other changes to keep with best practices such as putting timeouts on jobs.