### PR TITLE
Pin the container image versions used for job runners

### DIFF
--- a/.github/workflows/ci-build-checks.yaml
+++ b/.github/workflows/ci-build-checks.yaml
@@ -54,7 +54,7 @@ jobs:
     name: Library tests
     runs-on: linux-x86-n2-32
     container:
-      image: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest
+      image: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:infrastructure-public-image-82c7ac59ba4b
     timeout-minutes: 60
 
     steps:
@@ -103,7 +103,7 @@ jobs:
     name: Tutorial tests
     runs-on: linux-x86-n2-32
     container:
-      image: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest
+      image: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:infrastructure-public-image-82c7ac59ba4b
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
The containers used on the  `linux-x86-n2-32` runners were referenced using `latest`. For better reproducibility of results, this changes the version to a specific image tag.

Details about the Docker image we are currently:

* The container image is pulled from [us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build](http://us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build)
* We are currently using the image with the tag [infrastructure-public-image-82c7ac59ba4b](https://pantheon.corp.google.com/artifacts/docker/ml-oss-artifacts-published/us/ml-public-container/ml-build/sha256:eb889e60ef91683d2eda5b8250a0f6191889731084ecc78a974158912c6164f4)
    * This is based on Ubuntu 22.04
	* The container image is built by a [Dockerfile](https://github.com/tensorflow/tensorflow/blob/master/ci/official/containers/ml_build/Dockerfile) and associated scripts in the TensorFlow GitHub repo found at ci/official/containers/ml_build
    * The specific copy of that Dockerfile and the other files is what existed at git commit [2658e16b3cba8dfa7e95e762a21028b6eff1616c](https://github.com/tensorflow/tensorflow/blob/2658e16b3cba8dfa7e95e762a21028b6eff1616c/ci/official/containers/ml_build/Dockerfile)