### PR TITLE
Add channel random circuit test coverage

### DIFF
--- a/tensorflow_quantum/python/util_test.py
+++ b/tensorflow_quantum/python/util_test.py
@@ -159,8 +159,15 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
             any(has_channel(c) for c in circuits),
             "Expected at least one channel operation across batch when "
             "include_channels=True")
-        # Verify circuits containing channels are serializable.
-        self.assertIsNotNone(util.convert_to_tensor(circuits))
+        # Verify circuits containing channels are correctly serializable
+        # round-trip.
+        serialized = util.convert_to_tensor(circuits,
+                                            deterministic_proto_serialize=True)
+        deserialized = util.from_tensor(serialized)
+        self.assertAllEqual(
+            serialized,
+            util.convert_to_tensor(deserialized,
+                                   deterministic_proto_serialize=True))
 
     def test_random_symbol_circuit_resolver_batch_channels_present(self):
         """Confirm channel ops appear in circuits when include_channels=True."""
@@ -181,8 +188,15 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
             any(has_channel(c) for c in circuits),
             "Expected at least one channel operation across batch when "
             "include_channels=True")
-        # Verify circuits containing channels are serializable.
-        self.assertIsNotNone(util.convert_to_tensor(circuits))
+        # Verify circuits containing channels are correctly serializable
+        # round-trip.
+        serialized = util.convert_to_tensor(circuits,
+                                            deterministic_proto_serialize=True)
+        deserialized = util.from_tensor(serialized)
+        self.assertAllEqual(
+            serialized,
+            util.convert_to_tensor(deserialized,
+                                   deterministic_proto_serialize=True))
 
     @parameterized.parameters(_items_to_tensorize())
     def test_convert_to_tensor(self, item):

--- a/tensorflow_quantum/python/util_test.py
+++ b/tensorflow_quantum/python/util_test.py
@@ -139,6 +139,51 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
                     isinstance(value, float)
                     for value in resolver.param_dict.values()))
 
+    def test_random_circuit_resolver_batch_channels_present(self):
+        """Confirm channel ops appear in circuits when include_channels=True."""
+        qubits = cirq.GridQubit.rect(1, 3)
+        channel_types = tuple(type(c) for c in util.get_supported_channels())
+
+        circuits, _ = util.random_circuit_resolver_batch(qubits,
+                                                         batch_size=5,
+                                                         n_moments=20,
+                                                         include_channels=True)
+
+        def has_channel(circuit):
+            return any(
+                isinstance(op.gate, channel_types)
+                for moment in circuit
+                for op in moment.operations)
+
+        self.assertTrue(
+            any(has_channel(c) for c in circuits),
+            "Expected at least one channel operation across batch when "
+            "include_channels=True")
+        # Verify circuits containing channels are serializable.
+        self.assertIsNotNone(util.convert_to_tensor(circuits))
+
+    def test_random_symbol_circuit_resolver_batch_channels_present(self):
+        """Confirm channel ops appear in circuits when include_channels=True."""
+        qubits = cirq.GridQubit.rect(1, 3)
+        symbols = ['alpha', 'beta']
+        channel_types = tuple(type(c) for c in util.get_supported_channels())
+
+        circuits, _ = util.random_symbol_circuit_resolver_batch(
+            qubits, symbols, batch_size=5, n_moments=20, include_channels=True)
+
+        def has_channel(circuit):
+            return any(
+                isinstance(op.gate, channel_types)
+                for moment in circuit
+                for op in moment.operations)
+
+        self.assertTrue(
+            any(has_channel(c) for c in circuits),
+            "Expected at least one channel operation across batch when "
+            "include_channels=True")
+        # Verify circuits containing channels are serializable.
+        self.assertIsNotNone(util.convert_to_tensor(circuits))
+
     @parameterized.parameters(_items_to_tensorize())
     def test_convert_to_tensor(self, item):
         """Test that the convert_to_tensor function works correctly by manually


### PR DESCRIPTION
Adds regression coverage for random circuit generation with channels.

The `include_channels=True` argument mentioned here is a parameter of two functions in the `tensorflow_quantum.python.util` module (imported as `util` in the tests):

* `util.random_circuit_resolver_batch`
* `util.random_symbol_circuit_resolver_batch`

The new tests in `tensorflow_quantum/python/util_test.py` assert that, when each of these functions is called with `include_channels=True`, the generated random circuits contain at least one supported channel operation (taken from `util.get_supported_channels()`).

Following the Gemini Code Assist review, the tests also verify that the circuits survive a full serialization round trip: `util.convert_to_tensor` is used to serialize, `util.from_tensor` to deserialize, and the re-serialized result is compared for equality. This is stronger than only checking that serialization does not return null.

This addresses issue #1066.
