### PR TITLE
Use r-strings for docstrings containing LaTeX markup

### DIFF
--- a/tensorflow_quantum/core/ops/math_ops/fidelity_op.py
+++ b/tensorflow_quantum/core/ops/math_ops/fidelity_op.py
@@ -20,7 +20,7 @@ from tensorflow_quantum.core.ops.math_ops import inner_product_op
 @tf.function
 @tf.custom_gradient
 def fidelity(programs, symbol_names, symbol_values, other_programs):
-    """Calculate the fidelity between circuits.
+    r"""Calculate the fidelity between circuits.
 
     Compute (potentially many) fidelities between the given circuits and
     the symbol free comparison circuits.

--- a/tensorflow_quantum/core/ops/math_ops/inner_product_op.py
+++ b/tensorflow_quantum/core/ops/math_ops/inner_product_op.py
@@ -22,7 +22,7 @@ MATH_OP_MODULE = load_module(os.path.join("math_ops", "_tfq_math_ops.so"))
 
 def _inner_product_grad(programs, symbol_names, symbol_values, other_programs,
                         prev_grad):
-    """Calculate the adjoint gradients of the inner product between circuits.
+    r"""Calculate the adjoint gradients of the inner product between circuits.
 
     Compute the gradients of the (potentially many) inner products between
     the given circuits and the symbol free comparison circuits.
@@ -70,7 +70,7 @@ def _inner_product_grad(programs, symbol_names, symbol_values, other_programs,
 
 @tf.custom_gradient
 def inner_product(programs, symbol_names, symbol_values, other_programs):
-    """Calculate the inner product between circuits.
+    r"""Calculate the inner product between circuits.
 
     Compute (potentially many) inner products between the given circuits and
     the symbol free comparison circuits.

--- a/tensorflow_quantum/datasets/spin_system.py
+++ b/tensorflow_quantum/datasets/spin_system.py
@@ -92,7 +92,7 @@ def _download_spin_data(system_name, boundary_condition, nspins, data_dir):
 
 
 def tfi_chain(qubits, boundary_condition="closed", data_dir=None):
-    """1D Transverse field Ising-model quantum data set.
+    r"""1D Transverse field Ising-model quantum data set.
 
     $$
     H = - \sum_{i} \sigma_i^z \sigma_{i+1}^z - g\sigma_i^x
@@ -322,7 +322,7 @@ def tfi_chain(qubits, boundary_condition="closed", data_dir=None):
 
 
 def xxz_chain(qubits, boundary_condition="closed", data_dir=None):
-    """1D XXZ model quantum data set.
+    r"""1D XXZ model quantum data set.
 
     $$
     H = \sum_{i} \sigma_i^x \sigma_{i+1}^x + \sigma_i^y \sigma_{i+1}^y +
@@ -558,7 +558,7 @@ def xxz_chain(qubits, boundary_condition="closed", data_dir=None):
 
 
 def tfi_rectangular(qubits, boundary_condition="torus", data_dir=None):
-    """2D transverse field Ising-model quantum data set.
+    r"""2D transverse field Ising-model quantum data set.
 
     $$
     H = - \sum_{\langle i,j \rangle} \sigma_i^z \sigma_{j}^z - g\sigma_i^x


### PR DESCRIPTION
A few docstrings in Python files contained LaTeX mathematical notation. They should be made into raw strings (using the `r` prefix) so that Python doesn't misinterpret the backslash characters.

There are no code or content changes in this PR.