### PR TITLE
Set version number to 0.7.5 for the release

### DIFF
--- a/release/setup.py
+++ b/release/setup.py
@@ -31,7 +31,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 from setuptools.dist import Distribution
 
-CUR_VERSION = "0.7.4"
+CUR_VERSION = "0.7.5"
 
 DOCLINES = __doc__.split("\n")
 

--- a/tensorflow_quantum/__init__.py
+++ b/tensorflow_quantum/__init__.py
@@ -64,4 +64,4 @@ del python
 del core
 # pylint: enable=undefined-variable
 
-__version__ = '0.7.4'
+__version__ = '0.7.5'


### PR DESCRIPTION
We are about to release 0.7.5. This updates the version number in release/setup.py and tensorflow_quantum/__init__.py to 0.7.5.