### PR TITLE
Add `source-roots` value to `.pylintrc`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -105,7 +105,7 @@ recursive=yes
 # source root is an absolute path or a path relative to the current working
 # directory used to determine a package namespace for modules located under the
 # source root.
-source-roots=
+source-roots=.
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.


### PR DESCRIPTION
This makes it possible for pylint to be able to find tensorflow_quantum when it's running. This solves failures in linting in CI for some my recent PRs involving linting.