### PR TITLE
Update format of tutorial notebooks

### DIFF
--- a/docs/tutorials/barren_plateaus.ipynb
+++ b/docs/tutorials/barren_plateaus.ipynb
@@ -117,8 +117,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "import os\n",
+    "\n",
+    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "os.environ[\"TF_USE_LEGACY_KERAS\"] = \"1\""
    ]
   },

--- a/docs/tutorials/gradients.ipynb
+++ b/docs/tutorials/gradients.ipynb
@@ -119,8 +119,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "import os\n",
+    "\n",
+    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "os.environ[\"TF_USE_LEGACY_KERAS\"] = \"1\""
    ]
   },

--- a/docs/tutorials/hello_many_worlds.ipynb
+++ b/docs/tutorials/hello_many_worlds.ipynb
@@ -117,8 +117,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "import os\n",
+    "\n",
+    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "os.environ[\"TF_USE_LEGACY_KERAS\"] = \"1\""
    ]
   },

--- a/docs/tutorials/mnist.ipynb
+++ b/docs/tutorials/mnist.ipynb
@@ -127,8 +127,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "import os\n",
+    "\n",
+    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "os.environ[\"TF_USE_LEGACY_KERAS\"] = \"1\""
    ]
   },

--- a/docs/tutorials/noise.ipynb
+++ b/docs/tutorials/noise.ipynb
@@ -105,8 +105,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "import os\n",
+    "\n",
+    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "os.environ[\"TF_USE_LEGACY_KERAS\"] = \"1\""
    ]
   },

--- a/docs/tutorials/qcnn.ipynb
+++ b/docs/tutorials/qcnn.ipynb
@@ -122,8 +122,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "import os\n",
+    "\n",
+    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "os.environ[\"TF_USE_LEGACY_KERAS\"] = \"1\""
    ]
   },

--- a/docs/tutorials/quantum_data.ipynb
+++ b/docs/tutorials/quantum_data.ipynb
@@ -119,8 +119,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "import os\n",
+    "\n",
+    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "os.environ[\"TF_USE_LEGACY_KERAS\"] = \"1\""
    ]
   },

--- a/docs/tutorials/quantum_reinforcement_learning.ipynb
+++ b/docs/tutorials/quantum_reinforcement_learning.ipynb
@@ -136,8 +136,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "import os\n",
+    "\n",
+    "# Keras 2 must be selected before importing TensorFlow or TensorFlow Quantum:\n",
     "os.environ[\"TF_USE_LEGACY_KERAS\"] = \"1\""
    ]
   },
@@ -1493,7 +1494,9 @@
     "    episode_reward_history.append(episode_reward)\n",
     "    if (episode + 1) % 10 == 0:\n",
     "        avg_rewards = np.mean(episode_reward_history[-10:])\n",
-    "        print(f\"Episode {episode + 1}/{n_episodes}, average last 10 rewards {avg_rewards}\")\n",
+    "        print(\n",
+    "            f\"Episode {episode + 1}/{n_episodes}, average last 10 rewards {avg_rewards}\"\n",
+    "        )\n",
     "        if avg_rewards >= 500.0:\n",
     "            break"
    ]


### PR DESCRIPTION
Running `scripts/format_all.sh` produces some small differences in the tutorials. I further adjusted the results from what `format_all.sh` produced in order to move a comment that ended up in a less-than-ideal place. The result passes `scripts/format_all.sh` without further changes.

The fact that this difference arose is most likely a sign that I didn't run `scripts/format_all.sh` during the final steps of the last release. I will add a note to the release procedure to remind us to do that in the future.