### PR TITLE
Add  `scripts/` to directories checked by `format_all.sh`

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -43,8 +43,6 @@ flags.DEFINE_string("site_path", "quantum/api_docs/python",
 FLAGS = flags.FLAGS
 
 
-
-
 def main(unused_argv):
 
     doc_generator = generate_lib.DocGenerator(

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -44,6 +44,7 @@ FLAGS = flags.FLAGS
 
 
 def main(unused_argv):
+    """Run the documentation builder."""
 
     doc_generator = generate_lib.DocGenerator(
         root_title="TensorFlow Quantum",

--- a/scripts/format_all.sh
+++ b/scripts/format_all.sh
@@ -14,9 +14,8 @@
 # limitations under the License.
 # ==============================================================================
 echo "Doing python language formatting..."
-python3 -m yapf --style=google --in-place --recursive ./benchmarks
-python3 -m yapf --style=google --in-place --recursive ./tensorflow_quantum
-python3 -m yapf --style=google --in-place --recursive ./scripts
+python3 -m yapf --style=google --in-place --recursive --parallel \
+  ./benchmarks ./scripts ./tensorflow_quantum
 echo -e "Done! \nDoing notebook formatting..."
 python3 ./scripts/format_ipynb.py
 echo -e "Done! \nDoing C++ formatting..."

--- a/scripts/format_all.sh
+++ b/scripts/format_all.sh
@@ -14,8 +14,9 @@
 # limitations under the License.
 # ==============================================================================
 echo "Doing python language formatting..."
-python3 -m yapf --style=google --in-place --recursive ./benchmarks
-python3 -m yapf --style=google --in-place --recursive ./tensorflow_quantum
+python3 -m yapf --in-place --recursive ./benchmarks
+python3 -m yapf --in-place --recursive ./tensorflow_quantum
+python3 -m yapf --in-place --recursive ./scripts
 echo -e "Done! \nDoing notebook formatting..."
 python3 ./scripts/format_ipynb.py
 echo -e "Done! \nDoing C++ formatting..."

--- a/scripts/format_all.sh
+++ b/scripts/format_all.sh
@@ -14,9 +14,9 @@
 # limitations under the License.
 # ==============================================================================
 echo "Doing python language formatting..."
-python3 -m yapf --in-place --recursive ./benchmarks
-python3 -m yapf --in-place --recursive ./tensorflow_quantum
-python3 -m yapf --in-place --recursive ./scripts
+python3 -m yapf --style=google --in-place --recursive ./benchmarks
+python3 -m yapf --style=google --in-place --recursive ./tensorflow_quantum
+python3 -m yapf --style=google --in-place --recursive ./scripts
 echo -e "Done! \nDoing notebook formatting..."
 python3 ./scripts/format_ipynb.py
 echo -e "Done! \nDoing C++ formatting..."


### PR DESCRIPTION
The `format_all.sh` script did not format files in the `scripts/` directory. However, it makes sense to format those scripts according to project conventions too. This PR adds the `scripts/` directory to the directories passed to `yapf` in `scripts/format_all.sh`.

This PR also includes a couple of small changes to `scripts/build_docs.py` (add a docstring, remove some whitespace), which are the result of running `format_all.sh` on the `scripts/` directory.