### PR TITLE
Add test for non-integer args to batch_sample()

### DIFF
--- a/tensorflow_quantum/core/ops/batch_util_test.py
+++ b/tensorflow_quantum/core/ops/batch_util_test.py
@@ -308,6 +308,30 @@ class BatchUtilTest(tf.test.TestCase, parameterized.TestCase):
         self.assertDTypeEqual(results, np.int8)
         self.assertEqual(np.zeros(shape=(0, 0, 0)).shape, results.shape)
 
+    @parameterized.parameters([{
+        'sim': cirq.DensityMatrixSimulator()
+    }, {
+        'sim': cirq.Simulator()
+    }])
+    def test_batch_sample_errors(self, sim):
+        """Test that batch_sample raises errors on invalid n_samples."""
+        circuit = cirq.Circuit(cirq.X(cirq.GridQubit(0, 0)))
+        resolvers = [cirq.ParamResolver({})]
+
+        # Test non-int n_samples
+        with self.assertRaisesRegex(TypeError, 'n_samples must be an int'):
+            batch_util.batch_sample([circuit], resolvers, '100', sim)
+
+        with self.assertRaisesRegex(TypeError, 'n_samples must be an int'):
+            batch_util.batch_sample([circuit], resolvers, [100], sim)
+
+        # Test n_samples <= 0
+        with self.assertRaisesRegex(ValueError, 'n_samples must be > 0'):
+            batch_util.batch_sample([circuit], resolvers, 0, sim)
+
+        with self.assertRaisesRegex(ValueError, 'n_samples must be > 0'):
+            batch_util.batch_sample([circuit], resolvers, -1, sim)
+
 
 if __name__ == '__main__':
     tf.test.main()


### PR DESCRIPTION
This change adds a unit test function `test_batch_sample_errors()` to `tensorflow_quantum/core/ops/batch_util_test.py` to verify that `batch_util.batch_sample` correctly raises `TypeError` for non-integer `n_samples` and `ValueError` for `n_samples <= 0`.

(This change was done with the help of Jules.)