### PR TITLE
Update `setup.py` to support Python 3.9

### DIFF
--- a/release/setup.py
+++ b/release/setup.py
@@ -123,7 +123,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Scientific/Engineering :: Mathematics",


### PR DESCRIPTION
After extensive experimentation with dependency version constraints, it has become possible to support Python 3.9. This PR updates `setup.py` for the values of `python_requires` and `install_requires`.