### PR TITLE
Revert version number to 0.7.6

### DIFF
--- a/release/setup.py
+++ b/release/setup.py
@@ -31,7 +31,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 from setuptools.dist import Distribution
 
-CUR_VERSION = "0.7.7"
+CUR_VERSION = "0.7.6"
 
 DOCLINES = __doc__.split("\n")
 

--- a/tensorflow_quantum/__init__.py
+++ b/tensorflow_quantum/__init__.py
@@ -64,4 +64,4 @@ del python
 del core
 # pylint: enable=undefined-variable
 
-__version__ = '0.7.7'
+__version__ = '0.7.6'


### PR DESCRIPTION
PR #984 incorrectly bumped the version number to 0.7.7, and I didn't notice it during review. This PR changes the version back to 0.7.6, which is the current development version in the main branch on GitHub.