### PR TITLE
Use absolute URL for logo files in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <div align="center">
 
 <img width="450px" alt="TensorFlow Quantum logo"
-src="docs/images/logo/tf_quantum1.svg">
+src="https://raw.githubusercontent.com/tensorflow/quantum/refs/heads/master/docs/images/logo/tf_quantum1.svg">
 
 High-performance Python framework for hybrid quantum-classical machine learning
 
@@ -130,6 +130,7 @@ Copyright 2020 Google LLC.
 <div align="center">
   <a href="https://quantumai.google">
     <img width="15%" alt="Google Quantum AI"
-         src="docs/images/quantum-ai-vertical.svg">
+         src="https://raw.githubusercontent.com/tensorflow/quantum/refs/heads/master/docs/images/quantum-ai-vertical.svg">
+
   </a>
 </div>


### PR DESCRIPTION
To make it possible to use the top-level `README.md` for the documentation on PyPI, the image references must use absolute URLs rather than relative URLs.
