### PR TITLE
Fix miscellaneous trivial typos

### DIFF
--- a/.github/workflows/ci-nightly-cirq-test.yaml
+++ b/.github/workflows/ci-nightly-cirq-test.yaml
@@ -19,7 +19,7 @@
 # For testing, this workflow can be invoked manually from the GitHub page at
 # https://github.com/tensorflow/quantum/actions/workflows/ci-nightly-cirq-test.yaml
 # Clicking the "Run workflow" button there will present a form interface with
-# options for overridding some of the parameters for the run.
+# options for overriding some of the parameters for the run.
 
 # yamllint disable rule:line-length
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,7 +118,7 @@ jobs:
   # 2024-11-30 [mhucka] temporarily turning off leak-tests because it produces
   # false positives on GH that we can't immediately address. TODO: if updating
   # TFQ to use Clang and the latest TF does not resolve this, find a way to
-  # skip the handful of failing tests and renable the rest of the msan tests.
+  # skip the handful of failing tests and re-enable the rest of the msan tests.
   #
   # leak-tests:
   #   name: Memory Leak tests

--- a/configure.sh
+++ b/configure.sh
@@ -201,7 +201,7 @@ fi
 
 write_bazelrc ""
 
-# The following supressions are for warnings coming from external dependencies.
+# The following suppressions are for warnings coming from external dependencies.
 # They're most likely inconsequential or false positives. Since we can't fix
 # them, we suppress the warnings to reduce noise. Note: single quotes are needed
 # for the first two so that the $ anchors are preserved in the .bazelrc file.

--- a/release/README.md
+++ b/release/README.md
@@ -82,7 +82,7 @@ into the upstream repository before proceeding further.
 
     This will update the dependency versions in the file `requirements.txt` to
     the latest versions based on `requirements.in`. If this process fails, you
-    may have to iterate on adjusting the contraints in `requirements.in`
+    may have to iterate on adjusting the constraints in `requirements.in`
     followed by running `generate_requirements.sh` again until it succeeds.
 
 3.  If any changes were made to `requirements.in`, check the requirements listed

--- a/tensorflow_quantum/core/ops/batch_util.py
+++ b/tensorflow_quantum/core/ops/batch_util.py
@@ -73,7 +73,7 @@ class TFQPauliSumCollector(cirq.work.collector.Collector):
         self._ones[job_id] += parities[1]
 
     def collect(self, sampler):
-        """Synchronus collect."""
+        """Synchronous collect."""
         # See #562, this is a workaround to an event loop issue in the tutorials
         # see also:
         # https://stackoverflow.com/questions/55409641/asyncio-run-cannot-be-called-from-a-running-event-loop

--- a/tensorflow_quantum/core/ops/cirq_ops.py
+++ b/tensorflow_quantum/core/ops/cirq_ops.py
@@ -437,7 +437,7 @@ def _get_cirq_samples(sampler=cirq.Simulator()):
         symbol labeled 'b' and 1 into the symbol labeled 'c'. Then it would
         draw 100 samples from the circuit.
 
-        Note: In the case of circuits with varying size, all nonexistant
+        Note: In the case of circuits with varying size, all nonexistent
         samples for a particular circuit are padded with -2.
 
         Args:

--- a/tensorflow_quantum/core/ops/cirq_ops_test.py
+++ b/tensorflow_quantum/core/ops/cirq_ops_test.py
@@ -295,7 +295,7 @@ class CirqSimulateStateTest(tf.test.TestCase, parameterized.TestCase):
         for circuit in circuit_batch:
             result = sim.simulate(circuit)
 
-            # density matricies should be zero everywhere except for the
+            # density matrices should be zero everywhere except for the
             # top left corner
             if isinstance(result, cirq.DensityMatrixTrialResult):
                 dm = result.final_density_matrix

--- a/tensorflow_quantum/core/ops/math_ops/fidelity_op.py
+++ b/tensorflow_quantum/core/ops/math_ops/fidelity_op.py
@@ -70,7 +70,7 @@ def fidelity(programs, symbol_names, symbol_values, other_programs):
             `programs`.
         symbol_values: `tf.Tensor` of real numbers with shape
             [batch_size, n_params] specifying parameter values to resolve
-            into the circuits specificed by programs, following the ordering
+            into the circuits specified by programs, following the ordering
             dictated by `symbol_names`.
         other_programs: `tf.Tensor` of strings with shape [batch_size, n_others]
             containing the string representations of the circuits with which to

--- a/tensorflow_quantum/core/ops/math_ops/inner_product_grad_test.py
+++ b/tensorflow_quantum/core/ops/math_ops/inner_product_grad_test.py
@@ -122,7 +122,7 @@ class InnerProductAdjGradTest(tf.test.TestCase, parameterized.TestCase):
         with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
                                     'not found in reference circuit'):
             # other_programs tensor has the right type but operates on
-            # qubits that the reference ciruit doesn't have.
+            # qubits that the reference circuit doesn't have.
             new_qubits = [cirq.GridQubit(5, 5), cirq.GridQubit(9, 9)]
             new_circuits, _ = util.random_circuit_resolver_batch(
                 new_qubits, batch_size)
@@ -134,7 +134,7 @@ class InnerProductAdjGradTest(tf.test.TestCase, parameterized.TestCase):
         with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
                                     'not found in paired circuit'):
             # other_programs tensor has the right type but operates on
-            # qubits that the reference ciruit doesn't have.
+            # qubits that the reference circuit doesn't have.
             new_qubits = cirq.GridQubit.rect(1, n_qubits - 1)
             new_circuits, _ = util.random_circuit_resolver_batch(
                 new_qubits, batch_size)

--- a/tensorflow_quantum/core/ops/math_ops/inner_product_op.py
+++ b/tensorflow_quantum/core/ops/math_ops/inner_product_op.py
@@ -46,7 +46,7 @@ def _inner_product_grad(programs, symbol_names, symbol_values, other_programs,
             `programs`.
         symbol_values: `tf.Tensor` of real numbers with shape
             [batch_size, n_params] specifying parameter values to resolve
-            into the circuits specificed by programs, following the ordering
+            into the circuits specified by programs, following the ordering
             dictated by `symbol_names`.
         other_programs: `tf.Tensor` of strings with shape [batch_size, n_others]
             containing the string representations of the circuits with which to
@@ -122,7 +122,7 @@ def inner_product(programs, symbol_names, symbol_values, other_programs):
             `programs`.
         symbol_values: `tf.Tensor` of real numbers with shape
             [batch_size, n_params] specifying parameter values to resolve
-            into the circuits specificed by programs, following the ordering
+            into the circuits specified by programs, following the ordering
             dictated by `symbol_names`.
         other_programs: `tf.Tensor` of strings with shape [batch_size, n_others]
             containing the string representations of the circuits with which to

--- a/tensorflow_quantum/core/ops/math_ops/inner_product_op_test.py
+++ b/tensorflow_quantum/core/ops/math_ops/inner_product_op_test.py
@@ -115,7 +115,7 @@ class InnerProductTest(tf.test.TestCase, parameterized.TestCase):
         with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
                                     'not found in reference circuit'):
             # other_programs tensor has the right type but operates on
-            # qubits that the reference ciruit doesn't have.
+            # qubits that the reference circuit doesn't have.
             new_qubits = [cirq.GridQubit(5, 5), cirq.GridQubit(9, 9)]
             new_circuits, _ = util.random_circuit_resolver_batch(
                 new_qubits, batch_size)
@@ -127,7 +127,7 @@ class InnerProductTest(tf.test.TestCase, parameterized.TestCase):
         with self.assertRaisesRegex(tf.errors.InvalidArgumentError,
                                     'not found in paired circuit'):
             # other_programs tensor has the right type but operates on
-            # qubits that the reference ciruit doesn't have.
+            # qubits that the reference circuit doesn't have.
             new_qubits = cirq.GridQubit.rect(1, n_qubits - 1)
             new_circuits, _ = util.random_circuit_resolver_batch(
                 new_qubits, batch_size)

--- a/tensorflow_quantum/core/ops/math_ops/simulate_mps.py
+++ b/tensorflow_quantum/core/ops/math_ops/simulate_mps.py
@@ -42,7 +42,7 @@ def mps_1d_expectation(programs,
             `programs`.
         symbol_values: `tf.Tensor` of real numbers with shape
             [batch_size, n_params] specifying parameter values to resolve
-            into the circuits specificed by programs, following the ordering
+            into the circuits specified by programs, following the ordering
             dictated by `symbol_names`.
         pauli_sums: `tf.Tensor` of strings with shape [batch_size, n_ops]
             containing the string representation of the operators that will
@@ -127,7 +127,7 @@ def mps_1d_sampled_expectation(programs,
             `programs`.
         symbol_values: `tf.Tensor` of real numbers with shape
             [batch_size, n_params] specifying parameter values to resolve
-            into the circuits specificed by programs, following the ordering
+            into the circuits specified by programs, following the ordering
             dictated by `symbol_names`.
         pauli_sums: `tf.Tensor` of strings with shape [batch_size, n_ops]
             containing the string representation of the operators that will

--- a/tensorflow_quantum/core/ops/noise/noisy_expectation_op.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_expectation_op.py
@@ -75,7 +75,7 @@ def expectation(programs, symbol_names, symbol_values, pauli_sums, num_samples):
             `programs`.
         symbol_values: `tf.Tensor` of real numbers with shape
             [batch_size, n_params] specifying parameter values to resolve
-            into the circuits specificed by programs, following the ordering
+            into the circuits specified by programs, following the ordering
             dictated by `symbol_names`.
         pauli_sums: `tf.Tensor` of strings with shape [batch_size, n_ops]
             containing the string representation of the operators that will

--- a/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op.py
+++ b/tensorflow_quantum/core/ops/noise/noisy_sampled_expectation_op.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Module for high performance noisy circuit sampled epxectation ops."""
+"""Module for high performance noisy circuit sampled expectation ops."""
 import os
 import tensorflow as tf
 from tensorflow_quantum.core.ops.load_module import load_module
@@ -74,7 +74,7 @@ def sampled_expectation(programs, symbol_names, symbol_values, pauli_sums,
             `programs`.
         symbol_values: `tf.Tensor` of real numbers with shape
             [batch_size, n_params] specifying parameter values to resolve
-            into the circuits specificed by programs, following the ordering
+            into the circuits specified by programs, following the ordering
             dictated by `symbol_names`.
         pauli_sums: `tf.Tensor` of strings with shape [batch_size, n_ops]
             containing the string representation of the operators that will

--- a/tensorflow_quantum/core/ops/noise/tfq_noisy_samples.cc
+++ b/tensorflow_quantum/core/ops/noise/tfq_noisy_samples.cc
@@ -159,7 +159,7 @@ class TfqNoisySamplesOp : public tensorflow::OpKernel {
 
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
-    // a larger circuit we will grow the Statevector as nescessary.
+    // a larger circuit we will grow the Statevector as necessary.
     for (size_t i = 0; i < ncircuits.size(); i++) {
       int nq = num_qubits[i];
 

--- a/tensorflow_quantum/core/ops/parse_context.cc
+++ b/tensorflow_quantum/core/ops/parse_context.cc
@@ -52,7 +52,7 @@ Status ParseProto(const std::string& text, T* proto) {
 
   return Status(
       static_cast<tensorflow::errors::Code>(absl::StatusCode::kInvalidArgument),
-      "Unparsable proto: " + text);
+      "Unparseable proto: " + text);
 }
 
 }  // namespace

--- a/tensorflow_quantum/core/ops/parse_context.cc
+++ b/tensorflow_quantum/core/ops/parse_context.cc
@@ -52,7 +52,7 @@ Status ParseProto(const std::string& text, T* proto) {
 
   return Status(
       static_cast<tensorflow::errors::Code>(absl::StatusCode::kInvalidArgument),
-      "Unparseable proto: " + text);
+      "Unparsable proto: " + text);
 }
 
 }  // namespace

--- a/tensorflow_quantum/core/ops/tfq_adj_grad_op.py
+++ b/tensorflow_quantum/core/ops/tfq_adj_grad_op.py
@@ -31,7 +31,7 @@ def tfq_adj_grad(programs, symbol_names, symbol_values, pauli_sums, prev_grad):
             `programs`.
         symbol_values: `tf.Tensor` of real numbers with shape
             [batch_size, n_params] specifying parameter values to resolve
-            into the circuits specificed by programs, following the ordering
+            into the circuits specified by programs, following the ordering
             dictated by `symbol_names`.
         pauli_sums: `tf.Tensor` of strings with shape [batch_size, n_ops]
             containing the string representation of the operators that will

--- a/tensorflow_quantum/core/ops/tfq_calculate_unitary_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_calculate_unitary_op.cc
@@ -115,7 +115,7 @@ class TfqCalculateUnitaryOp : public tensorflow::OpKernel {
 
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
-    // a larger circuit we will grow the unitary as nescessary.
+    // a larger circuit we will grow the unitary as necessary.
     for (size_t i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
       UCalculator sim = UCalculator(tfq_for);

--- a/tensorflow_quantum/core/ops/tfq_ps_util_ops_test.py
+++ b/tensorflow_quantum/core/ops/tfq_ps_util_ops_test.py
@@ -304,7 +304,7 @@ class PSDecomposeTest(tf.test.TestCase):
         # The non-decomposed moments should be the same.
         self.assertEqual(decomposed_programs[0][0], circuit_batch[0][0])
         self.assertEqual(decomposed_programs[0][-1], circuit_batch[0][-1])
-        # Check paralellized decompose gates in Moment[1]~[3].
+        # Check parallelized decompose gates in Moment[1]~[3].
         # The target ops are replaced by the first decomposition gates. It means
         # the first Moment has exactly the same number of gate ops.
         self.assertEqual(len(decomposed_programs[0][1]),
@@ -343,7 +343,7 @@ class PSDecomposeTest(tf.test.TestCase):
         # The non-decomposed moments should be the same.
         self.assertEqual(decomposed_programs[0][0], circuit_batch[0][0])
         self.assertEqual(decomposed_programs[0][-1], circuit_batch[0][-1])
-        # Check paralellized decompose gates in Moment[1]~[3].
+        # Check parallelized decompose gates in Moment[1]~[3].
         # The target ops are replaced by the first decomposition gates. It means
         # the first Moment has exactly the same number of gate ops.
         self.assertEqual(len(decomposed_programs[0][1]),

--- a/tensorflow_quantum/core/ops/tfq_simulate_ops.py
+++ b/tensorflow_quantum/core/ops/tfq_simulate_ops.py
@@ -31,7 +31,7 @@ def tfq_simulate_expectation(programs, symbol_names, symbol_values, pauli_sums):
             `programs`.
         symbol_values: `tf.Tensor` of real numbers with shape
             [batch_size, n_params] specifying parameter values to resolve
-            into the circuits specificed by programs, following the ordering
+            into the circuits specified by programs, following the ordering
             dictated by `symbol_names`.
         pauli_sums: `tf.Tensor` of strings with shape [batch_size, n_ops]
             containing the string representation of the operators that will
@@ -60,7 +60,7 @@ def tfq_simulate_state(programs, symbol_names, symbol_values):
             `programs`.
         symbol_values: `tf.Tensor` of real numbers with shape
             [batch_size, n_params] specifying parameter values to resolve
-            into the circuits specificed by programs, following the ordering
+            into the circuits specified by programs, following the ordering
             dictated by `symbol_names`.
     Returns:
         A `tf.Tensor` containing the final state of each circuit in `programs`.
@@ -116,7 +116,7 @@ def tfq_simulate_sampled_expectation(programs, symbol_names, symbol_values,
             `programs`.
         symbol_values: `tf.Tensor` of real numbers with shape
             [batch_size, n_params] specifying parameter values to resolve
-            into the circuits specificed by programs, following the ordering
+            into the circuits specified by programs, following the ordering
             dictated by `symbol_names`.
         pauli_sums: `tf.Tensor` of strings with shape [batch_size, n_ops]
             containing the string representation of the operators that will

--- a/tensorflow_quantum/core/ops/tfq_simulate_samples_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_samples_op.cc
@@ -153,7 +153,7 @@ class TfqSimulateSamplesOp : public tensorflow::OpKernel {
 
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
-    // a larger circuit we will grow the Statevector as nescessary.
+    // a larger circuit we will grow the Statevector as necessary.
     for (size_t i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
 

--- a/tensorflow_quantum/core/ops/tfq_simulate_state_op.cc
+++ b/tensorflow_quantum/core/ops/tfq_simulate_state_op.cc
@@ -135,7 +135,7 @@ class TfqSimulateStateOp : public tensorflow::OpKernel {
 
     // Simulate programs one by one. Parallelizing over state vectors
     // we no longer parallelize over circuits. Each time we encounter a
-    // a larger circuit we will grow the Statevector as nescessary.
+    // a larger circuit we will grow the Statevector as necessary.
     for (size_t i = 0; i < fused_circuits.size(); i++) {
       int nq = num_qubits[i];
 

--- a/tensorflow_quantum/core/ops/tfq_utility_ops_test.py
+++ b/tensorflow_quantum/core/ops/tfq_utility_ops_test.py
@@ -93,7 +93,7 @@ class AppendCircuitOpTest(tf.test.TestCase, parameterized.TestCase):
     def test_append_circuit(self, max_n_bits, symbols, n_circuits):
         """Generate a bunch of circuits of different lengths acting on different
         numbers of qubits and append them using our op, checking that results
-        are consistant with the native cirq method.
+        are consistent with the native cirq method.
         """
         base_circuits = []
         circuits_to_append = []

--- a/tensorflow_quantum/core/serialize/op_serializer.py
+++ b/tensorflow_quantum/core/serialize/op_serializer.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""op_serializer.py adapated from Cirq release 0.9.0"""
+"""op_serializer.py adapted from Cirq release 0.9.0"""
 
 from typing import List
 import cirq

--- a/tensorflow_quantum/core/serialize/op_serializer_test.py
+++ b/tensorflow_quantum/core/serialize/op_serializer_test.py
@@ -327,7 +327,7 @@ class OpSerializerTest(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.parameters([cirq.GridQubit(1, 2), cirq.LineQubit(4)])
     def test_to_proto_not_required_ok(self, q):
-        """Test non require arg absense succeeds."""
+        """Test non require arg absence succeeds."""
         serializer = op_serializer.GateOpSerializer(
             gate_type=GateWithProperty,
             serialized_gate_id='my_gate',

--- a/tensorflow_quantum/core/src/circuit_parser_qsim.cc
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim.cc
@@ -102,7 +102,7 @@ inline Status ParseProtoControls(const Operation& op,
 
   if (control_toks.size() != control_v_toks.size()) {
     return Status(absl::StatusCode::kInvalidArgument,
-                  "Mistmatched number of control qubits and control values.");
+                  "Mismatched number of control qubits and control values.");
   }
   if (control_toks.empty()) {
     return ::tensorflow::Status();
@@ -121,7 +121,7 @@ inline Status ParseProtoControls(const Operation& op,
     valid = absl::SimpleAtoi(tok, &tmp);
     if (!valid) {
       return Status(absl::StatusCode::kInvalidArgument,
-                    "Unparseable control value: " + std::string(tok));
+                    "Unparsable control value: " + std::string(tok));
     }
     control_values->push_back(tmp);
   }
@@ -146,7 +146,7 @@ inline Status OptionalInsertControls(const Operation& op,
 }
 
 // series of fixed signature gate builders.
-// there is no need to error check for unparseable symbols
+// there is no need to error check for unparsable symbols
 // or proto args not being present. Those errors are caught
 // upstream.
 

--- a/tensorflow_quantum/core/src/circuit_parser_qsim.cc
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim.cc
@@ -121,7 +121,7 @@ inline Status ParseProtoControls(const Operation& op,
     valid = absl::SimpleAtoi(tok, &tmp);
     if (!valid) {
       return Status(absl::StatusCode::kInvalidArgument,
-                    "Unparsable control value: " + std::string(tok));
+                    "Unparseable control value: " + std::string(tok));
     }
     control_values->push_back(tmp);
   }
@@ -146,7 +146,7 @@ inline Status OptionalInsertControls(const Operation& op,
 }
 
 // series of fixed signature gate builders.
-// there is no need to error check for unparsable symbols
+// there is no need to error check for unparseable symbols
 // or proto args not being present. Those errors are caught
 // upstream.
 

--- a/tensorflow_quantum/core/src/circuit_parser_qsim.h
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim.h
@@ -72,7 +72,7 @@ tensorflow::Status QsimCircuitFromProgram(
     const absl::flat_hash_map<std::string, std::pair<int, float>>& param_map,
     const int num_qubits, qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit,
     std::vector<qsim::GateFused<qsim::Cirq::GateCirq<float>>>* fused_circuit,
-    std::vector<GateMetaData>* metdata = nullptr);
+    std::vector<GateMetaData>* metadata = nullptr);
 
 // parse a serialized Cirq program into a qsim representation.
 // ingests a Cirq Circuit proto and produces a resolved Noisy qsim Circuit.

--- a/tensorflow_quantum/core/src/circuit_parser_qsim_test.cc
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim_test.cc
@@ -1125,7 +1125,7 @@ TEST(QsimCircuitParserTest, InvalidControlValues) {
   ASSERT_EQ(QsimCircuitFromProgram(program_proto, empty_map, 3, &test_circuit,
                                    &fused_circuit, &metadata),
             tensorflow::Status(absl::StatusCode::kInvalidArgument,
-                               "Unparsable control value: junk"));
+                               "Unparseable control value: junk"));
 }
 
 TEST(QsimCircuitParserTest, MismatchControlNum) {

--- a/tensorflow_quantum/core/src/circuit_parser_qsim_test.cc
+++ b/tensorflow_quantum/core/src/circuit_parser_qsim_test.cc
@@ -1125,7 +1125,7 @@ TEST(QsimCircuitParserTest, InvalidControlValues) {
   ASSERT_EQ(QsimCircuitFromProgram(program_proto, empty_map, 3, &test_circuit,
                                    &fused_circuit, &metadata),
             tensorflow::Status(absl::StatusCode::kInvalidArgument,
-                               "Unparseable control value: junk"));
+                               "Unparsable control value: junk"));
 }
 
 TEST(QsimCircuitParserTest, MismatchControlNum) {
@@ -1158,7 +1158,7 @@ TEST(QsimCircuitParserTest, MismatchControlNum) {
                                    &fused_circuit, &metadata),
             tensorflow::Status(
                 absl::StatusCode::kInvalidArgument,
-                "Mistmatched number of control qubits and control values."));
+                "Mismatched number of control qubits and control values."));
 }
 
 TEST(QsimCircuitParserTest, EmptyTest) {

--- a/tensorflow_quantum/core/src/program_resolution.h
+++ b/tensorflow_quantum/core/src/program_resolution.h
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// Utilties around parsing Cirq Programs into forms that the TensorFlow op can
+// Utilities around parsing Cirq Programs into forms that the TensorFlow op can
 // better understand.
 
 #ifndef TFQ_CORE_SRC_PROGRAM_RESOLUTION
@@ -52,7 +52,7 @@ tensorflow::Status ResolveQubitIds(
 // operations in all moments, and if any Args have a symbol, replaces the one-of
 // with an ArgValue representing the value in the parameter map keyed by the
 // symbol. When `resolve_all` is true, returns an error if a symbol does not
-// have a correponding value in `param_map`.
+// have a corresponding value in `param_map`.
 // TODO(pmassey): Consider returning an error if a value in the parameter map
 // isn't used.
 tensorflow::Status ResolveSymbols(

--- a/tensorflow_quantum/datasets/spin_system.py
+++ b/tensorflow_quantum/datasets/spin_system.py
@@ -104,7 +104,7 @@ def tfi_chain(qubits, boundary_condition="closed", data_dir=None):
     circuit (`cirq.Circuit`), a label (Python `float`) a Hamiltonian
     (`cirq.PauliSum`) and some additional metadata. Each Hamiltonian in a
     datapoint is a 1D TFI chain with boundary condition `boundary_condition` on
-    `qubits` whos order parameter dictates the value of label. The circuit in a
+    `qubits` whose order parameter dictates the value of label. The circuit in a
     datapoint prepares (an approximation to) the ground state of the Hamiltonian
     in the datapoint.
 
@@ -335,7 +335,7 @@ def xxz_chain(qubits, boundary_condition="closed", data_dir=None):
     circuit (`cirq.Circuit`), a label (Python `float`) a Hamiltonian
     (`cirq.PauliSum`) and some additional metadata. Each Hamiltonian in a
     datapoint is a 1D XXZ chain with boundary condition `boundary_condition` on
-    `qubits` whos order parameter dictates the value of label. The circuit in a
+    `qubits` whose order parameter dictates the value of label. The circuit in a
     datapoint prepares (an approximation to) the ground state of the Hamiltonian
     in the datapoint.
 
@@ -570,7 +570,7 @@ def tfi_rectangular(qubits, boundary_condition="torus", data_dir=None):
     circuit (`cirq.Circuit`), a label (Python `float`) a Hamiltonian
     (`cirq.PauliSum`) and some additional metadata. Each Hamiltonian in a
     datapoint is a 2D TFI rectangular lattice with boundary condition
-    `boundary_condition` on `qubits` whos order parameter dictates the value of
+    `boundary_condition` on `qubits` whose order parameter dictates the value of
     label. The circuit in a datapoint prepares (an approximation to) the ground
     state of the Hamiltonian in the datapoint.
 

--- a/tensorflow_quantum/python/differentiators/linear_combination.py
+++ b/tensorflow_quantum/python/differentiators/linear_combination.py
@@ -218,7 +218,7 @@ class ForwardDifference(LinearCombination):
         """Instantiate a ForwardDifference.
 
         Create a ForwardDifference differentiator, passing along an error order
-        and grid spacing to be used to contstruct differentiator coeffecients.
+        and grid spacing to be used to construct differentiator coeffecients.
 
         Args:
             error_order: A positive `int` specifying the error order of this
@@ -286,7 +286,7 @@ class CentralDifference(LinearCombination):
         """Instantiate a CentralDifference.
 
         Create a CentralDifference differentaitor, passing along an error order
-        and grid spacing to be used to contstruct differentiator coeffecients.
+        and grid spacing to be used to construct differentiator coeffecients.
 
         Args:
             error_order: A positive, even `int` specifying the error order

--- a/tensorflow_quantum/python/layers/circuit_executors/expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/expectation_test.py
@@ -129,8 +129,8 @@ class ExpectationTest(tf.test.TestCase):
             expectation.Expectation()([symb_circuit], operators=test_psum)
 
         with self.assertRaisesRegex(Exception,
-                                    expected_regex="Unparsable proto"):
-            # Proto is unparsable.
+                                    expected_regex="Unparseable proto"):
+            # Proto is unparseable.
             expectation.Expectation()([reg_circuit],
                                       operators=tf.convert_to_tensor(
                                           [['bad_operator']]))

--- a/tensorflow_quantum/python/layers/circuit_executors/expectation_test.py
+++ b/tensorflow_quantum/python/layers/circuit_executors/expectation_test.py
@@ -129,8 +129,8 @@ class ExpectationTest(tf.test.TestCase):
             expectation.Expectation()([symb_circuit], operators=test_psum)
 
         with self.assertRaisesRegex(Exception,
-                                    expected_regex="Unparseable proto"):
-            # Proto is unparseable.
+                                    expected_regex="Unparsable proto"):
+            # Proto is unparsable.
             expectation.Expectation()([reg_circuit],
                                       operators=tf.convert_to_tensor(
                                           [['bad_operator']]))

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer.py
@@ -225,7 +225,7 @@ def minimize(expectation_value_function,
                                             dtype='float32')
 
         def _spsa_once(state):
-            """Caclulate single SPSA gradient estimation
+            """Calculate single SPSA gradient estimation
 
             Args:
                 state: A SPSAOptimizerResults object stores the

--- a/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
+++ b/tensorflow_quantum/python/optimizers/spsa_minimizer_test.py
@@ -155,7 +155,7 @@ class SPSAMinimizerTest(tf.test.TestCase, parameterized.TestCase):
         self.assertFalse(result.converged)
         self.assertEqual(result.num_iterations, it)
         self.assertEqual(result.objective_value,
-                         init * 4)  # function executd 3 (in step) +
+                         init * 4)  # function executed 3 (in step) +
         # 1 (initial evaluation) times
 
         init = 1 / 6 * 0.49

--- a/tensorflow_quantum/python/util.py
+++ b/tensorflow_quantum/python/util.py
@@ -46,7 +46,7 @@ def get_supported_gates():
     Returns a dictionary mapping from supported gate types
     to the number of qubits each gate operates on.
 
-    Any of these gates used in conjuction with the
+    Any of these gates used in conjunction with the
     `controlled_by` function for multi-qubit control are also
     supported.
     """
@@ -682,7 +682,7 @@ def _many_clifford_to_many_z(pauli_sum):
 def _many_z_to_single_z(focal_qubit, pauli_sum):
     """Convert many Z's to single Z.
     Returns the gate set required for transforming an arbitrary tensor product
-    of pauli-z's into a product of all identites and a single pauli-Z.
+    of pauli-z's into a product of all identities and a single pauli-Z.
     Args:
         focal_qubit: central qubit among CNOT gates.
         pauli_sum: `cirq.PauliSum` object to be converted to CNOT's and Z.


### PR DESCRIPTION
This PR fixes random typos in the text of about three dozen files. The typos were flagged by `codespell`, which I'm beginning to use in my own pre-commit workflows. This is admittedly trivial stuff, but we may as well fix these silly typos in the source and be done with it. With these out of the way, we'll also be able to address https://github.com/tensorflow/quantum/issues/908 (request for a pre-commit hooks configuration) with a codespell check as one of the hooks.