### PR TITLE
Explicitly use Bash for job shell

### DIFF
--- a/.github/workflows/ci-nightly-build-test.yaml
+++ b/.github/workflows/ci-nightly-build-test.yaml
@@ -71,6 +71,10 @@ concurrency:
 
 permissions: read-all
 
+defaults:
+  run:
+    shell: bash -x {0}
+
 jobs:
   Decision:
     runs-on: ubuntu-24.04
@@ -85,7 +89,6 @@ jobs:
       - name: Get number of commits in the last 24 hrs
         id: commits
         run: |
-          set -x
           count=$(git log --oneline --since '24 hours ago' | wc -l)
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
@@ -112,24 +115,22 @@ jobs:
 
       - name: Build wheel
         run: |
-          set -x
           pip install --upgrade pip setuptools wheel
           # The next script does a pip install, configure, & bazel build.
           ./scripts/build_pip_package_test.sh
 
       - name: Test wheel
         run: |
-          set -x
           ./scripts/run_example.sh
 
       - name: Test rest of TFQ
         run: |
-          set -x -o pipefail
+          set -o pipefail
           ./scripts/test_all.sh 2>&1 | tee test_all.log
 
       - name: Test tutorials
         run: |
-          set -x -o pipefail
+          set -o pipefail
           pip install jupyter
           pip install nbclient==0.6.5 jupyter-client==6.1.12 ipython==7.22.0
           pip install ipykernel==5.1.1


### PR DESCRIPTION
It appears that the default shell in the custom runner image is not Bash, or else it's Bash running in POSIX mode. This leads to syntax problems with, e.g., `set`. We can avoid this by setting Bash as the default shell for the workflow.